### PR TITLE
feat(database): add AgentConversationEntryDao and migration for agent…

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/AgentConversationHistoryRepository.kt
@@ -1,0 +1,463 @@
+package cn.com.omnimind.bot.agent
+
+import android.content.Context
+import cn.com.omnimind.baselib.database.AgentConversationEntry
+import cn.com.omnimind.baselib.database.DatabaseHelper
+import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.time.Instant
+
+class AgentConversationHistoryRepository(
+    @Suppress("UNUSED_PARAMETER")
+    private val context: Context
+) {
+    data class PromptSeed(
+        val historyMessages: List<ChatCompletionMessage>
+    )
+
+    companion object {
+        const val ENTRY_TYPE_USER_MESSAGE = "user_message"
+        const val ENTRY_TYPE_ASSISTANT_MESSAGE = "assistant_message"
+        const val ENTRY_TYPE_TOOL_EVENT = "tool_event"
+        const val ENTRY_TYPE_UI_CARD = "ui_card"
+
+        const val STATUS_RUNNING = "running"
+        const val STATUS_SUCCESS = "success"
+        const val STATUS_ERROR = "error"
+        const val STATUS_INTERRUPTED = "interrupted"
+
+    }
+
+    private val gson = Gson()
+
+    suspend fun upsertUserMessage(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String,
+        text: String,
+        attachments: List<Map<String, Any?>> = emptyList(),
+        createdAt: Long = System.currentTimeMillis()
+    ) {
+        val payload = buildTextMessagePayload(
+            messageId = entryId,
+            user = 1,
+            text = text,
+            attachments = attachments,
+            isError = false,
+            createdAt = createdAt
+        )
+        upsertMessageEntry(
+            conversationId = conversationId,
+            conversationMode = conversationMode,
+            entryId = entryId,
+            entryType = ENTRY_TYPE_USER_MESSAGE,
+            payload = payload,
+            summary = text,
+            status = STATUS_SUCCESS,
+            createdAt = createdAt
+        )
+    }
+
+    suspend fun upsertAssistantMessage(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String,
+        text: String,
+        isError: Boolean = false,
+        attachments: List<Map<String, Any?>> = emptyList(),
+        createdAt: Long = System.currentTimeMillis()
+    ) {
+        val payload = buildTextMessagePayload(
+            messageId = entryId,
+            user = 2,
+            text = text,
+            attachments = attachments,
+            isError = isError,
+            createdAt = createdAt
+        )
+        upsertMessageEntry(
+            conversationId = conversationId,
+            conversationMode = conversationMode,
+            entryId = entryId,
+            entryType = ENTRY_TYPE_ASSISTANT_MESSAGE,
+            payload = payload,
+            summary = text,
+            status = if (isError) STATUS_ERROR else STATUS_SUCCESS,
+            createdAt = createdAt
+        )
+    }
+
+    suspend fun upsertUiCard(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String,
+        cardData: Map<String, Any?>,
+        createdAt: Long = System.currentTimeMillis()
+    ) {
+        val payload = buildCardMessagePayload(
+            messageId = entryId,
+            cardData = cardData,
+            isError = false,
+            createdAt = createdAt
+        )
+        upsertMessageEntry(
+            conversationId = conversationId,
+            conversationMode = conversationMode,
+            entryId = entryId,
+            entryType = ENTRY_TYPE_UI_CARD,
+            payload = payload,
+            summary = cardData["summary"]?.toString().orEmpty(),
+            status = STATUS_SUCCESS,
+            createdAt = createdAt
+        )
+    }
+
+    suspend fun upsertToolEvent(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String,
+        payload: Map<String, Any?>,
+        fallbackStatus: String = STATUS_RUNNING,
+        fallbackSummary: String = ""
+    ) = withContext(Dispatchers.IO) {
+        val existing = DatabaseHelper.getAgentConversationEntryByThreadAndId(
+            conversationId = conversationId,
+            conversationMode = conversationMode,
+            entryId = entryId
+        )
+        val mergedPayload = mergeToolPayload(
+            existing = existing?.takeIf { it.entryType == ENTRY_TYPE_TOOL_EVENT }?.let {
+                readMap(it.payloadJson)
+            }.orEmpty(),
+            incoming = payload,
+            fallbackStatus = fallbackStatus,
+            fallbackSummary = fallbackSummary
+        )
+        val normalizedStatus = mergedPayload["status"]?.toString()?.trim()
+            ?.ifEmpty { null }
+            ?: fallbackStatus
+        val normalizedSummary = mergedPayload["summary"]?.toString()?.trim()
+            ?.ifEmpty { null }
+            ?: fallbackSummary
+
+        upsertEntry(
+            AgentConversationEntry(
+                id = existing?.id ?: 0,
+                conversationId = conversationId,
+                conversationMode = conversationMode,
+                entryId = entryId,
+                entryType = ENTRY_TYPE_TOOL_EVENT,
+                status = normalizedStatus,
+                summary = normalizedSummary,
+                payloadJson = gson.toJson(mergedPayload),
+                createdAt = existing?.createdAt ?: System.currentTimeMillis(),
+                updatedAt = System.currentTimeMillis()
+            )
+        )
+        refreshConversationMetadata(conversationId)
+    }
+
+    suspend fun replaceThreadMessagesFromUiSnapshot(
+        conversationId: Long,
+        conversationMode: String,
+        messages: List<Map<String, Any?>>
+    ) = withContext(Dispatchers.IO) {
+        DatabaseHelper.deleteAgentConversationThread(conversationId, conversationMode)
+        messages.sortedBy { parseCreatedAtMillis(it) }.forEach { message ->
+            val entryId = message["id"]?.toString()?.trim().orEmpty().ifEmpty {
+                "entry_${System.currentTimeMillis()}"
+            }
+            val type = when {
+                (message["type"] as? Number)?.toInt() == 2 -> ENTRY_TYPE_UI_CARD
+                (message["user"] as? Number)?.toInt() == 1 -> ENTRY_TYPE_USER_MESSAGE
+                else -> ENTRY_TYPE_ASSISTANT_MESSAGE
+            }
+            val status = if (message["isError"] == true) STATUS_ERROR else STATUS_SUCCESS
+            val summary = extractSummaryFromMessagePayload(message)
+            val createdAt = parseCreatedAtMillis(message)
+            upsertEntry(
+                AgentConversationEntry(
+                    conversationId = conversationId,
+                    conversationMode = conversationMode,
+                    entryId = entryId,
+                    entryType = type,
+                    status = status,
+                    summary = summary,
+                    payloadJson = gson.toJson(message),
+                    createdAt = createdAt,
+                    updatedAt = createdAt
+                )
+            )
+        }
+        refreshConversationMetadata(conversationId)
+    }
+
+    suspend fun listConversationMessages(
+        conversationId: Long,
+        conversationMode: String
+    ): List<Map<String, Any?>> = withContext(Dispatchers.IO) {
+        val normalized = normalizeInterruptedToolEntries(
+            DatabaseHelper.getAgentConversationEntriesDesc(conversationId, conversationMode)
+        )
+        normalized.mapNotNull { entry -> entryToMessagePayload(entry) }
+    }
+
+    suspend fun clearConversationMessages(
+        conversationId: Long,
+        conversationMode: String
+    ) = withContext(Dispatchers.IO) {
+        DatabaseHelper.deleteAgentConversationThread(conversationId, conversationMode)
+        refreshConversationMetadata(conversationId)
+    }
+
+    suspend fun deleteConversation(conversationId: Long) = withContext(Dispatchers.IO) {
+        DatabaseHelper.deleteAgentConversationEntries(conversationId)
+    }
+
+    suspend fun buildPromptSeed(
+        conversationId: Long?,
+        conversationMode: String
+    ): PromptSeed = withContext(Dispatchers.IO) {
+        if (conversationId == null || conversationId <= 0L) {
+            return@withContext PromptSeed(emptyList())
+        }
+        val normalizedEntries = normalizeInterruptedToolEntries(
+            DatabaseHelper.getAgentConversationEntriesAsc(conversationId, conversationMode)
+        )
+        AgentConversationHistorySupport.buildPromptSeedFromEntries(normalizedEntries)
+    }
+
+    private suspend fun upsertMessageEntry(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String,
+        entryType: String,
+        payload: Map<String, Any?>,
+        summary: String,
+        status: String,
+        createdAt: Long
+    ) = withContext(Dispatchers.IO) {
+        val existing = DatabaseHelper.getAgentConversationEntryByThreadAndId(
+            conversationId = conversationId,
+            conversationMode = conversationMode,
+            entryId = entryId
+        )
+        upsertEntry(
+            AgentConversationEntry(
+                id = existing?.id ?: 0,
+                conversationId = conversationId,
+                conversationMode = conversationMode,
+                entryId = entryId,
+                entryType = entryType,
+                status = status,
+                summary = summary.trim(),
+                payloadJson = gson.toJson(payload),
+                createdAt = existing?.createdAt ?: createdAt,
+                updatedAt = System.currentTimeMillis()
+            )
+        )
+        refreshConversationMetadata(conversationId)
+    }
+
+    private suspend fun upsertEntry(entry: AgentConversationEntry) {
+        DatabaseHelper.upsertAgentConversationEntry(entry)
+    }
+
+    private suspend fun refreshConversationMetadata(conversationId: Long) {
+        val conversation = DatabaseHelper.getConversationById(conversationId) ?: return
+        val lastEntry = DatabaseHelper.getLatestAgentConversationEntry(conversationId)
+        val firstEntry = DatabaseHelper.getEarliestAgentConversationEntry(conversationId)
+        val lastUpdate = DatabaseHelper.getLatestAgentConversationUpdate(conversationId)
+        val messageCount = DatabaseHelper.countAgentConversationEntries(conversationId)
+        val updatedConversation = conversation.copy(
+            lastMessage = lastEntry?.let(::conversationLastMessageFromEntry)?.takeIf { it.isNotBlank() },
+            messageCount = messageCount,
+            createdAt = firstEntry?.createdAt ?: conversation.createdAt,
+            updatedAt = lastUpdate?.updatedAt ?: conversation.updatedAt
+        )
+        DatabaseHelper.updateConversation(updatedConversation)
+    }
+
+    private suspend fun normalizeInterruptedToolEntries(
+        entries: List<AgentConversationEntry>
+    ): List<AgentConversationEntry> {
+        if (entries.isEmpty()) return entries
+        val normalized = AgentConversationHistorySupport.normalizeInterruptedEntries(entries)
+        normalized.forEachIndexed { index, updated ->
+            if (updated != entries[index]) {
+                upsertEntry(updated.copy(updatedAt = System.currentTimeMillis()))
+            }
+        }
+        return normalized
+    }
+
+    private fun buildTextMessagePayload(
+        messageId: String,
+        user: Int,
+        text: String,
+        attachments: List<Map<String, Any?>>,
+        isError: Boolean,
+        createdAt: Long
+    ): Map<String, Any?> {
+        val content = linkedMapOf<String, Any?>(
+            "text" to text,
+            "id" to messageId
+        )
+        if (attachments.isNotEmpty()) {
+            content["attachments"] = attachments
+        }
+        return linkedMapOf(
+            "id" to messageId,
+            "type" to 1,
+            "user" to user,
+            "content" to content,
+            "isLoading" to false,
+            "isFirst" to false,
+            "isError" to isError,
+            "isSummarizing" to false,
+            "createAt" to Instant.ofEpochMilli(createdAt).toString()
+        )
+    }
+
+    private fun buildCardMessagePayload(
+        messageId: String,
+        cardData: Map<String, Any?>,
+        isError: Boolean,
+        createdAt: Long
+    ): Map<String, Any?> {
+        return linkedMapOf(
+            "id" to messageId,
+            "type" to 2,
+            "user" to 3,
+            "content" to linkedMapOf(
+                "cardData" to cardData,
+                "id" to messageId
+            ),
+            "isLoading" to false,
+            "isFirst" to false,
+            "isError" to isError,
+            "isSummarizing" to false,
+            "createAt" to Instant.ofEpochMilli(createdAt).toString()
+        )
+    }
+
+    private fun entryToMessagePayload(entry: AgentConversationEntry): Map<String, Any?>? {
+        return when (entry.entryType) {
+            ENTRY_TYPE_TOOL_EVENT -> buildToolCardMessage(entry)
+            ENTRY_TYPE_USER_MESSAGE,
+            ENTRY_TYPE_ASSISTANT_MESSAGE,
+            ENTRY_TYPE_UI_CARD -> readMap(entry.payloadJson)
+            else -> null
+        }
+    }
+
+    private fun buildToolCardMessage(entry: AgentConversationEntry): Map<String, Any?> {
+        val payload = readMap(entry.payloadJson)
+        val messageId = entry.entryId
+        val cardData = linkedMapOf<String, Any?>(
+            "type" to "agent_tool_summary",
+            "taskId" to payload["taskId"],
+            "cardId" to messageId,
+            "toolName" to payload["toolName"]?.toString().orEmpty(),
+            "displayName" to payload["displayName"]?.toString().orEmpty(),
+            "toolType" to payload["toolType"]?.toString().orEmpty().ifEmpty { "builtin" },
+            "serverName" to payload["serverName"],
+            "status" to entry.status,
+            "summary" to payload["summary"]?.toString().orEmpty().ifEmpty { entry.summary },
+            "progress" to payload["progress"]?.toString().orEmpty(),
+            "argsJson" to payload["argsJson"]?.toString().orEmpty(),
+            "resultPreviewJson" to payload["resultPreviewJson"]?.toString().orEmpty(),
+            "rawResultJson" to payload["rawResultJson"]?.toString().orEmpty(),
+            "terminalOutput" to payload["terminalOutput"]?.toString().orEmpty(),
+            "terminalOutputDelta" to payload["terminalOutputDelta"]?.toString().orEmpty(),
+            "terminalSessionId" to payload["terminalSessionId"],
+            "terminalStreamState" to payload["terminalStreamState"]?.toString().orEmpty(),
+            "workspaceId" to payload["workspaceId"],
+            "artifacts" to toListOfStringAnyMap(payload["artifacts"]),
+            "actions" to toListOfStringAnyMap(payload["actions"]),
+            "success" to (payload["success"] ?: (entry.status == STATUS_SUCCESS)),
+            "showScheduleAction" to (payload["toolType"]?.toString() == "schedule"),
+            "showAlarmAction" to (payload["toolType"]?.toString() == "alarm")
+        )
+        return buildCardMessagePayload(
+            messageId = messageId,
+            cardData = cardData,
+            isError = entry.status == STATUS_ERROR,
+            createdAt = entry.createdAt
+        )
+    }
+
+    private fun mergeToolPayload(
+        existing: Map<String, Any?>,
+        incoming: Map<String, Any?>,
+        fallbackStatus: String,
+        fallbackSummary: String
+    ): Map<String, Any?> {
+        return AgentConversationHistorySupport.mergeToolPayload(
+            existing = existing,
+            incoming = incoming,
+            fallbackStatus = fallbackStatus,
+            fallbackSummary = fallbackSummary
+        )
+    }
+
+    private fun conversationLastMessageFromEntry(entry: AgentConversationEntry): String {
+        return when (entry.entryType) {
+            ENTRY_TYPE_TOOL_EVENT -> entry.summary.ifBlank { "执行了工具调用" }
+            ENTRY_TYPE_UI_CARD -> {
+                val payload = readMap(entry.payloadJson)
+                val content = toStringAnyMap(payload["content"])
+                val cardData = toStringAnyMap(content["cardData"])
+                cardData["summary"]?.toString()?.trim().orEmpty().ifEmpty {
+                    cardData["type"]?.toString()?.trim().orEmpty().ifEmpty { "卡片消息" }
+                }
+            }
+            else -> {
+                val payload = readMap(entry.payloadJson)
+                val content = toStringAnyMap(payload["content"])
+                content["text"]?.toString()?.trim().orEmpty().ifEmpty { entry.summary }
+            }
+        }
+    }
+
+    private fun extractSummaryFromMessagePayload(message: Map<String, Any?>): String {
+        val content = toStringAnyMap(message["content"])
+        val text = content["text"]?.toString()?.trim().orEmpty()
+        if (text.isNotEmpty()) return text
+        val cardData = toStringAnyMap(content["cardData"])
+        return cardData["summary"]?.toString()?.trim().orEmpty()
+    }
+
+    private fun parseCreatedAtMillis(message: Map<String, Any?>): Long {
+        val raw = message["createAt"]?.toString()?.trim().orEmpty()
+        return runCatching { Instant.parse(raw).toEpochMilli() }.getOrElse {
+            System.currentTimeMillis()
+        }
+    }
+
+    private fun readMap(json: String): Map<String, Any?> {
+        if (json.isBlank()) return emptyMap()
+        return runCatching {
+            gson.fromJson<Map<String, Any?>>(
+                json,
+                object : TypeToken<Map<String, Any?>>() {}.type
+            )
+        }.getOrElse { emptyMap() }
+    }
+
+    private fun toStringAnyMap(value: Any?): Map<String, Any?> {
+        if (value !is Map<*, *>) return emptyMap()
+        return value.entries.associate { (key, rawValue) ->
+            key.toString() to rawValue
+        }
+    }
+
+    private fun toListOfStringAnyMap(value: Any?): List<Map<String, Any?>> {
+        if (value !is List<*>) return emptyList()
+        return value.mapNotNull { item -> item?.let(::toStringAnyMap).takeIf { !it.isNullOrEmpty() } }
+    }
+
+}

--- a/app/src/main/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupport.kt
@@ -1,0 +1,348 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.baselib.database.AgentConversationEntry
+import cn.com.omnimind.baselib.llm.AssistantToolCall
+import cn.com.omnimind.baselib.llm.AssistantToolCallFunction
+import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+internal object AgentConversationHistorySupport {
+    private const val MAX_PROMPT_RELEVANT_ENTRIES = 20
+    private const val MAX_TOOL_SUMMARY_CHARS = 240
+    private const val MAX_TOOL_PREVIEW_CHARS = 800
+    private const val MAX_TOOL_TERMINAL_CHARS = 1200
+
+    private val gson = Gson()
+
+    fun buildPromptSeedFromEntries(
+        entries: List<AgentConversationEntry>
+    ): AgentConversationHistoryRepository.PromptSeed {
+        val relevantEntries = entries
+            .filter {
+                it.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_USER_MESSAGE ||
+                    it.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE ||
+                    it.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT
+            }
+            .takeLast(MAX_PROMPT_RELEVANT_ENTRIES)
+
+        val historyMessages = relevantEntries.flatMap { entry ->
+            when (entry.entryType) {
+                AgentConversationHistoryRepository.ENTRY_TYPE_USER_MESSAGE -> {
+                    buildUserPromptMessages(entry)
+                }
+
+                AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE -> {
+                    buildAssistantPromptMessages(entry)
+                }
+
+                AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT -> {
+                    buildToolReplayMessages(entry)
+                }
+
+                else -> emptyList()
+            }
+        }
+        return AgentConversationHistoryRepository.PromptSeed(historyMessages = historyMessages)
+    }
+
+    fun normalizeInterruptedEntries(
+        entries: List<AgentConversationEntry>
+    ): List<AgentConversationEntry> {
+        if (entries.isEmpty()) return entries
+        return entries.map { entry ->
+            if (
+                entry.entryType != AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT ||
+                entry.status != AgentConversationHistoryRepository.STATUS_RUNNING
+            ) {
+                entry
+            } else {
+                val mergedPayload = mergeToolPayload(
+                    existing = readMap(entry.payloadJson),
+                    incoming = mapOf(
+                        "status" to AgentConversationHistoryRepository.STATUS_INTERRUPTED,
+                        "summary" to entry.summary.ifBlank { "工具调用已中断" }
+                    ),
+                    fallbackStatus = AgentConversationHistoryRepository.STATUS_INTERRUPTED,
+                    fallbackSummary = entry.summary.ifBlank { "工具调用已中断" }
+                )
+                entry.copy(
+                    status = AgentConversationHistoryRepository.STATUS_INTERRUPTED,
+                    summary = mergedPayload["summary"]?.toString().orEmpty().ifBlank {
+                        "工具调用已中断"
+                    },
+                    payloadJson = gson.toJson(mergedPayload),
+                    updatedAt = entry.updatedAt
+                )
+            }
+        }
+    }
+
+    fun mergeToolPayload(
+        existing: Map<String, Any?>,
+        incoming: Map<String, Any?>,
+        fallbackStatus: String,
+        fallbackSummary: String
+    ): Map<String, Any?> {
+        fun text(source: Map<String, Any?>, key: String): String {
+            return source[key]?.toString()?.trim().orEmpty()
+        }
+
+        fun chooseText(key: String, fallback: String = ""): String {
+            return text(incoming, key).ifEmpty {
+                text(existing, key).ifEmpty { fallback }
+            }
+        }
+
+        fun chooseAny(key: String): Any? {
+            return incoming[key] ?: existing[key]
+        }
+
+        val toolType = chooseText("toolType", "builtin")
+        val existingTerminalOutput = text(existing, "terminalOutput")
+        val terminalOutputDelta = text(incoming, "terminalOutputDelta")
+        val terminalOutput = if (toolType == "terminal") {
+            text(incoming, "terminalOutput").ifEmpty {
+                if (terminalOutputDelta.isNotEmpty()) {
+                    existingTerminalOutput + terminalOutputDelta
+                } else {
+                    existingTerminalOutput
+                }
+            }
+        } else {
+            chooseText("terminalOutput")
+        }
+
+        return linkedMapOf<String, Any?>(
+            "taskId" to chooseAny("taskId"),
+            "toolName" to chooseText("toolName"),
+            "displayName" to chooseText("displayName"),
+            "toolType" to toolType,
+            "serverName" to chooseAny("serverName"),
+            "status" to chooseText("status", fallbackStatus),
+            "summary" to chooseText("summary", fallbackSummary),
+            "progress" to chooseText("progress"),
+            "args" to chooseText("args"),
+            "argsJson" to chooseText("argsJson"),
+            "resultPreviewJson" to chooseText("resultPreviewJson"),
+            "rawResultJson" to chooseText("rawResultJson"),
+            "terminalOutput" to terminalOutput,
+            "terminalOutputDelta" to terminalOutputDelta,
+            "terminalSessionId" to chooseAny("terminalSessionId"),
+            "terminalStreamState" to chooseText("terminalStreamState"),
+            "workspaceId" to chooseAny("workspaceId"),
+            "artifacts" to toListOfStringAnyMap(incoming["artifacts"]).ifEmpty {
+                toListOfStringAnyMap(existing["artifacts"])
+            },
+            "actions" to toListOfStringAnyMap(incoming["actions"]).ifEmpty {
+                toListOfStringAnyMap(existing["actions"])
+            },
+            "success" to (incoming["success"] ?: existing["success"] ?: (fallbackStatus == AgentConversationHistoryRepository.STATUS_SUCCESS))
+        )
+    }
+
+    private fun buildUserPromptMessages(entry: AgentConversationEntry): List<ChatCompletionMessage> {
+        val payload = readMap(entry.payloadJson)
+        val content = buildPromptContentFromMessagePayload(payload) ?: return emptyList()
+        if (content.isBlankJsonPrimitive()) return emptyList()
+        return listOf(
+            ChatCompletionMessage(
+                role = "user",
+                content = content
+            )
+        )
+    }
+
+    private fun buildAssistantPromptMessages(entry: AgentConversationEntry): List<ChatCompletionMessage> {
+        val payload = readMap(entry.payloadJson)
+        val content = buildPromptContentFromMessagePayload(payload) ?: return emptyList()
+        if (content.isBlankJsonPrimitive()) return emptyList()
+        return listOf(
+            ChatCompletionMessage(
+                role = "assistant",
+                content = content
+            )
+        )
+    }
+
+    private fun buildToolReplayMessages(entry: AgentConversationEntry): List<ChatCompletionMessage> {
+        val payload = readMap(entry.payloadJson)
+        val toolName = payload["toolName"]?.toString()?.trim().orEmpty()
+        if (toolName.isEmpty()) return emptyList()
+
+        val toolCallId = "restored_${entry.entryId}"
+        val argsJson = payload["argsJson"]?.toString()?.trim()?.ifEmpty { null } ?: "{}"
+        val assistantMessage = ChatCompletionMessage(
+            role = "assistant",
+            toolCalls = listOf(
+                AssistantToolCall(
+                    id = toolCallId,
+                    function = AssistantToolCallFunction(
+                        name = toolName,
+                        arguments = argsJson
+                    )
+                )
+            )
+        )
+        val toolMessage = ChatCompletionMessage(
+            role = "tool",
+            toolCallId = toolCallId,
+            content = JsonPrimitive(buildToolSummaryContent(entry, payload))
+        )
+        return listOf(assistantMessage, toolMessage)
+    }
+
+    private fun buildToolSummaryContent(
+        entry: AgentConversationEntry,
+        payload: Map<String, Any?>
+    ): String {
+        val preview = parseJsonMap(payload["resultPreviewJson"]?.toString().orEmpty())
+        val content = linkedMapOf<String, Any?>(
+            "toolName" to payload["toolName"]?.toString().orEmpty(),
+            "displayName" to payload["displayName"]?.toString().orEmpty(),
+            "toolType" to payload["toolType"]?.toString().orEmpty().ifEmpty { "builtin" },
+            "status" to entry.status,
+            "success" to parseBoolean(payload["success"], default = entry.status == AgentConversationHistoryRepository.STATUS_SUCCESS),
+            "summary" to trimText(
+                payload["summary"]?.toString()?.trim().orEmpty().ifEmpty { entry.summary.trim() },
+                MAX_TOOL_SUMMARY_CHARS
+            )
+        )
+        payload["serverName"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+            content["serverName"] = it
+        }
+
+        listOf("message", "question", "taskId", "goal").forEach { key ->
+            preview[key]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let { value ->
+                content[key] = trimText(value, MAX_TOOL_PREVIEW_CHARS)
+            }
+        }
+        listOf("missing", "missingFields").forEach { key ->
+            val values = toStringList(preview[key])
+            if (values.isNotEmpty()) {
+                content[key] = values
+            }
+        }
+
+        payload["resultPreviewJson"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let { raw ->
+            content["previewJson"] = trimText(raw, MAX_TOOL_PREVIEW_CHARS)
+        }
+        payload["terminalOutput"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let { raw ->
+            content["terminalOutput"] = trimText(raw, MAX_TOOL_TERMINAL_CHARS)
+        }
+        payload["terminalStreamState"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+            content["terminalStreamState"] = it
+        }
+        payload["terminalSessionId"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+            content["terminalSessionId"] = it
+        }
+
+        return gson.toJson(content)
+    }
+
+    private fun buildPromptContentFromMessagePayload(
+        payload: Map<String, Any?>
+    ): JsonElement? {
+        val content = toStringAnyMap(payload["content"])
+        val text = content["text"]?.toString().orEmpty()
+        val attachments = toListOfStringAnyMap(content["attachments"])
+        val imageBlocks = attachments.mapNotNull { attachment ->
+            val imageUrl = resolveImageAttachmentUrl(attachment)
+            if (imageUrl.isBlank()) {
+                null
+            } else {
+                JsonObject(
+                    mapOf(
+                        "type" to JsonPrimitive("image_url"),
+                        "image_url" to JsonObject(
+                            mapOf("url" to JsonPrimitive(imageUrl))
+                        )
+                    )
+                )
+            }
+        }
+        if (imageBlocks.isEmpty()) {
+            return JsonPrimitive(text)
+        }
+        val blocks = mutableListOf<JsonElement>()
+        if (text.isNotBlank()) {
+            blocks += JsonObject(
+                mapOf(
+                    "type" to JsonPrimitive("text"),
+                    "text" to JsonPrimitive(text)
+                )
+            )
+        }
+        blocks += imageBlocks
+        return JsonArray(blocks)
+    }
+
+    private fun resolveImageAttachmentUrl(attachment: Map<String, Any?>): String {
+        val dataUrl = attachment["dataUrl"]?.toString()?.trim().orEmpty()
+        if (dataUrl.startsWith("data:")) return dataUrl
+        val remoteUrl = attachment["url"]?.toString()?.trim().orEmpty()
+        return if (
+            remoteUrl.startsWith("https://") ||
+            remoteUrl.startsWith("http://") ||
+            remoteUrl.startsWith("data:")
+        ) {
+            remoteUrl
+        } else {
+            ""
+        }
+    }
+
+    private fun parseJsonMap(json: String): Map<String, Any?> {
+        if (json.isBlank()) return emptyMap()
+        return runCatching {
+            gson.fromJson<Map<String, Any?>>(
+                json,
+                object : TypeToken<Map<String, Any?>>() {}.type
+            )
+        }.getOrElse { emptyMap() }
+    }
+
+    private fun readMap(json: String): Map<String, Any?> {
+        return parseJsonMap(json)
+    }
+
+    private fun toStringAnyMap(value: Any?): Map<String, Any?> {
+        if (value !is Map<*, *>) return emptyMap()
+        return value.entries.associate { (key, rawValue) ->
+            key.toString() to rawValue
+        }
+    }
+
+    private fun toListOfStringAnyMap(value: Any?): List<Map<String, Any?>> {
+        if (value !is List<*>) return emptyList()
+        return value.mapNotNull { item -> item?.let(::toStringAnyMap).takeIf { !it.isNullOrEmpty() } }
+    }
+
+    private fun toStringList(value: Any?): List<String> {
+        if (value !is List<*>) return emptyList()
+        return value.mapNotNull { item ->
+            item?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun trimText(value: String, maxChars: Int): String {
+        val normalized = value.trim()
+        return if (normalized.length <= maxChars) normalized else normalized.take(maxChars) + "..."
+    }
+
+    private fun parseBoolean(value: Any?, default: Boolean): Boolean {
+        return when (value) {
+            is Boolean -> value
+            is String -> value.equals("true", ignoreCase = true)
+            else -> default
+        }
+    }
+
+    private fun JsonElement.isBlankJsonPrimitive(): Boolean {
+        return this is JsonPrimitive && this.isString && this.content.isBlank()
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/agent/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/OmniAgentExecutor.kt
@@ -5,10 +5,7 @@ import cn.com.omnimind.bot.mcp.RemoteMcpDiscoveryRegistry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
@@ -48,6 +45,7 @@ class OmniAgentExecutor(
             conversationId = conversationId,
             agentRunId = agentRunId
         )
+        val historyRepository = AgentConversationHistoryRepository(context)
         val promptMemoryContext = runCatching {
             memoryService.buildPromptContext()
         }.getOrNull()
@@ -70,7 +68,10 @@ class OmniAgentExecutor(
             discoveredServers = discoveredServers
         )
         val initialMessages = buildInitialMessages(
-            conversationHistory = conversationHistory,
+            promptSeed = historyRepository.buildPromptSeed(
+                conversationId = conversationId,
+                conversationMode = conversationMode
+            ),
             userMessage = userMessage,
             attachments = attachments,
             workspaceDescriptor = workspaceDescriptor,
@@ -131,7 +132,7 @@ class OmniAgentExecutor(
     }
 
     private fun buildInitialMessages(
-        conversationHistory: List<Map<String, Any?>>,
+        promptSeed: AgentConversationHistoryRepository.PromptSeed,
         userMessage: String,
         attachments: List<Map<String, Any?>>,
         workspaceDescriptor: AgentWorkspaceDescriptor,
@@ -141,7 +142,7 @@ class OmniAgentExecutor(
         resolvedSkills: List<ResolvedSkillContext>,
         memoryContext: WorkspaceMemoryPromptContext?
     ): List<cn.com.omnimind.baselib.llm.ChatCompletionMessage> {
-        val historyMessages = normalizeConversationHistory(conversationHistory).toMutableList()
+        val historyMessages = promptSeed.historyMessages.toMutableList()
         if (historyMessages.lastOrNull()?.role == "user") {
             historyMessages.removeLast()
         }
@@ -164,23 +165,6 @@ class OmniAgentExecutor(
         messages.addAll(historyMessages)
         messages.add(buildCurrentUserMessage(userMessage, attachments))
         return messages
-    }
-
-    private fun normalizeConversationHistory(
-        conversationHistory: List<Map<String, Any?>>
-    ): List<cn.com.omnimind.baselib.llm.ChatCompletionMessage> {
-        if (conversationHistory.isEmpty()) return emptyList()
-        return conversationHistory.mapNotNull { raw ->
-            val role = raw["role"]?.toString()?.trim()?.lowercase().orEmpty()
-            if (role !in setOf("system", "user", "assistant")) return@mapNotNull null
-            val rawContent = raw["content"] ?: return@mapNotNull null
-            val content = mapToJsonElement(rawContent)
-            if (content is JsonPrimitive && content.content.isBlank()) return@mapNotNull null
-            cn.com.omnimind.baselib.llm.ChatCompletionMessage(
-                role = role,
-                content = content
-            )
-        }
     }
 
     private fun buildCurrentUserMessage(
@@ -253,21 +237,5 @@ class OmniAgentExecutor(
             return remoteUrl
         }
         return ""
-    }
-
-    private fun mapToJsonElement(value: Any?): JsonElement {
-        return when (value) {
-            null -> JsonNull
-            is JsonElement -> value
-            is Map<*, *> -> JsonObject(
-                value.entries.associate { (key, item) ->
-                    key.toString() to mapToJsonElement(item)
-                }
-            )
-            is List<*> -> JsonArray(value.map { mapToJsonElement(it) })
-            is Boolean -> JsonPrimitive(value)
-            is Number -> JsonPrimitive(value)
-            else -> JsonPrimitive(value.toString())
-        }
     }
 }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/WorkspaceScheduledTaskScheduler.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/WorkspaceScheduledTaskScheduler.kt
@@ -6,12 +6,15 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.util.Base64
+import cn.com.omnimind.baselib.database.Conversation
+import cn.com.omnimind.baselib.database.DatabaseHelper
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.manager.AssistsCoreManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayInputStream
@@ -33,10 +36,6 @@ class WorkspaceScheduledTaskScheduler(
         private const val FLUTTER_PREFS_NAME = "FlutterSharedPreferences"
         private const val FLUTTER_PREF_PREFIX = "flutter."
         private const val FLUTTER_SCHEDULED_TASKS_KEY = "${FLUTTER_PREF_PREFIX}scheduled_tasks"
-        private const val FLUTTER_LOCAL_CONVERSATION_LIST_KEY =
-            "${FLUTTER_PREF_PREFIX}local_conversation_list"
-        private const val FLUTTER_CONVERSATION_MESSAGES_KEY_PREFIX =
-            "${FLUTTER_PREF_PREFIX}conversation_messages_"
         private const val LIST_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu"
         private const val JSON_LIST_PREFIX = "$LIST_PREFIX!"
         private const val SUBAGENT_MODE = "subagent"
@@ -237,11 +236,9 @@ class WorkspaceScheduledTaskScheduler(
         val prompt = task.subagentPrompt?.trim().orEmpty()
         require(prompt.isNotEmpty()) { "subagentPrompt is empty" }
         val conversationId = ensureSubagentConversationId(task)
-        val history = loadSubagentConversationHistory(conversationId)
         val args = mutableMapOf<String, Any?>(
             "taskId" to "subagent_schedule_${System.currentTimeMillis()}_${task.taskId}",
             "userMessage" to prompt,
-            "conversationHistory" to history,
             "conversationId" to conversationId,
             "conversationMode" to SUBAGENT_MODE,
             "scheduledTaskId" to task.taskId,
@@ -277,78 +274,22 @@ class WorkspaceScheduledTaskScheduler(
         if (existingId != null && existingId > 0) {
             return existingId
         }
-        return allocateNextConversationIdFromFlutterStorage()
-    }
-
-    private fun allocateNextConversationIdFromFlutterStorage(): Long {
-        val flutterPrefs =
-            appContext.getSharedPreferences(FLUTTER_PREFS_NAME, Context.MODE_PRIVATE)
-        var maxId = 0L
-
-        val rawList = flutterPrefs.getString(FLUTTER_LOCAL_CONVERSATION_LIST_KEY, null).orEmpty()
-        if (rawList.isNotBlank()) {
-            val list = runCatching { JSONArray(rawList) }.getOrElse { JSONArray() }
-            for (index in 0 until list.length()) {
-                val item = list.optJSONObject(index) ?: continue
-                val id = item.optLong("id", -1L)
-                if (id > maxId) {
-                    maxId = id
-                }
-            }
-        }
-
-        flutterPrefs.all.keys.forEach { key ->
-            if (!key.startsWith(FLUTTER_CONVERSATION_MESSAGES_KEY_PREFIX)) {
-                return@forEach
-            }
-            val suffix = key.removePrefix(FLUTTER_CONVERSATION_MESSAGES_KEY_PREFIX)
-            val idCandidate = if (suffix.contains('_')) {
-                suffix.substringAfterLast('_')
-            } else {
-                suffix
-            }
-            val parsedId = idCandidate.toLongOrNull() ?: return@forEach
-            if (parsedId > maxId) {
-                maxId = parsedId
-            }
-        }
-
-        return (maxId + 1L).coerceAtLeast(1L)
-    }
-
-    private fun loadSubagentConversationHistory(conversationId: Long): List<Map<String, Any?>> {
-        val flutterPrefs =
-            appContext.getSharedPreferences(FLUTTER_PREFS_NAME, Context.MODE_PRIVATE)
-        val key = "${FLUTTER_PREF_PREFIX}conversation_messages_${SUBAGENT_MODE}_$conversationId"
-        val raw = flutterPrefs.getString(key, null).orEmpty()
-        if (raw.isBlank()) return emptyList()
-        val source = runCatching { JSONArray(raw) }.getOrElse { JSONArray() }
-        val history = mutableListOf<Map<String, Any?>>()
-        for (index in source.length() - 1 downTo 0) {
-            val item = source.optJSONObject(index) ?: continue
-            val role = when (item.optInt("user", 0)) {
-                1 -> "user"
-                2 -> "assistant"
-                else -> "system"
-            }
-            var text = item.optJSONObject("content")
-                ?.optString("text")
-                ?.trim()
-                .orEmpty()
-            if (text.isEmpty()) {
-                text = item.optString("text").trim()
-            }
-            if (text.isEmpty()) {
-                continue
-            }
-            history.add(
-                mapOf(
-                    "role" to role,
-                    "content" to text
+        val now = System.currentTimeMillis()
+        return runBlocking {
+            DatabaseHelper.insertConversation(
+                Conversation(
+                    id = 0,
+                    title = task.title.ifBlank { "SubAgent 定时任务" },
+                    mode = SUBAGENT_MODE,
+                    summary = null,
+                    status = 0,
+                    lastMessage = null,
+                    messageCount = 0,
+                    createdAt = now,
+                    updatedAt = now
                 )
             )
         }
-        return history.takeLast(20)
     }
 
     private fun parseTask(rawTask: Map<String, Any?>, existing: StoredTask?): StoredTask {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -46,6 +46,7 @@ import cn.com.omnimind.bot.agent.AgentCallback
 import cn.com.omnimind.bot.agent.AgentAlarmToolService
 import cn.com.omnimind.bot.agent.AgentModelOverride
 import cn.com.omnimind.bot.agent.AgentResult
+import cn.com.omnimind.bot.agent.AgentConversationHistoryRepository
 import cn.com.omnimind.bot.agent.AgentRuntimeContextRepository
 import cn.com.omnimind.bot.agent.AgentScheduleToolBridge
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
@@ -66,7 +67,6 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import org.json.JSONArray
 import org.json.JSONObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -83,12 +83,12 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.ArrayDeque
 import kotlin.collections.mapOf
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -101,9 +101,6 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         private const val SUMMARY_TASK_PREFIX_TASK = "task-summary-"
         private const val MEMORY_GREETING_TOOL = "submit_memory_greeting"
         private const val DEFAULT_MEMORY_GREETING = "愿你今天也有温暖收获"
-        private const val FLUTTER_SHARED_PREFS_NAME = "FlutterSharedPreferences"
-        private const val FLUTTER_PREF_PREFIX = "flutter."
-        private const val KEY_LOCAL_CONVERSATION_LIST = "${FLUTTER_PREF_PREFIX}local_conversation_list"
         private const val SUBAGENT_MODE = "subagent"
         private const val SCHEDULED_SUBAGENT_NOTIFICATION_CHANNEL =
             "scheduled_subagent_tasks_v1"
@@ -128,14 +125,24 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val conversationId: Long
     )
 
+    private data class ChatTaskPersistenceState(
+        val conversationId: Long,
+        val conversationMode: String,
+        val userEntryId: String,
+        val assistantEntryId: String,
+        val assistantBuffer: StringBuilder = StringBuilder(),
+        var isError: Boolean = false
+    )
+
     // 用于存储需要等待用户操作的回调结果
     private lateinit var channel: MethodChannel
     private var mainJob: CoroutineScope = CoroutineScope(Dispatchers.Main)
     private var workJob: CoroutineScope = CoroutineScope(Dispatchers.Default)
     private val activeAgentLock = Any()
-    private val flutterPrefsLock = Any()
 
     private val activeAgentJobs: MutableMap<String, Job> = mutableMapOf()
+    private val chatTaskPersistenceStates: MutableMap<String, ChatTaskPersistenceState> =
+        mutableMapOf()
 
     // 当前活跃的对话ID
     private var currentConversationId: Long? = null
@@ -144,6 +151,24 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     private fun registerActiveAgentJob(taskId: String, job: Job) {
         synchronized(activeAgentLock) {
             activeAgentJobs[taskId] = job
+        }
+    }
+
+    private fun registerChatTaskPersistenceState(taskId: String, state: ChatTaskPersistenceState) {
+        synchronized(activeAgentLock) {
+            chatTaskPersistenceStates[taskId] = state
+        }
+    }
+
+    private fun getChatTaskPersistenceState(taskId: String): ChatTaskPersistenceState? {
+        return synchronized(activeAgentLock) {
+            chatTaskPersistenceStates[taskId]
+        }
+    }
+
+    private fun removeChatTaskPersistenceState(taskId: String): ChatTaskPersistenceState? {
+        return synchronized(activeAgentLock) {
+            chatTaskPersistenceStates.remove(taskId)
         }
     }
 
@@ -558,6 +583,44 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         return payload
     }
 
+    private fun conversationHistoryRepository(): AgentConversationHistoryRepository {
+        return AgentConversationHistoryRepository(context)
+    }
+
+    private fun normalizeConversationMode(mode: String?): String {
+        return mode?.trim()?.ifEmpty { null } ?: "normal"
+    }
+
+    private fun resolveRequiredPermissionIds(missing: List<String>): List<String> {
+        val nameToId = linkedMapOf(
+            "无障碍权限" to "accessibility",
+            "悬浮窗权限" to "overlay",
+            "应用列表读取权限" to "installed_apps",
+            WorkspaceStorageAccess.REQUIRED_PERMISSION_NAME to "workspace_storage"
+        )
+        return missing.mapNotNull { raw ->
+            nameToId[raw.trim()]
+        }.distinct()
+    }
+
+    private fun buildPermissionCardData(requiredPermissionIds: List<String>): Map<String, Any?> {
+        return linkedMapOf(
+            "type" to "permission_section",
+            "requiredPermissionIds" to requiredPermissionIds
+        )
+    }
+
+    private fun extractChatTaskText(content: String): String {
+        val normalized = content.trim()
+        if (normalized.isEmpty()) return ""
+        if (!normalized.startsWith("{")) {
+            return normalized
+        }
+        return runCatching {
+            JSONObject(normalized).optString("text").trim()
+        }.getOrElse { normalized }
+    }
+
 
     /**
      * 执行陪伴模式
@@ -763,38 +826,68 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     fun createChatTask(
         call: MethodCall, result: MethodChannel.Result,
     ) {
+        val taskID = call.argument<String>("taskID") ?: ""
+        val content = call.argument<List<Map<String, Any>>>("content") ?: emptyList()
+        val provider = call.argument<String>("provider")
+        val conversationId = call.argument<Number>("conversationId")?.toLong()
+        val conversationMode = normalizeConversationMode(call.argument<String>("conversationMode"))
+        val userMessage = call.argument<String>("userMessage")?.trim().orEmpty()
+        val userAttachments = call.argument<List<Map<String, Any?>>>("userAttachments") ?: emptyList()
+        val openClawConfigMap = call.argument<Map<String, Any>>("openClawConfig")
+        val openClawConfig = openClawConfigMap?.let { map ->
+            val baseUrl = map["baseUrl"] as? String ?: ""
+            if (baseUrl.isBlank()) {
+                null
+            } else {
+                cn.com.omnimind.assists.api.bean.TaskParams.OpenClawConfig(
+                    baseUrl = baseUrl,
+                    token = map["token"] as? String,
+                    userId = map["userId"] as? String,
+                    sessionKey = map["sessionKey"] as? String
+                )
+            }
+        }
 
-        try {
-            val taskID = call.argument<String>("taskID")!!
-            val content = call.argument<List<Map<String, Any>>>("content")!!
-            val provider = call.argument<String>("provider")
-            val openClawConfigMap = call.argument<Map<String, Any>>("openClawConfig")
-            val openClawConfig = openClawConfigMap?.let { map ->
-                val baseUrl = map["baseUrl"] as? String ?: ""
-                if (baseUrl.isBlank()) {
-                    null
-                } else {
-                    cn.com.omnimind.assists.api.bean.TaskParams.OpenClawConfig(
-                        baseUrl = baseUrl,
-                        token = map["token"] as? String,
-                        userId = map["userId"] as? String,
-                        sessionKey = map["sessionKey"] as? String
+        mainJob.launch {
+            try {
+                val normalizedConversationId = conversationId?.takeIf { it > 0L }
+                if (normalizedConversationId != null) {
+                    val repository = conversationHistoryRepository()
+                    if (userMessage.isNotBlank() || userAttachments.isNotEmpty()) {
+                        repository.upsertUserMessage(
+                            conversationId = normalizedConversationId,
+                            conversationMode = conversationMode,
+                            entryId = "$taskID-user",
+                            text = userMessage,
+                            attachments = userAttachments
+                        )
+                    }
+                    registerChatTaskPersistenceState(
+                        taskID,
+                        ChatTaskPersistenceState(
+                            conversationId = normalizedConversationId,
+                            conversationMode = conversationMode,
+                            userEntryId = "$taskID-user",
+                            assistantEntryId = "$taskID-assistant"
+                        )
                     )
                 }
-            }
-            AssistsUtil.Core.createChatTask(
-                taskID, content, this@AssistsCoreManager, provider, openClawConfig
-            )
-            mainJob.launch(Dispatchers.Main) {
-                result.success("SUCCESS")
-            }
-        } catch (e: PermissionException) {
-            mainJob.launch(Dispatchers.Main) {
-                result.error("PERMISSION_ERROR", e.message, null);
-            }
-        } catch (e: Exception) {
-            mainJob.launch(Dispatchers.Main) {
-                result.error("DO_TASK_ERROR", e.message, null)
+                AssistsUtil.Core.createChatTask(
+                    taskID, content, this@AssistsCoreManager, provider, openClawConfig
+                )
+                withContext(Dispatchers.Main) {
+                    result.success("SUCCESS")
+                }
+            } catch (e: PermissionException) {
+                removeChatTaskPersistenceState(taskID)
+                withContext(Dispatchers.Main) {
+                    result.error("PERMISSION_ERROR", e.message, null)
+                }
+            } catch (e: Exception) {
+                removeChatTaskPersistenceState(taskID)
+                withContext(Dispatchers.Main) {
+                    result.error("DO_TASK_ERROR", e.message, null)
+                }
             }
         }
 
@@ -802,6 +895,46 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
 
     override suspend fun onChatMessage(taskID: String, content: String, type: String?) {
+        getChatTaskPersistenceState(taskID)?.let { state ->
+            val repository = conversationHistoryRepository()
+            val normalizedType = type?.trim()?.lowercase().orEmpty()
+            when (normalizedType) {
+                "summary_start",
+                "openclaw_attachment" -> Unit
+                "error",
+                "rate_limited" -> {
+                    val message = extractChatTaskText(content).ifBlank {
+                        content.trim().ifBlank {
+                            if (normalizedType == "rate_limited") {
+                                "请求过于频繁，请稍后重试。"
+                            } else {
+                                "网络异常，请稍后重试。"
+                            }
+                        }
+                    }
+                    state.assistantBuffer.setLength(0)
+                    state.assistantBuffer.append(message)
+                    state.isError = true
+                }
+                else -> {
+                    val message = extractChatTaskText(content)
+                    if (message.isNotEmpty()) {
+                        state.assistantBuffer.append(message)
+                    }
+                    state.isError = false
+                }
+            }
+            val snapshot = state.assistantBuffer.toString().trim()
+            if (snapshot.isNotEmpty()) {
+                repository.upsertAssistantMessage(
+                    conversationId = state.conversationId,
+                    conversationMode = state.conversationMode,
+                    entryId = state.assistantEntryId,
+                    text = snapshot,
+                    isError = state.isError
+                )
+            }
+        }
         withContext(Dispatchers.Main) {
             try {
                 val isSummary = isSummaryTask(taskID)
@@ -830,6 +963,18 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     }
 
     override suspend fun onChatMessageEnd(taskID: String) {
+        removeChatTaskPersistenceState(taskID)?.let { state ->
+            val snapshot = state.assistantBuffer.toString().trim()
+            if (snapshot.isNotEmpty()) {
+                conversationHistoryRepository().upsertAssistantMessage(
+                    conversationId = state.conversationId,
+                    conversationMode = state.conversationMode,
+                    entryId = state.assistantEntryId,
+                    text = snapshot,
+                    isError = state.isError
+                )
+            }
+        }
         withContext(Dispatchers.Main) {
             try {
                 val isSummary = isSummaryTask(taskID)
@@ -2456,362 +2601,6 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         }
     }
 
-    private fun subagentMessagePrefsKey(conversationId: Long): String {
-        return "${FLUTTER_PREF_PREFIX}conversation_messages_${SUBAGENT_MODE}_$conversationId"
-    }
-
-    private fun readJsonArray(raw: String?): JSONArray {
-        if (raw.isNullOrBlank()) return JSONArray()
-        return runCatching { JSONArray(raw) }.getOrElse { JSONArray() }
-    }
-
-    private fun buildChatMessageJson(
-        messageId: String,
-        user: Int,
-        text: String,
-        isError: Boolean,
-        createdAtIso: String
-    ): JSONObject {
-        return JSONObject().apply {
-            put("id", messageId)
-            put("type", 1)
-            put("user", user)
-            put(
-                "content",
-                JSONObject().apply {
-                    put("text", text)
-                    put("id", messageId)
-                }
-            )
-            put("isLoading", false)
-            put("isFirst", false)
-            put("isError", isError)
-            put("isSummarizing", false)
-            put("createAt", createdAtIso)
-        }
-    }
-
-    private fun buildCardMessageJson(
-        messageId: String,
-        cardData: Map<String, Any?>,
-        isError: Boolean,
-        createdAtIso: String
-    ): JSONObject {
-        return JSONObject().apply {
-            put("id", messageId)
-            put("type", 2)
-            put("user", 3)
-            put(
-                "content",
-                JSONObject().apply {
-                    put("cardData", mapToJsonObject(cardData))
-                    put("id", messageId)
-                }
-            )
-            put("isLoading", false)
-            put("isFirst", false)
-            put("isError", isError)
-            put("isSummarizing", false)
-            put("createAt", createdAtIso)
-        }
-    }
-
-    private fun mapToJsonObject(source: Map<String, Any?>): JSONObject {
-        return JSONObject().apply {
-            source.forEach { (key, value) ->
-                put(key, toJsonValue(value))
-            }
-        }
-    }
-
-    private fun toJsonValue(value: Any?): Any {
-        return when (value) {
-            null -> JSONObject.NULL
-            is Map<*, *> -> {
-                val normalized = value.entries.associate { (k, v) ->
-                    k.toString() to normalizeChannelValue(v)
-                }
-                mapToJsonObject(normalized)
-            }
-            is List<*> -> JSONArray().apply {
-                value.forEach { item -> put(toJsonValue(normalizeChannelValue(item))) }
-            }
-            else -> value
-        }
-    }
-
-    private fun upsertMessageAtTop(
-        source: JSONArray,
-        messageId: String,
-        user: Int,
-        text: String,
-        isError: Boolean
-    ): JSONArray {
-        val nowIso = Instant.now().toString()
-        var existingCreateAt: String? = null
-        var existingIndex = -1
-        for (index in 0 until source.length()) {
-            val item = source.optJSONObject(index) ?: continue
-            if (item.optString("id") == messageId) {
-                existingIndex = index
-                val existing = item.optString("createAt").trim()
-                if (existing.isNotEmpty()) {
-                    existingCreateAt = existing
-                }
-                break
-            }
-        }
-        val message = buildChatMessageJson(
-            messageId = messageId,
-            user = user,
-            text = text,
-            isError = isError,
-            createdAtIso = existingCreateAt ?: nowIso
-        )
-        val target = JSONArray()
-        target.put(message)
-        for (index in 0 until source.length()) {
-            if (index == existingIndex) continue
-            target.put(source.opt(index))
-        }
-        return target
-    }
-
-    private fun upsertCardMessageAtTop(
-        source: JSONArray,
-        messageId: String,
-        cardData: Map<String, Any?>,
-        isError: Boolean
-    ): JSONArray {
-        val nowIso = Instant.now().toString()
-        var existingCreateAt: String? = null
-        var existingIndex = -1
-        for (index in 0 until source.length()) {
-            val item = source.optJSONObject(index) ?: continue
-            if (item.optString("id") == messageId) {
-                existingIndex = index
-                val existing = item.optString("createAt").trim()
-                if (existing.isNotEmpty()) {
-                    existingCreateAt = existing
-                }
-                break
-            }
-        }
-        val message = buildCardMessageJson(
-            messageId = messageId,
-            cardData = cardData,
-            isError = isError,
-            createdAtIso = existingCreateAt ?: nowIso
-        )
-        val target = JSONArray()
-        target.put(message)
-        for (index in 0 until source.length()) {
-            if (index == existingIndex) continue
-            target.put(source.opt(index))
-        }
-        return target
-    }
-
-    private fun sortedConversationListByUpdatedAt(source: JSONArray): JSONArray {
-        val conversations = mutableListOf<JSONObject>()
-        for (index in 0 until source.length()) {
-            val item = source.optJSONObject(index) ?: continue
-            conversations.add(item)
-        }
-        conversations.sortByDescending { it.optLong("updatedAt", 0L) }
-        return JSONArray().apply {
-            conversations.forEach { put(it) }
-        }
-    }
-
-    private fun updateSubagentConversationListLocked(
-        conversationId: Long,
-        title: String,
-        lastMessage: String,
-        messageCount: Int
-    ) {
-        val prefs = context.getSharedPreferences(FLUTTER_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
-        val raw = prefs.getString(KEY_LOCAL_CONVERSATION_LIST, null)
-        val list = readJsonArray(raw)
-        val now = System.currentTimeMillis()
-        var hit = false
-        for (index in 0 until list.length()) {
-            val item = list.optJSONObject(index) ?: continue
-            val mode = item.optString("mode").trim()
-            val id = item.optLong("id", -1L)
-            if (id == conversationId && mode.equals(SUBAGENT_MODE, ignoreCase = true)) {
-                if (item.optString("title").isBlank() && title.isNotBlank()) {
-                    item.put("title", title)
-                }
-                item.put("lastMessage", lastMessage)
-                item.put("messageCount", messageCount)
-                item.put("updatedAt", now)
-                hit = true
-                break
-            }
-        }
-        if (!hit) {
-            list.put(
-                JSONObject().apply {
-                    put("id", conversationId)
-                    put("mode", SUBAGENT_MODE)
-                    put("title", title.ifBlank { "SubAgent 定时任务" })
-                    put("summary", JSONObject.NULL)
-                    put("status", 0)
-                    put("lastMessage", lastMessage)
-                    put("messageCount", messageCount)
-                    put("createdAt", now)
-                    put("updatedAt", now)
-                }
-            )
-        }
-        prefs.edit()
-            .putString(KEY_LOCAL_CONVERSATION_LIST, sortedConversationListByUpdatedAt(list).toString())
-            .apply()
-    }
-
-    private fun persistScheduledSubagentMessage(
-        meta: ScheduledSubagentRunMeta,
-        messageId: String,
-        user: Int,
-        text: String,
-        isError: Boolean
-    ) {
-        val normalized = text.trim()
-        if (normalized.isEmpty()) return
-        synchronized(flutterPrefsLock) {
-            val prefs = context.getSharedPreferences(FLUTTER_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
-            val key = subagentMessagePrefsKey(meta.conversationId)
-            val source = readJsonArray(prefs.getString(key, null))
-            val updated = upsertMessageAtTop(
-                source = source,
-                messageId = messageId,
-                user = user,
-                text = normalized,
-                isError = isError
-            )
-            prefs.edit().putString(key, updated.toString()).apply()
-            updateSubagentConversationListLocked(
-                conversationId = meta.conversationId,
-                title = meta.scheduleTaskTitle,
-                lastMessage = normalized,
-                messageCount = updated.length()
-            )
-        }
-    }
-
-    private fun persistScheduledSubagentToolCard(
-        meta: ScheduledSubagentRunMeta,
-        cardId: String,
-        cardData: Map<String, Any?>,
-        isError: Boolean
-    ) {
-        synchronized(flutterPrefsLock) {
-            val prefs = context.getSharedPreferences(FLUTTER_SHARED_PREFS_NAME, Context.MODE_PRIVATE)
-            val key = subagentMessagePrefsKey(meta.conversationId)
-            val source = readJsonArray(prefs.getString(key, null))
-            val updated = upsertCardMessageAtTop(
-                source = source,
-                messageId = cardId,
-                cardData = cardData,
-                isError = isError
-            )
-            prefs.edit().putString(key, updated.toString()).apply()
-            val summary = cardData["summary"]?.toString()?.trim().orEmpty()
-            val lastMessage = summary.ifEmpty {
-                val displayName = cardData["displayName"]?.toString()?.trim().orEmpty()
-                if (displayName.isNotEmpty()) {
-                    "执行工具：$displayName"
-                } else {
-                    "执行了工具调用"
-                }
-            }
-            updateSubagentConversationListLocked(
-                conversationId = meta.conversationId,
-                title = meta.scheduleTaskTitle,
-                lastMessage = lastMessage,
-                messageCount = updated.length()
-            )
-        }
-    }
-
-    private fun mergeScheduledToolCardData(
-        taskId: String,
-        cardId: String,
-        payload: Map<String, Any?>,
-        existingCardData: Map<String, Any?> = emptyMap(),
-        fallbackStatus: String = "running",
-        fallbackSummary: String = ""
-    ): Map<String, Any?> {
-        fun payloadText(key: String): String {
-            return payload[key]?.toString()?.trim().orEmpty()
-        }
-        fun existingText(key: String): String {
-            return existingCardData[key]?.toString()?.trim().orEmpty()
-        }
-        fun chooseText(key: String, fallback: String = ""): String {
-            return payloadText(key).ifEmpty { existingText(key).ifEmpty { fallback } }
-        }
-        fun chooseAny(key: String): Any? {
-            return payload[key] ?: existingCardData[key]
-        }
-
-        val toolType = chooseText("toolType", "builtin")
-        val existingTerminalOutput = existingText("terminalOutput")
-        val terminalOutputDelta = payloadText("terminalOutputDelta")
-        val terminalOutput = if (toolType == "terminal") {
-            payloadText("terminalOutput").ifEmpty {
-                if (terminalOutputDelta.isNotEmpty()) {
-                    existingTerminalOutput + terminalOutputDelta
-                } else {
-                    existingTerminalOutput
-                }
-            }
-        } else {
-            ""
-        }
-        val summary = chooseText("summary", fallbackSummary)
-        val progress = chooseText("progress")
-        val status = chooseText("status", fallbackStatus)
-        val artifacts = toListOfStringAnyMap(payload["artifacts"]).ifEmpty {
-            toListOfStringAnyMap(existingCardData["artifacts"])
-        }
-        val actions = toListOfStringAnyMap(payload["actions"]).ifEmpty {
-            toListOfStringAnyMap(existingCardData["actions"])
-        }
-        val success = when (val value = payload["success"] ?: existingCardData["success"]) {
-            is Boolean -> value
-            is String -> value.equals("true", ignoreCase = true)
-            else -> true
-        }
-
-        return linkedMapOf<String, Any?>(
-            "type" to "agent_tool_summary",
-            "taskId" to taskId,
-            "cardId" to cardId,
-            "toolName" to chooseText("toolName"),
-            "displayName" to chooseText("displayName"),
-            "toolType" to toolType,
-            "serverName" to chooseAny("serverName"),
-            "status" to status,
-            "summary" to summary,
-            "progress" to progress,
-            "argsJson" to chooseText("argsJson"),
-            "resultPreviewJson" to chooseText("resultPreviewJson"),
-            "rawResultJson" to chooseText("rawResultJson"),
-            "terminalOutput" to terminalOutput,
-            "terminalOutputDelta" to terminalOutputDelta,
-            "terminalSessionId" to chooseAny("terminalSessionId"),
-            "terminalStreamState" to chooseText("terminalStreamState"),
-            "workspaceId" to chooseAny("workspaceId"),
-            "artifacts" to artifacts,
-            "actions" to actions,
-            "success" to success,
-            "showScheduleAction" to (toolType == "schedule"),
-            "showAlarmAction" to (toolType == "alarm")
-        )
-    }
-
     private fun notifyScheduledSubagentCompletion(
         meta: ScheduledSubagentRunMeta,
         message: String
@@ -2895,13 +2684,15 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     fun createAgentTask(call: MethodCall, result: MethodChannel.Result) {
         val taskId = (call.argument<String>("taskId") ?: "").trim()
         val userMessage = (call.argument<String>("userMessage") ?: "").toString()
-        val conversationHistory =
+        val legacyConversationHistory =
             call.argument<List<Map<String, Any?>>>("conversationHistory") ?: emptyList()
         val attachments = call.argument<List<Map<String, Any?>>>("attachments") ?: emptyList()
-        val conversationId = call.argument<Number>("conversationId")?.toLong()
+        val conversationId = call.argument<Number>("conversationId")?.toLong()?.takeIf { it > 0L }
         val requestedConversationMode =
             call.argument<String>("conversationMode")?.trim()?.ifEmpty { null }
-        val resolvedConversationMode = requestedConversationMode ?: currentConversationMode
+        val resolvedConversationMode = normalizeConversationMode(
+            requestedConversationMode ?: currentConversationMode
+        )
         val scheduledSubagentMeta = parseScheduledSubagentRunMeta(
             conversationMode = resolvedConversationMode,
             conversationId = conversationId,
@@ -2933,6 +2724,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             result.error("INVALID_ARGUMENTS", "taskId is empty", null)
             return
         }
+        if (legacyConversationHistory.isNotEmpty()) {
+            OmniLog.d(
+                TAG,
+                "Ignoring legacy conversationHistory for createAgentTask taskId=$taskId size=${legacyConversationHistory.size}"
+            )
+        }
         val agentRunJob = SupervisorJob()
         val agentRunScope = CoroutineScope(agentRunJob + Dispatchers.Default)
         registerActiveAgentJob(taskId, agentRunJob)
@@ -2942,6 +2739,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 // 1. 获取当前包名
                 val currentPackageName = AssistsCore.getCurrentPackageName()
                 val runtimeContextRepository = AgentRuntimeContextRepository(context)
+                val historyRepository = conversationHistoryRepository()
 
                 val scheduleBridge = object : AgentScheduleToolBridge {
                     override suspend fun createTask(arguments: Map<String, Any?>): Map<String, Any?> {
@@ -2971,19 +2769,120 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
                 // 2. 初始化 Executor
                 val executor = OmniAgentExecutor(context, agentRunScope, scheduleBridge)
-                val activeToolArgs = mutableMapOf<String, String>()
+                val activeToolArgs = mutableMapOf<String, ArrayDeque<String>>()
+                val activeToolEntryIds = mutableMapOf<String, ArrayDeque<String>>()
                 val scheduledAssistantBuffer = StringBuilder()
-                var scheduledToolCardSequence = 0
-                var scheduledActiveToolCardId: String? = null
-                val scheduledToolCardCache = mutableMapOf<String, Map<String, Any?>>()
-                scheduledSubagentMeta?.let { meta ->
-                    persistScheduledSubagentMessage(
-                        meta = meta,
-                        messageId = "$taskId-user",
-                        user = 1,
-                        text = userMessage,
+                var toolSequence = 0
+
+                fun pushToolValue(
+                    store: MutableMap<String, ArrayDeque<String>>,
+                    toolName: String,
+                    value: String
+                ) {
+                    store.getOrPut(toolName) { ArrayDeque() }.addLast(value)
+                }
+
+                fun peekToolValue(
+                    store: MutableMap<String, ArrayDeque<String>>,
+                    toolName: String
+                ): String {
+                    return store[toolName]?.lastOrNull().orEmpty()
+                }
+
+                fun popToolValue(
+                    store: MutableMap<String, ArrayDeque<String>>,
+                    toolName: String
+                ): String {
+                    val queue = store[toolName] ?: return ""
+                    val value = if (queue.isEmpty()) "" else queue.removeLast()
+                    if (queue.isEmpty()) {
+                        store.remove(toolName)
+                    }
+                    return value
+                }
+
+                suspend fun upsertAssistantSnapshot(text: String, isError: Boolean) {
+                    val normalizedConversationId = conversationId ?: return
+                    val normalizedText = text.trim()
+                    if (normalizedText.isEmpty()) return
+                    historyRepository.upsertAssistantMessage(
+                        conversationId = normalizedConversationId,
+                        conversationMode = resolvedConversationMode,
+                        entryId = "$taskId-assistant",
+                        text = normalizedText,
+                        isError = isError
+                    )
+                }
+
+                suspend fun upsertClarifyMessage(question: String) {
+                    val normalizedConversationId = conversationId ?: return
+                    val normalizedQuestion = question.trim()
+                    if (normalizedQuestion.isEmpty()) return
+                    historyRepository.upsertAssistantMessage(
+                        conversationId = normalizedConversationId,
+                        conversationMode = resolvedConversationMode,
+                        entryId = "$taskId-clarify",
+                        text = normalizedQuestion,
                         isError = false
                     )
+                }
+
+                suspend fun upsertPermissionState(missing: List<String>) {
+                    val normalizedConversationId = conversationId ?: return
+                    val names = missing.map { it.trim() }.filter { it.isNotEmpty() }
+                    val message = if (names.isEmpty()) {
+                        "执行任务前需要先开启权限"
+                    } else {
+                        "执行任务前，请先开启：${names.joinToString("、")}"
+                    }
+                    historyRepository.upsertAssistantMessage(
+                        conversationId = normalizedConversationId,
+                        conversationMode = resolvedConversationMode,
+                        entryId = "$taskId-text",
+                        text = message,
+                        isError = false
+                    )
+                    val permissionIds = resolveRequiredPermissionIds(names)
+                    if (permissionIds.isNotEmpty()) {
+                        historyRepository.upsertUiCard(
+                            conversationId = normalizedConversationId,
+                            conversationMode = resolvedConversationMode,
+                            entryId = "$taskId-permission",
+                            cardData = buildPermissionCardData(permissionIds)
+                        )
+                    }
+                }
+
+                suspend fun upsertToolEvent(
+                    entryId: String,
+                    payload: Map<String, Any?>,
+                    fallbackStatus: String,
+                    fallbackSummary: String
+                ) {
+                    val normalizedConversationId = conversationId ?: return
+                    if (entryId.isBlank()) return
+                    historyRepository.upsertToolEvent(
+                        conversationId = normalizedConversationId,
+                        conversationMode = resolvedConversationMode,
+                        entryId = entryId,
+                        payload = linkedMapOf<String, Any?>("taskId" to taskId).apply {
+                            putAll(payload)
+                        },
+                        fallbackStatus = fallbackStatus,
+                        fallbackSummary = fallbackSummary
+                    )
+                }
+
+                conversationId?.let { normalizedConversationId ->
+                    if (userMessage.isNotBlank() || attachments.isNotEmpty()) {
+                        historyRepository.upsertUserMessage(
+                            conversationId = normalizedConversationId,
+                            conversationMode = resolvedConversationMode,
+                            entryId = "$taskId-user",
+                            text = userMessage,
+                            attachments = attachments
+                        )
+                    }
                 }
 
                 // 3. 创建回调
@@ -3001,30 +2900,18 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         arguments: JsonObject
                     ) {
                         val argsJson = arguments.toString()
-                        activeToolArgs[toolName] = argsJson
+                        pushToolValue(activeToolArgs, toolName, argsJson)
+                        val entryId = "$taskId-tool-${++toolSequence}"
+                        pushToolValue(activeToolEntryIds, toolName, entryId)
                         val payload = buildToolStartPayload(toolName, argsJson)
-                        scheduledSubagentMeta?.let { meta ->
-                            scheduledToolCardSequence += 1
-                            val cardId = "$taskId-tool-$scheduledToolCardSequence"
-                            scheduledActiveToolCardId = cardId
-                            val cardData = mergeScheduledToolCardData(
-                                taskId = taskId,
-                                cardId = cardId,
-                                payload = payload,
-                                existingCardData = scheduledToolCardCache[cardId] ?: emptyMap(),
-                                fallbackStatus = "running",
-                                fallbackSummary = payload["summary"]?.toString()?.ifBlank {
-                                    "正在调用工具"
-                                } ?: "正在调用工具"
-                            )
-                            scheduledToolCardCache[cardId] = cardData
-                            persistScheduledSubagentToolCard(
-                                meta = meta,
-                                cardId = cardId,
-                                cardData = cardData,
-                                isError = false
-                            )
-                        }
+                        upsertToolEvent(
+                            entryId = entryId,
+                            payload = payload,
+                            fallbackStatus = AgentConversationHistoryRepository.STATUS_RUNNING,
+                            fallbackSummary = payload["summary"]?.toString()?.ifBlank {
+                                "正在调用工具"
+                            } ?: "正在调用工具"
+                        )
                         sendEvent(
                             "onAgentToolCallStart",
                             payload
@@ -3036,32 +2923,21 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         progress: String,
                         extras: Map<String, Any?>
                     ) {
+                        val entryId = peekToolValue(activeToolEntryIds, toolName)
                         val payload = buildToolProgressPayload(
                             toolName,
                             progress,
-                            activeToolArgs[toolName].orEmpty(),
+                            peekToolValue(activeToolArgs, toolName),
                             extras
                         )
-                        scheduledSubagentMeta?.let { meta ->
-                            val cardId = scheduledActiveToolCardId
-                            if (!cardId.isNullOrBlank()) {
-                                val cardData = mergeScheduledToolCardData(
-                                    taskId = taskId,
-                                    cardId = cardId,
-                                    payload = payload,
-                                    existingCardData = scheduledToolCardCache[cardId] ?: emptyMap(),
-                                    fallbackStatus = "running",
-                                    fallbackSummary = "正在调用工具"
-                                )
-                                scheduledToolCardCache[cardId] = cardData
-                                persistScheduledSubagentToolCard(
-                                    meta = meta,
-                                    cardId = cardId,
-                                    cardData = cardData,
-                                    isError = false
-                                )
-                            }
-                        }
+                        upsertToolEvent(
+                            entryId = entryId,
+                            payload = payload,
+                            fallbackStatus = AgentConversationHistoryRepository.STATUS_RUNNING,
+                            fallbackSummary = payload["summary"]?.toString()?.ifBlank {
+                                "正在调用工具"
+                            } ?: "正在调用工具"
+                        )
                         sendEvent(
                             "onAgentToolCallProgress",
                             payload
@@ -3072,27 +2948,22 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         toolName: String,
                         result: ToolExecutionResult
                     ) {
-                        val argsJson = activeToolArgs.remove(toolName).orEmpty()
+                        val argsJson = popToolValue(activeToolArgs, toolName)
                         val payload = buildToolCompletePayload(toolName, result, argsJson)
-                        scheduledSubagentMeta?.let { meta ->
-                            val cardId = scheduledActiveToolCardId ?: "$taskId-tool-${++scheduledToolCardSequence}"
-                            val cardData = mergeScheduledToolCardData(
-                                taskId = taskId,
-                                cardId = cardId,
-                                payload = payload,
-                                existingCardData = scheduledToolCardCache[cardId] ?: emptyMap(),
-                                fallbackStatus = if (payload["success"] == false) "error" else "success",
-                                fallbackSummary = payload["summary"]?.toString().orEmpty()
-                            )
-                            scheduledToolCardCache[cardId] = cardData
-                            persistScheduledSubagentToolCard(
-                                meta = meta,
-                                cardId = cardId,
-                                cardData = cardData,
-                                isError = payload["success"] == false
-                            )
+                        val entryId = popToolValue(activeToolEntryIds, toolName).ifBlank {
+                            "$taskId-tool-${++toolSequence}"
                         }
-                        scheduledActiveToolCardId = null
+                        val success = payload["success"] != false
+                        upsertToolEvent(
+                            entryId = entryId,
+                            payload = payload,
+                            fallbackStatus = if (success) {
+                                AgentConversationHistoryRepository.STATUS_SUCCESS
+                            } else {
+                                AgentConversationHistoryRepository.STATUS_ERROR
+                            },
+                            fallbackSummary = payload["summary"]?.toString().orEmpty()
+                        )
                         sendEvent(
                             "onAgentToolCallComplete",
                             payload
@@ -3111,6 +2982,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         question: String,
                         missingFields: List<String>?
                     ) {
+                        upsertClarifyMessage(question)
                         sendEvent(
                             "onAgentClarifyRequired",
                             mapOf("question" to question, "missingFields" to missingFields)
@@ -3122,28 +2994,31 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         val outputKind = (result as? AgentResult.Success)?.outputKind ?: "none"
                         val hasUserVisibleOutput =
                             (result as? AgentResult.Success)?.hasUserVisibleOutput == true
+                        val streamed = scheduledAssistantBuffer.toString().trim()
+                        val fallback = (result as? AgentResult.Success)
+                            ?.response
+                            ?.content
+                            ?.trim()
+                            .orEmpty()
+                        val finalText = streamed.ifEmpty { fallback }.ifEmpty {
+                            if (isSuccess && outputKind == "none" && !hasUserVisibleOutput) {
+                                "暂时无法生成回复，请重试。"
+                            } else {
+                                ""
+                            }
+                        }
+                        if (finalText.isNotBlank()) {
+                            upsertAssistantSnapshot(finalText, isError = !isSuccess)
+                        }
                         scheduledSubagentMeta?.let { meta ->
-                            val streamed = scheduledAssistantBuffer.toString().trim()
-                            val fallback = (result as? AgentResult.Success)
-                                ?.response
-                                ?.content
-                                ?.trim()
-                                .orEmpty()
-                            val finalText = streamed.ifEmpty { fallback }.ifEmpty {
+                            val notificationText = finalText.ifEmpty {
                                 if (isSuccess) {
                                     "任务已完成，点击查看详情。"
                                 } else {
                                     "任务已结束，请点击查看详情。"
                                 }
                             }
-                            persistScheduledSubagentMessage(
-                                meta = meta,
-                                messageId = "$taskId-assistant",
-                                user = 2,
-                                text = finalText,
-                                isError = !isSuccess
-                            )
-                            notifyScheduledSubagentCompletion(meta, finalText)
+                            notifyScheduledSubagentCompletion(meta, notificationText)
                         }
                         sendEvent(
                             "onAgentComplete",
@@ -3156,22 +3031,21 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     }
 
                     override suspend fun onError(error: String) {
+                        val streamed = scheduledAssistantBuffer.toString().trim()
+                        val finalText = streamed.ifEmpty {
+                            error.trim().ifEmpty { "暂时无法生成回复，请重试。" }
+                        }
+                        if (finalText.isNotBlank()) {
+                            upsertAssistantSnapshot(finalText, isError = true)
+                        }
                         scheduledSubagentMeta?.let { meta ->
-                            val streamed = scheduledAssistantBuffer.toString().trim()
-                            val finalText = streamed.ifEmpty { error }
-                            persistScheduledSubagentMessage(
-                                meta = meta,
-                                messageId = "$taskId-assistant",
-                                user = 2,
-                                text = finalText,
-                                isError = true
-                            )
                             notifyScheduledSubagentCompletion(meta, finalText)
                         }
                         sendEvent("onAgentError", mapOf("error" to error))
                     }
 
                     override suspend fun onPermissionRequired(missing: List<String>) {
+                        upsertPermissionState(missing)
                         sendEvent("onAgentPermissionRequired", mapOf("missing" to missing))
                     }
 
@@ -3189,17 +3063,9 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             // 否则会把同一段内容在流式阶段重复拼接。
                             scheduledAssistantBuffer.setLength(0)
                             scheduledAssistantBuffer.append(normalizedMessage)
-                            scheduledSubagentMeta?.let { meta ->
-                                val streamingText = scheduledAssistantBuffer.toString().trim()
-                                if (streamingText.isNotEmpty()) {
-                                    persistScheduledSubagentMessage(
-                                        meta = meta,
-                                        messageId = "$taskId-assistant",
-                                        user = 2,
-                                        text = streamingText,
-                                        isError = false
-                                    )
-                                }
+                            val streamingText = scheduledAssistantBuffer.toString().trim()
+                            if (streamingText.isNotEmpty()) {
+                                upsertAssistantSnapshot(streamingText, isError = false)
                             }
                         }
                         sendEvent(
@@ -3225,7 +3091,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 // 4. 执行任务
                 executor.processUserMessage(
                     userMessage,
-                    conversationHistory,
+                    legacyConversationHistory,
                     runtimeContextRepository,
                     currentPackageName,
                     attachments,
@@ -3402,6 +3268,89 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         }
     }
 
+    fun getConversationMessages(call: MethodCall, result: MethodChannel.Result) {
+        val conversationId = call.argument<Number>("conversationId")?.toLong() ?: 0L
+        val mode = normalizeConversationMode(
+            call.argument<String>("mode") ?: call.argument<String>("conversationMode")
+        )
+        if (conversationId <= 0L) {
+            result.error("INVALID_ARGUMENTS", "conversationId is invalid", null)
+            return
+        }
+        workJob.launch {
+            try {
+                val messages = conversationHistoryRepository().listConversationMessages(
+                    conversationId = conversationId,
+                    conversationMode = mode
+                )
+                withContext(Dispatchers.Main) {
+                    result.success(messages)
+                }
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "获取对话消息失败: ${e.message}")
+                withContext(Dispatchers.Main) {
+                    result.error("GET_CONVERSATION_MESSAGES_ERROR", e.message, null)
+                }
+            }
+        }
+    }
+
+    fun replaceConversationMessages(call: MethodCall, result: MethodChannel.Result) {
+        val conversationId = call.argument<Number>("conversationId")?.toLong() ?: 0L
+        val mode = normalizeConversationMode(
+            call.argument<String>("mode") ?: call.argument<String>("conversationMode")
+        )
+        val messages = call.argument<List<Map<String, Any?>>>("messages") ?: emptyList()
+        if (conversationId <= 0L) {
+            result.error("INVALID_ARGUMENTS", "conversationId is invalid", null)
+            return
+        }
+        workJob.launch {
+            try {
+                conversationHistoryRepository().replaceThreadMessagesFromUiSnapshot(
+                    conversationId = conversationId,
+                    conversationMode = mode,
+                    messages = messages
+                )
+                withContext(Dispatchers.Main) {
+                    result.success("SUCCESS")
+                }
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "替换对话消息失败: ${e.message}")
+                withContext(Dispatchers.Main) {
+                    result.error("REPLACE_CONVERSATION_MESSAGES_ERROR", e.message, null)
+                }
+            }
+        }
+    }
+
+    fun clearConversationMessages(call: MethodCall, result: MethodChannel.Result) {
+        val conversationId = call.argument<Number>("conversationId")?.toLong() ?: 0L
+        val mode = normalizeConversationMode(
+            call.argument<String>("mode") ?: call.argument<String>("conversationMode")
+        )
+        if (conversationId <= 0L) {
+            result.error("INVALID_ARGUMENTS", "conversationId is invalid", null)
+            return
+        }
+        workJob.launch {
+            try {
+                conversationHistoryRepository().clearConversationMessages(
+                    conversationId = conversationId,
+                    conversationMode = mode
+                )
+                withContext(Dispatchers.Main) {
+                    result.success("SUCCESS")
+                }
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "清理对话消息失败: ${e.message}")
+                withContext(Dispatchers.Main) {
+                    result.error("CLEAR_CONVERSATION_MESSAGES_ERROR", e.message, null)
+                }
+            }
+        }
+    }
+
     /**
      * 分页获取对话列表
      */
@@ -3442,7 +3391,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
      */
     fun createConversation(call: MethodCall, result: MethodChannel.Result) {
         val title = call.argument<String>("title") ?: "新对话"
-        val mode = call.argument<String>("mode") ?: "normal"
+        val mode = normalizeConversationMode(call.argument<String>("mode"))
         val summary = call.argument<String>("summary")
 
         workJob.launch {
@@ -3480,18 +3429,24 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         workJob.launch {
             try {
                 if (conversationMap != null) {
-                    val conversation = Conversation(
-                        id = (conversationMap["id"] as Number).toLong(),
-                        title = conversationMap["title"] as String,
-                        mode = (conversationMap["mode"] as? String ?: "normal"),
+                    val conversationId = (conversationMap["id"] as Number).toLong()
+                    val existing = DatabaseHelper.getConversationById(conversationId)
+                    if (existing == null) {
+                        withContext(Dispatchers.Main) {
+                            result.error("CONVERSATION_NOT_FOUND", "Conversation not found", null)
+                        }
+                        return@launch
+                    }
+                    val updatedConversation = existing.copy(
+                        title = (conversationMap["title"] as? String)?.trim()?.ifEmpty {
+                            existing.title
+                        } ?: existing.title,
+                        mode = normalizeConversationMode(conversationMap["mode"] as? String ?: existing.mode),
                         summary = conversationMap["summary"] as String?,
-                        status = (conversationMap["status"] as Number).toInt(),
-                        lastMessage = conversationMap["lastMessage"] as String?,
-                        messageCount = (conversationMap["messageCount"] as Number).toInt(),
-                        createdAt = (conversationMap["createdAt"] as Number).toLong(),
-                        updatedAt = (conversationMap["updatedAt"] as Number).toLong()
+                        status = (conversationMap["status"] as? Number)?.toInt() ?: existing.status,
+                        updatedAt = System.currentTimeMillis()
                     )
-                    DatabaseHelper.updateConversation(conversation)
+                    DatabaseHelper.updateConversation(updatedConversation)
                     withContext(Dispatchers.Main) {
                         result.success("SUCCESS")
                     }
@@ -3517,6 +3472,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
         workJob.launch {
             try {
+                conversationHistoryRepository().deleteConversation(conversationId)
                 DatabaseHelper.deleteConversationById(conversationId)
                 withContext(Dispatchers.Main) {
                     result.success("SUCCESS")

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
@@ -259,6 +259,15 @@ class AssistsCoreChannel {
                 "getConversations" -> {
                     assistsCoreManager!!.getConversations(call, result)
                 }
+                "getConversationMessages" -> {
+                    assistsCoreManager!!.getConversationMessages(call, result)
+                }
+                "replaceConversationMessages" -> {
+                    assistsCoreManager!!.replaceConversationMessages(call, result)
+                }
+                "clearConversationMessages" -> {
+                    assistsCoreManager!!.clearConversationMessages(call, result)
+                }
                 "getConversationsByPage" -> {
                     assistsCoreManager!!.getConversationsByPage(call, result)
                 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
@@ -1,0 +1,204 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.baselib.database.AgentConversationEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlinx.serialization.json.jsonPrimitive
+
+class AgentConversationHistorySupportTest {
+    @Test
+    fun `mergeToolPayload keeps args and final status across tool lifecycle`() {
+        val startPayload = mapOf(
+            "toolName" to "browser_use",
+            "displayName" to "浏览器自动化",
+            "toolType" to "builtin",
+            "argsJson" to """{"url":"https://example.com","steps":2}""",
+            "summary" to "打开页面"
+        )
+        val progressPayload = mapOf(
+            "progress" to "正在分析页面",
+            "summary" to "正在分析页面"
+        )
+        val completePayload = mapOf(
+            "status" to AgentConversationHistoryRepository.STATUS_SUCCESS,
+            "summary" to "已完成页面分析",
+            "resultPreviewJson" to """{"message":"done"}""",
+            "rawResultJson" to """{"message":"done","details":"very long raw"}""",
+            "success" to true
+        )
+
+        val mergedProgress = AgentConversationHistorySupport.mergeToolPayload(
+            existing = startPayload,
+            incoming = progressPayload,
+            fallbackStatus = AgentConversationHistoryRepository.STATUS_RUNNING,
+            fallbackSummary = "正在调用工具"
+        )
+        val mergedComplete = AgentConversationHistorySupport.mergeToolPayload(
+            existing = mergedProgress,
+            incoming = completePayload,
+            fallbackStatus = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            fallbackSummary = "已完成页面分析"
+        )
+
+        assertEquals(
+            """{"url":"https://example.com","steps":2}""",
+            mergedComplete["argsJson"]
+        )
+        assertEquals(
+            AgentConversationHistoryRepository.STATUS_SUCCESS,
+            mergedComplete["status"]
+        )
+        assertEquals("已完成页面分析", mergedComplete["summary"])
+        assertEquals("""{"message":"done"}""", mergedComplete["resultPreviewJson"])
+    }
+
+    @Test
+    fun `buildPromptSeedFromEntries replays per-tool summaries in chronological order`() {
+        val userEntry = AgentConversationEntry(
+            id = 1,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "u1",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_USER_MESSAGE,
+            status = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            summary = "查看 example",
+            payloadJson = """
+                {"id":"u1","type":1,"user":1,"content":{"text":"查看 example","id":"u1"},"createAt":"2026-03-27T00:00:00Z"}
+            """.trimIndent(),
+            createdAt = 1,
+            updatedAt = 1
+        )
+        val assistantEntry = AgentConversationEntry(
+            id = 2,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "a1",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE,
+            status = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            summary = "assistant should start being replayed",
+            payloadJson = """
+                {"id":"a1","type":1,"user":2,"content":{"text":"assistant should start being replayed","id":"a1"},"createAt":"2026-03-27T00:00:01Z"}
+            """.trimIndent(),
+            createdAt = 2,
+            updatedAt = 2
+        )
+        val toolEntry = AgentConversationEntry(
+            id = 3,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "t1",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT,
+            status = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            summary = "抓取成功",
+            payloadJson = """
+                {
+                  "toolName":"browser_use",
+                  "displayName":"浏览器自动化",
+                  "toolType":"builtin",
+                  "argsJson":"{\"url\":\"https://example.com\",\"query\":\"latest\"}",
+                  "summary":"抓取成功",
+                  "resultPreviewJson":"{\"title\":\"Example\"}",
+                  "rawResultJson":"{\"title\":\"Example\",\"html\":\"<html>super long raw payload</html>\"}",
+                  "success":true
+                }
+            """.trimIndent(),
+            createdAt = 3,
+            updatedAt = 3
+        )
+
+        val secondToolEntry = AgentConversationEntry(
+            id = 4,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "t2",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT,
+            status = AgentConversationHistoryRepository.STATUS_ERROR,
+            summary = "执行命令失败",
+            payloadJson = """
+                {
+                  "toolName":"terminal_execute",
+                  "displayName":"执行命令",
+                  "toolType":"terminal",
+                  "argsJson":"{\"command\":\"pwd\"}",
+                  "summary":"执行命令失败",
+                  "resultPreviewJson":"{\"message\":\"permission denied\"}",
+                  "rawResultJson":"{\"message\":\"permission denied\",\"trace\":\"super long raw payload terminal\"}",
+                  "terminalOutput":"permission denied",
+                  "success":false
+                }
+            """.trimIndent(),
+            createdAt = 4,
+            updatedAt = 4
+        )
+
+        val seed = AgentConversationHistorySupport.buildPromptSeedFromEntries(
+            listOf(userEntry, assistantEntry, toolEntry, secondToolEntry)
+        )
+
+        assertEquals(6, seed.historyMessages.size)
+        assertEquals(
+            listOf("user", "assistant", "assistant", "tool", "assistant", "tool"),
+            seed.historyMessages.map { it.role }
+        )
+        assertTrue(seed.historyMessages[0].content.toString().contains("查看 example"))
+        assertEquals(1, seed.historyMessages[2].toolCalls?.size)
+        assertEquals("browser_use", seed.historyMessages[2].toolCalls?.single()?.function?.name)
+        assertTrue(
+            seed.historyMessages[2].toolCalls
+                ?.single()
+                ?.function
+                ?.arguments
+                .orEmpty()
+                .contains("\"url\":\"https://example.com\"")
+        )
+        assertEquals("terminal_execute", seed.historyMessages[4].toolCalls?.single()?.function?.name)
+
+        val firstToolSummary = seed.historyMessages[3].content!!.jsonPrimitive.content
+        assertTrue(firstToolSummary.contains("浏览器自动化"))
+        assertTrue(firstToolSummary.contains("抓取成功"))
+        assertTrue(firstToolSummary.contains("previewJson"))
+
+        val secondToolSummary = seed.historyMessages[5].content!!.jsonPrimitive.content
+        assertTrue(secondToolSummary.contains("执行命令"))
+        assertTrue(secondToolSummary.contains("执行命令失败"))
+        assertTrue(secondToolSummary.contains("terminalOutput"))
+
+        val allReplayText = seed.historyMessages.joinToString("\n") {
+            it.content?.toString().orEmpty()
+        }
+        assertTrue(allReplayText.contains("assistant should start being replayed"))
+        assertFalse(allReplayText.contains("super long raw payload"))
+    }
+
+    @Test
+    fun `normalizeInterruptedEntries converts running tools to interrupted`() {
+        val runningEntry = AgentConversationEntry(
+            id = 1,
+            conversationId = 9,
+            conversationMode = "subagent",
+            entryId = "tool-running",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT,
+            status = AgentConversationHistoryRepository.STATUS_RUNNING,
+            summary = "",
+            payloadJson = """
+                {"toolName":"terminal_run","displayName":"执行命令","toolType":"terminal","status":"running","summary":"","terminalOutput":"hello"}
+            """.trimIndent(),
+            createdAt = 1,
+            updatedAt = 1
+        )
+
+        val normalized = AgentConversationHistorySupport.normalizeInterruptedEntries(
+            listOf(runningEntry)
+        )
+
+        assertEquals(1, normalized.size)
+        assertEquals(
+            AgentConversationHistoryRepository.STATUS_INTERRUPTED,
+            normalized.single().status
+        )
+        assertTrue(normalized.single().summary.isNotBlank())
+        assertTrue(normalized.single().payloadJson.contains("\"status\":\"interrupted\""))
+    }
+}

--- a/baselib/src/main/java/cn/com/omnimind/baselib/database/AgentConversationEntry.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/database/AgentConversationEntry.kt
@@ -1,0 +1,30 @@
+package cn.com.omnimind.baselib.database
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(
+    tableName = "agent_conversation_entries",
+    indices = [
+        Index(
+            value = ["conversationId", "conversationMode", "entryId"],
+            unique = true
+        ),
+        Index(value = ["conversationId", "conversationMode", "updatedAt"])
+    ]
+)
+data class AgentConversationEntry(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val conversationId: Long,
+    val conversationMode: String,
+    val entryId: String,
+    val entryType: String,
+    val status: String,
+    val summary: String,
+    val payloadJson: String,
+    val createdAt: Long = Date().time,
+    val updatedAt: Long = Date().time
+)

--- a/baselib/src/main/java/cn/com/omnimind/baselib/database/AgentConversationEntryDao.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/database/AgentConversationEntryDao.kt
@@ -1,0 +1,127 @@
+package cn.com.omnimind.baselib.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface AgentConversationEntryDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entry: AgentConversationEntry): Long
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId AND conversationMode = :conversationMode
+        ORDER BY createdAt ASC, id ASC
+        """
+    )
+    suspend fun getThreadEntriesAsc(
+        conversationId: Long,
+        conversationMode: String
+    ): List<AgentConversationEntry>
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId AND conversationMode = :conversationMode
+        ORDER BY createdAt DESC, id DESC
+        """
+    )
+    suspend fun getThreadEntriesDesc(
+        conversationId: Long,
+        conversationMode: String
+    ): List<AgentConversationEntry>
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        ORDER BY createdAt DESC, id DESC
+        """
+    )
+    suspend fun getConversationEntriesDesc(conversationId: Long): List<AgentConversationEntry>
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        ORDER BY createdAt ASC, id ASC
+        """
+    )
+    suspend fun getConversationEntriesAsc(conversationId: Long): List<AgentConversationEntry>
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        ORDER BY createdAt DESC, id DESC
+        LIMIT 1
+        """
+    )
+    suspend fun getLatestConversationEntry(conversationId: Long): AgentConversationEntry?
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        ORDER BY createdAt ASC, id ASC
+        LIMIT 1
+        """
+    )
+    suspend fun getEarliestConversationEntry(conversationId: Long): AgentConversationEntry?
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        ORDER BY updatedAt DESC, id DESC
+        LIMIT 1
+        """
+    )
+    suspend fun getLatestConversationUpdate(conversationId: Long): AgentConversationEntry?
+
+    @Query(
+        """
+        SELECT COUNT(*) FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        """
+    )
+    suspend fun countConversationEntries(conversationId: Long): Int
+
+    @Query(
+        """
+        SELECT * FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+          AND conversationMode = :conversationMode
+          AND entryId = :entryId
+        LIMIT 1
+        """
+    )
+    suspend fun getByThreadAndEntryId(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String
+    ): AgentConversationEntry?
+
+    @Query(
+        """
+        DELETE FROM agent_conversation_entries
+        WHERE conversationId = :conversationId AND conversationMode = :conversationMode
+        """
+    )
+    suspend fun deleteThreadEntries(
+        conversationId: Long,
+        conversationMode: String
+    ): Int
+
+    @Query(
+        """
+        DELETE FROM agent_conversation_entries
+        WHERE conversationId = :conversationId
+        """
+    )
+    suspend fun deleteConversationEntries(conversationId: Long): Int
+}

--- a/baselib/src/main/java/cn/com/omnimind/baselib/database/AppDatabase.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/database/AppDatabase.kt
@@ -12,9 +12,10 @@ import androidx.room.RoomDatabase
         ExecutionRecord::class,
         Message::class,
         CacheSuggestion::class,
-        Conversation::class
+        Conversation::class,
+        AgentConversationEntry::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -26,6 +27,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun messageDao(): MessageDao
     abstract fun cacheSuggestionDao(): CacheSuggestionDao
     abstract fun conversationDao(): ConversationDao
+    abstract fun agentConversationEntryDao(): AgentConversationEntryDao
 
     companion object {
         const val DATABASE_NAME = "omnibot_cache_database"

--- a/baselib/src/main/java/cn/com/omnimind/baselib/database/DatabaseHelper.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/database/DatabaseHelper.kt
@@ -137,6 +137,41 @@ object DatabaseHelper {
         }
     }
 
+    private val MIGRATION_7_8 = object : Migration(7, 8) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `agent_conversation_entries` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `conversationId` INTEGER NOT NULL,
+                    `conversationMode` TEXT NOT NULL,
+                    `entryId` TEXT NOT NULL,
+                    `entryType` TEXT NOT NULL,
+                    `status` TEXT NOT NULL,
+                    `summary` TEXT NOT NULL,
+                    `payloadJson` TEXT NOT NULL,
+                    `createdAt` INTEGER NOT NULL,
+                    `updatedAt` INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            database.execSQL(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS
+                `index_agent_conversation_entries_conversationId_conversationMode_entryId`
+                ON `agent_conversation_entries` (`conversationId`, `conversationMode`, `entryId`)
+                """.trimIndent()
+            )
+            database.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS
+                `index_agent_conversation_entries_conversationId_conversationMode_updatedAt`
+                ON `agent_conversation_entries` (`conversationId`, `conversationMode`, `updatedAt`)
+                """.trimIndent()
+            )
+        }
+    }
+
     fun init(context: Context) {
         database = Room.databaseBuilder(
             context.applicationContext, AppDatabase::class.java, LOCAL_DATABASE_NAME
@@ -146,7 +181,8 @@ object DatabaseHelper {
             MIGRATION_3_4,
             MIGRATION_4_5,
             MIGRATION_5_6,
-            MIGRATION_6_7
+            MIGRATION_6_7,
+            MIGRATION_7_8
         ).build()
 
     }
@@ -651,6 +687,72 @@ object DatabaseHelper {
 
     suspend fun getConversationCount(): Int {
         return getDatabase().conversationDao().getConversationCount()
+    }
+
+    suspend fun upsertAgentConversationEntry(entry: AgentConversationEntry): Long {
+        return getDatabase().agentConversationEntryDao().upsert(entry)
+    }
+
+    suspend fun getAgentConversationEntriesAsc(
+        conversationId: Long,
+        conversationMode: String
+    ): List<AgentConversationEntry> {
+        return getDatabase().agentConversationEntryDao().getThreadEntriesAsc(
+            conversationId = conversationId,
+            conversationMode = conversationMode
+        )
+    }
+
+    suspend fun getAgentConversationEntriesDesc(
+        conversationId: Long,
+        conversationMode: String
+    ): List<AgentConversationEntry> {
+        return getDatabase().agentConversationEntryDao().getThreadEntriesDesc(
+            conversationId = conversationId,
+            conversationMode = conversationMode
+        )
+    }
+
+    suspend fun getAgentConversationEntryByThreadAndId(
+        conversationId: Long,
+        conversationMode: String,
+        entryId: String
+    ): AgentConversationEntry? {
+        return getDatabase().agentConversationEntryDao().getByThreadAndEntryId(
+            conversationId = conversationId,
+            conversationMode = conversationMode,
+            entryId = entryId
+        )
+    }
+
+    suspend fun deleteAgentConversationThread(
+        conversationId: Long,
+        conversationMode: String
+    ): Int {
+        return getDatabase().agentConversationEntryDao().deleteThreadEntries(
+            conversationId = conversationId,
+            conversationMode = conversationMode
+        )
+    }
+
+    suspend fun deleteAgentConversationEntries(conversationId: Long): Int {
+        return getDatabase().agentConversationEntryDao().deleteConversationEntries(conversationId)
+    }
+
+    suspend fun getLatestAgentConversationEntry(conversationId: Long): AgentConversationEntry? {
+        return getDatabase().agentConversationEntryDao().getLatestConversationEntry(conversationId)
+    }
+
+    suspend fun getLatestAgentConversationUpdate(conversationId: Long): AgentConversationEntry? {
+        return getDatabase().agentConversationEntryDao().getLatestConversationUpdate(conversationId)
+    }
+
+    suspend fun getEarliestAgentConversationEntry(conversationId: Long): AgentConversationEntry? {
+        return getDatabase().agentConversationEntryDao().getEarliestConversationEntry(conversationId)
+    }
+
+    suspend fun countAgentConversationEntries(conversationId: Long): Int {
+        return getDatabase().agentConversationEntryDao().countConversationEntries(conversationId)
     }
 
     suspend fun incrementConversationMessageCount(id: Long) {

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -363,6 +363,8 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       return;
     }
     final history = buildConversationHistory();
+    final userMessage = latestUserUtterance();
+    final userAttachments = await _latestUserAttachments();
     final openClawConfig = {
       'baseUrl': _openClawBaseUrl,
       if (_openClawToken.isNotEmpty) 'token': _openClawToken,
@@ -382,6 +384,10 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       history,
       provider: 'openclaw',
       openClawConfig: openClawConfig,
+      conversationId: conversationId,
+      conversationMode: activeConversationModeValue.storageValue,
+      userMessage: userMessage,
+      userAttachments: userAttachments,
     );
     if (success) return;
     _runtimeCoordinator.unregisterTask(aiMessageId);
@@ -558,13 +564,11 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       _registerActiveTaskBinding(aiMessageId);
 
       final userMessage = latestUserUtterance();
-      final history = _historyBeforeLatestUser(buildConversationHistory());
       final attachments = await _latestUserAttachments();
 
       final success = await AssistsMessageService.createAgentTask(
         taskId: aiMessageId,
         userMessage: userMessage,
-        conversationHistory: history,
         attachments: attachments,
         conversationId: _currentConversationId,
         conversationMode: activeConversationModeValue.storageValue,

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -513,12 +513,6 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           );
         }
 
-        await ConversationHistoryService.saveConversationMessages(
-          targetId,
-          snapshotMessages,
-          mode: snapshotMode,
-        );
-
         final baseConversation =
             snapshotConversation ??
             ConversationModel(

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -361,12 +361,6 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
             );
     }
 
-    await ConversationHistoryService.saveConversationMessages(
-      conversationId,
-      snapshotMessages,
-      mode: conversationMode,
-    );
-
     final baseConversation =
         (snapshotConversation?.mode == conversationMode
             ? snapshotConversation

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -658,12 +658,6 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
         await ConversationHistoryService.saveCurrentConversationId(
           _currentConversationId,
         );
-        await ConversationHistoryService.saveConversationMessages(
-          _currentConversationId!,
-          _messages,
-        );
-        debugPrint('[ChatBotSheet] 保存对话消息成功，对话ID: $_currentConversationId');
-
         final baseConversation =
             _currentConversation ??
             ConversationModel(
@@ -1382,12 +1376,9 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
       _createThinkingCard(aiMessageId);
 
       final userMessage = _latestUserUtterance();
-      final history = _historyBeforeLatestUser(_buildConversationHistory());
-
       final success = await AssistsMessageService.createAgentTask(
         taskId: aiMessageId,
         userMessage: userMessage,
-        conversationHistory: history,
         conversationId: _currentConversationId,
         conversationMode: ConversationMode.normal.storageValue,
       );

--- a/ui/lib/services/assists_core_service.dart
+++ b/ui/lib/services/assists_core_service.dart
@@ -666,6 +666,10 @@ class AssistsMessageService {
     List<Map<String, dynamic>> content, {
     String? provider,
     Map<String, dynamic>? openClawConfig,
+    int? conversationId,
+    String? conversationMode,
+    String? userMessage,
+    List<Map<String, dynamic>> userAttachments = const [],
   }) async {
     try {
       print('createChatTask taskID: $taskID content: $content');
@@ -675,6 +679,18 @@ class AssistsMessageService {
       }
       if (openClawConfig != null) {
         args['openClawConfig'] = openClawConfig;
+      }
+      if (conversationId != null) {
+        args['conversationId'] = conversationId;
+      }
+      if (conversationMode != null && conversationMode.trim().isNotEmpty) {
+        args['conversationMode'] = conversationMode.trim();
+      }
+      if (userMessage != null) {
+        args['userMessage'] = userMessage;
+      }
+      if (userAttachments.isNotEmpty) {
+        args['userAttachments'] = userAttachments;
       }
       final result = await assistCore.invokeMethod('createChatTask', args);
       return result == "SUCCESS";
@@ -1034,7 +1050,7 @@ class AssistsMessageService {
   static Future<bool> createAgentTask({
     required String taskId,
     required String userMessage,
-    required List<Map<String, dynamic>> conversationHistory,
+    List<Map<String, dynamic>> conversationHistory = const [],
     List<Map<String, dynamic>> attachments = const [],
     int? conversationId,
     String? conversationMode,
@@ -1047,8 +1063,10 @@ class AssistsMessageService {
       final args = <String, dynamic>{
         'taskId': taskId,
         'userMessage': userMessage,
-        'conversationHistory': conversationHistory,
       };
+      if (conversationHistory.isNotEmpty) {
+        args['conversationHistory'] = conversationHistory;
+      }
       if (conversationId != null) {
         args['conversationId'] = conversationId;
       }

--- a/ui/lib/services/conversation_history_service.dart
+++ b/ui/lib/services/conversation_history_service.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:ui/models/chat_message_model.dart';
 import 'package:ui/models/conversation_model.dart';
@@ -6,6 +6,9 @@ import 'package:ui/models/conversation_thread_target.dart';
 
 /// 对话历史持久化服务
 class ConversationHistoryService {
+  static const MethodChannel _assistCore = MethodChannel(
+    'cn.com.omnimind.bot/AssistCoreEvent',
+  );
   static const String _legacyConversationIdKey = 'current_conversation_id';
   static const String _conversationIdKeyPrefix = 'current_conversation_id_';
   static const String _conversationTargetKeyPrefix =
@@ -228,15 +231,18 @@ class ConversationHistoryService {
     List<ChatMessageModel> messages, {
     ConversationMode mode = ConversationMode.normal,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
     final jsonList = messages.map((m) => m.toJson()).toList();
-    if (mode == ConversationMode.normal) {
-      await prefs.remove(_legacyConversationMessagesKey(conversationId));
+    try {
+      await _assistCore.invokeMethod('replaceConversationMessages', {
+        'conversationId': conversationId,
+        'mode': mode.storageValue,
+        'messages': jsonList,
+      });
+    } on PlatformException catch (e) {
+      print('保存对话历史失败: ${e.message}');
+    } catch (e) {
+      print('保存对话历史异常: $e');
     }
-    await prefs.setString(
-      conversationMessagesKey(conversationId, mode: mode),
-      jsonEncode(jsonList),
-    );
   }
 
   /// 获取对话消息列表
@@ -244,17 +250,23 @@ class ConversationHistoryService {
     int conversationId, {
     ConversationMode mode = ConversationMode.normal,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
-    final jsonStr =
-        prefs.getString(conversationMessagesKey(conversationId, mode: mode)) ??
-        (mode == ConversationMode.normal
-            ? prefs.getString(_legacyConversationMessagesKey(conversationId))
-            : null);
-    if (jsonStr == null) return [];
-
     try {
-      final jsonList = jsonDecode(jsonStr) as List;
-      return jsonList.map((json) => ChatMessageModel.fromJson(json)).toList();
+      final result = await _assistCore.invokeMethod<List<dynamic>>(
+        'getConversationMessages',
+        {'conversationId': conversationId, 'mode': mode.storageValue},
+      );
+      if (result == null) return [];
+      return result
+          .whereType<Map>()
+          .map(
+            (json) => ChatMessageModel.fromJson(
+              Map<String, dynamic>.from(json.cast<String, dynamic>()),
+            ),
+          )
+          .toList();
+    } on PlatformException catch (e) {
+      print('获取对话历史失败: ${e.message}');
+      return [];
     } catch (e) {
       print('解析对话历史失败: $e');
       return [];
@@ -266,10 +278,15 @@ class ConversationHistoryService {
     int conversationId, {
     ConversationMode mode = ConversationMode.normal,
   }) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(conversationMessagesKey(conversationId, mode: mode));
-    if (mode == ConversationMode.normal) {
-      await prefs.remove(_legacyConversationMessagesKey(conversationId));
+    try {
+      await _assistCore.invokeMethod('clearConversationMessages', {
+        'conversationId': conversationId,
+        'mode': mode.storageValue,
+      });
+    } on PlatformException catch (e) {
+      print('清理对话历史失败: ${e.message}');
+    } catch (e) {
+      print('清理对话历史异常: $e');
     }
   }
 }

--- a/ui/lib/services/conversation_service.dart
+++ b/ui/lib/services/conversation_service.dart
@@ -1,8 +1,5 @@
-import 'dart:convert';
 import 'package:flutter/services.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:ui/models/conversation_model.dart';
-import 'package:ui/models/chat_message_model.dart';
 import 'package:ui/models/conversation_thread_target.dart';
 import 'package:ui/services/conversation_history_service.dart';
 
@@ -10,153 +7,16 @@ class ConversationService {
   static const MethodChannel _assistCore = MethodChannel(
     'cn.com.omnimind.bot/AssistCoreEvent',
   );
-  static const String _localConversationListKey = 'local_conversation_list';
 
-  static Future<List<ConversationModel>> _loadLocalConversations({
-    bool reloadCache = false,
-  }) async {
-    final prefs = await SharedPreferences.getInstance();
-    if (reloadCache) {
-      await prefs.reload();
-    }
-    final jsonStr = prefs.getString(_localConversationListKey);
-    if (jsonStr == null || jsonStr.isEmpty) return [];
-
-    try {
-      final jsonList = jsonDecode(jsonStr) as List;
-      return jsonList
-          .map(
-            (json) => ConversationModel.fromJson(
-              Map<String, dynamic>.from(json as Map),
-            ),
-          )
-          .toList();
-    } catch (e) {
-      print('[ConversationService] 本地对话列表解析失败: $e');
-      return [];
-    }
-  }
-
-  static Future<List<ConversationModel>> _deriveConversationsFromMessages({
-    List<ConversationModel>? localConversations,
-  }) async {
-    final prefs = await SharedPreferences.getInstance();
-    final keys = prefs.getKeys();
-    final messageKeys = keys
-        .where(
-          (key) => key.startsWith(
-            ConversationHistoryService.conversationMessagesKeyPrefix,
+  static List<ConversationModel> _normalizeConversations(List<dynamic> raw) {
+    final conversations = raw
+        .whereType<Map>()
+        .map(
+          (json) => ConversationModel.fromJson(
+            Map<String, dynamic>.from(json.cast<String, dynamic>()),
           ),
         )
-        .map(ConversationHistoryService.tryParseConversationMessagesKey)
-        .whereType<ConversationMessageStorageKey>()
-        .fold<Map<String, ConversationMessageStorageKey>>(
-          <String, ConversationMessageStorageKey>{},
-          (accumulator, item) {
-            accumulator[item.threadKey] = item;
-            return accumulator;
-          },
-        )
-        .values;
-
-    final baseConversations =
-        localConversations ?? await _loadLocalConversations();
-    if (messageKeys.isEmpty) {
-      return _canonicalizeConversations(baseConversations);
-    }
-
-    final List<ConversationModel> conversations = [];
-    final Set<String> existingKeys = baseConversations
-        .map((conversation) => conversation.threadKey)
-        .toSet();
-    final Set<int> existingIds = baseConversations
-        .map((conversation) => conversation.id)
-        .toSet();
-
-    for (final storageKey in messageKeys) {
-      if (existingKeys.contains(storageKey.threadKey)) continue;
-      // subagent 会话由原生层显式写入 local_conversation_list，
-      // 这里不从消息键反推，避免把历史残留 key 误展示成新会话。
-      if (storageKey.mode == ConversationMode.subagent) {
-        continue;
-      }
-      final conversationId = storageKey.conversationId;
-      if (existingIds.contains(conversationId)) {
-        continue;
-      }
-      final mode = storageKey.mode;
-
-      final messages = await ConversationHistoryService.getConversationMessages(
-        conversationId,
-        mode: mode,
-      );
-      if (messages.isEmpty) continue;
-
-      // 确保消息列表中有有效的用户消息
-      final userMessage = messages.firstWhere(
-        (m) => m.user == 1 && (m.text ?? '').isNotEmpty,
-        orElse: () => ChatMessageModel.userMessage("新对话"),
-      );
-
-      final titleText = userMessage.text ?? '新对话';
-      final title = titleText.length > 20
-          ? '${titleText.substring(0, 20)}...'
-          : titleText;
-
-      final newest = messages.isNotEmpty ? messages.first : null;
-      final oldest = messages.isNotEmpty ? messages.last : null;
-      final lastText = newest?.text ?? '';
-      final createdAt =
-          oldest?.createAt.millisecondsSinceEpoch ??
-          DateTime.now().millisecondsSinceEpoch;
-      final updatedAt = newest?.createAt.millisecondsSinceEpoch ?? createdAt;
-
-      conversations.add(
-        ConversationModel(
-          id: conversationId,
-          mode: mode,
-          title: title,
-          summary: null,
-          status: 0,
-          lastMessage: lastText,
-          messageCount: messages.length,
-          createdAt: createdAt,
-          updatedAt: updatedAt,
-        ),
-      );
-    }
-
-    return _canonicalizeConversations([...baseConversations, ...conversations]);
-  }
-
-  static Future<void> _saveLocalConversations(
-    List<ConversationModel> conversations,
-  ) async {
-    final prefs = await SharedPreferences.getInstance();
-    final canonicalized = _canonicalizeConversations(conversations);
-    final jsonList = canonicalized.map((c) => c.toJson()).toList();
-    await prefs.setString(_localConversationListKey, jsonEncode(jsonList));
-  }
-
-  static bool _shouldPersistMerged(
-    List<ConversationModel> local,
-    List<ConversationModel> merged,
-  ) {
-    if (merged.isEmpty) return false;
-    if (local.isEmpty) return true;
-    if (merged.length != local.length) return true;
-    final localKeys = local
-        .map((conversation) => conversation.threadKey)
-        .toSet();
-    for (final conversation in merged) {
-      if (!localKeys.contains(conversation.threadKey)) return true;
-    }
-    return false;
-  }
-
-  static List<ConversationModel> _sortConversations(
-    List<ConversationModel> conversations,
-  ) {
+        .toList();
     conversations.sort((a, b) {
       final byUpdatedAt = b.updatedAt.compareTo(a.updatedAt);
       if (byUpdatedAt != 0) return byUpdatedAt;
@@ -169,104 +29,22 @@ class ConversationService {
     return conversations;
   }
 
-  static List<ConversationModel> _canonicalizeConversations(
-    List<ConversationModel> source,
-  ) {
-    if (source.isEmpty) return [];
-    final sorted = _sortConversations([...source]);
-    final seenThreadKeys = <String>{};
-    final seenIds = <int>{};
-    final normalized = <ConversationModel>[];
-    for (final conversation in sorted) {
-      if (seenThreadKeys.contains(conversation.threadKey)) {
-        continue;
-      }
-      // 历史遗留数据可能出现跨 mode 的同 ID 冲突；对外统一只保留一条。
-      if (seenIds.contains(conversation.id)) {
-        continue;
-      }
-      seenThreadKeys.add(conversation.threadKey);
-      seenIds.add(conversation.id);
-      normalized.add(conversation);
-    }
-    return _sortConversations(normalized);
-  }
-
-  static Future<int> _nextConversationId(
-    List<ConversationModel> conversations,
-  ) async {
-    int maxId = 0;
-    for (final conv in conversations) {
-      if (conv.id > maxId) maxId = conv.id;
-    }
-
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.reload();
-    final keys = prefs.getKeys();
-    for (final key in keys) {
-      final parsed = ConversationHistoryService.tryParseConversationMessagesKey(
-        key,
-      );
-      if (parsed == null) continue;
-      if (parsed.conversationId > maxId) {
-        maxId = parsed.conversationId;
-      }
-    }
-
-    for (final mode in ConversationMode.values) {
-      final currentId =
-          await ConversationHistoryService.getCurrentConversationId(mode: mode);
-      if (currentId != null && currentId > maxId) {
-        maxId = currentId;
-      }
-    }
-
-    return maxId + 1;
-  }
-
-  /// 获取所有对话列表
   static Future<List<ConversationModel>> getAllConversations() async {
-    // 本地为主，确保多引擎一致性，同时合并消息派生的对话
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.reload();
-    final localConversations = await _loadLocalConversations();
-    final merged = await _deriveConversationsFromMessages(
-      localConversations: localConversations,
-    );
-    if (merged.isNotEmpty) {
-      if (_shouldPersistMerged(localConversations, merged)) {
-        await _saveLocalConversations(merged);
-      }
-      return merged;
-    }
-
-    // 本地为空时尝试原生（兼容旧数据）
     try {
-      final result = await _assistCore.invokeMethod('getConversations');
-      if (result != null && result is List) {
-        final conversations = result
-            .map(
-              (json) => ConversationModel.fromJson(
-                Map<String, dynamic>.from(json as Map),
-              ),
-            )
-            .toList();
-        final normalized = _canonicalizeConversations(conversations);
-        if (normalized.isNotEmpty) {
-          await _saveLocalConversations(normalized);
-          return normalized;
-        }
-      }
+      final result = await _assistCore.invokeMethod<List<dynamic>>(
+        'getConversations',
+      );
+      if (result == null) return [];
+      return _normalizeConversations(result);
     } on PlatformException catch (e) {
       print('[ConversationService] 获取对话列表失败: ${e.message}');
+      return [];
     } catch (e) {
       print('[ConversationService] 获取对话列表异常: $e');
+      return [];
     }
-
-    return [];
   }
 
-  /// 分页获取对话列表
   static Future<List<ConversationModel>> getConversationsByPage({
     required int offset,
     required int limit,
@@ -279,87 +57,53 @@ class ConversationService {
     return all.sublist(start, end);
   }
 
-  /// 创建新对话
   static Future<int?> createConversation({
     required String title,
     String? summary,
     ConversationMode mode = ConversationMode.normal,
   }) async {
     try {
-      final now = DateTime.now().millisecondsSinceEpoch;
-      final conversations = await _loadLocalConversations(reloadCache: true);
-      final newId = await _nextConversationId(conversations);
-      final conversation = ConversationModel(
-        id: newId,
-        mode: mode,
-        title: title,
-        summary: summary,
-        status: 0,
-        lastMessage: null,
-        messageCount: 0,
-        createdAt: now,
-        updatedAt: now,
+      final result = await _assistCore.invokeMethod<dynamic>(
+        'createConversation',
+        {'title': title, 'summary': summary, 'mode': mode.storageValue},
       );
-      conversations.add(conversation);
-      await _saveLocalConversations(_sortConversations(conversations));
-      return newId;
+      if (result is int) return result;
+      if (result is String) return int.tryParse(result);
+      return null;
+    } on PlatformException catch (e) {
+      print('创建对话失败: ${e.message}');
+      return null;
     } catch (e) {
       print('创建对话失败: $e');
       return null;
     }
   }
 
-  /// 更新对话
   static Future<bool> updateConversation(ConversationModel conversation) async {
     try {
-      final conversations = await _loadLocalConversations();
-      final index = conversations.indexWhere(
-        (item) => item.threadKey == conversation.threadKey,
+      final result = await _assistCore.invokeMethod<dynamic>(
+        'updateConversation',
+        {'conversation': conversation.toJson()},
       );
-      if (index == -1) {
-        conversations.add(conversation);
-      } else {
-        conversations[index] = conversation;
-      }
-      await _saveLocalConversations(_sortConversations(conversations));
-      return true;
+      return result == 'SUCCESS';
+    } on PlatformException catch (e) {
+      print('更新对话失败: ${e.message}');
+      return false;
     } catch (e) {
       print('更新对话失败: $e');
       return false;
     }
   }
 
-  /// 删除对话
   static Future<bool> deleteConversation(
     int conversationId, {
     ConversationMode? mode,
   }) async {
     try {
-      // 1. 先删除消息
-      if (mode == null) {
-        for (final entryMode in ConversationMode.values) {
-          await ConversationHistoryService.clearConversationMessages(
-            conversationId,
-            mode: entryMode,
-          );
-        }
-      } else {
-        await ConversationHistoryService.clearConversationMessages(
-          conversationId,
-          mode: mode,
-        );
-      }
-
-      // 2. 从本地列表中删除对话
-      final conversations = await _loadLocalConversations();
-      conversations.removeWhere(
-        (conversation) =>
-            conversation.id == conversationId &&
-            (mode == null || conversation.mode == mode),
-      );
-      await _saveLocalConversations(_sortConversations(conversations));
-
-      // 3. 清理当前/上次可见线程记录
+      final result = await _assistCore.invokeMethod<dynamic>('deleteConversation', {
+        'conversationId': conversationId,
+        if (mode != null) 'mode': mode.storageValue,
+      });
       await ConversationHistoryService.clearConversationThreadReferences(
         conversationId,
         mode: mode,
@@ -367,53 +111,40 @@ class ConversationService {
       await setCurrentConversationTarget(
         await ConversationHistoryService.getLastVisibleThreadTarget(),
       );
-
-      // 4. 尝试删除原生层数据（如果原生层实现了该方法）
-      try {
-        await _assistCore.invokeMethod('deleteConversation', {
-          'conversationId': conversationId,
-          if (mode != null) 'mode': mode.storageValue,
-        });
-      } catch (e) {
-        // 忽略原生层删除失败，可能未实现该方法
-        print('[ConversationService] 原生层删除失败或未实现: $e');
-      }
-
-      return true;
+      return result == 'SUCCESS';
+    } on PlatformException catch (e) {
+      print('删除对话失败: ${e.message}');
+      return false;
     } catch (e) {
       print('删除对话失败: $e');
       return false;
     }
   }
 
-  /// 更新对话标题
   static Future<bool> updateConversationTitle({
     required int conversationId,
     required String newTitle,
     ConversationMode mode = ConversationMode.normal,
   }) async {
     try {
-      final conversations = await _loadLocalConversations();
-      final index = conversations.indexWhere(
-        (conversation) =>
-            conversation.id == conversationId && conversation.mode == mode,
+      final result = await _assistCore.invokeMethod<dynamic>(
+        'updateConversationTitle',
+        {
+          'conversationId': conversationId,
+          'newTitle': newTitle,
+          'mode': mode.storageValue,
+        },
       );
-      if (index == -1) return false;
-      final updated = conversations[index].copyWith(
-        title: newTitle,
-        updatedAt: DateTime.now().millisecondsSinceEpoch,
-      );
-      conversations[index] = updated;
-      await _saveLocalConversations(_sortConversations(conversations));
-      return true;
+      return result == 'SUCCESS';
+    } on PlatformException catch (e) {
+      print('更新对话标题失败: ${e.message}');
+      return false;
     } catch (e) {
       print('更新对话标题失败: $e');
       return false;
     }
   }
 
-  /// 生成对话摘要
-  /// 使用云端 qwen-plus 模型生成 6 字左右的摘要
   static Future<String?> generateConversationSummary({
     required String conversationHistory,
   }) async {
@@ -432,43 +163,35 @@ class ConversationService {
     }
   }
 
-  /// 完成对话（设置状态为已完成）
   static Future<bool> completeConversation(
     int conversationId, {
     ConversationMode? mode,
   }) async {
     try {
-      final conversations = await _loadLocalConversations();
-      final index = conversations.indexWhere(
-        (conversation) =>
-            conversation.id == conversationId &&
-            (mode == null || conversation.mode == mode),
-      );
-      if (index == -1) return false;
-      final updated = conversations[index].copyWith(
-        status: 1,
-        updatedAt: DateTime.now().millisecondsSinceEpoch,
-      );
-      conversations[index] = updated;
-      await _saveLocalConversations(_sortConversations(conversations));
-      return true;
+      final result = await _assistCore.invokeMethod<dynamic>('completeConversation', {
+        'conversationId': conversationId,
+        if (mode != null) 'mode': mode.storageValue,
+      });
+      return result == 'SUCCESS';
+    } on PlatformException catch (e) {
+      print('完成对话失败: ${e.message}');
+      return false;
     } catch (e) {
       print('完成对话失败: $e');
       return false;
     }
   }
 
-  /// 设置当前活跃的对话ID（用于任务完成后跳转）
   static Future<bool> setCurrentConversationId(
     int? conversationId, {
     ConversationMode mode = ConversationMode.normal,
   }) async {
     try {
-      final result = await _assistCore.invokeMethod(
+      final result = await _assistCore.invokeMethod<dynamic>(
         'setCurrentConversationId',
         {'conversationId': conversationId ?? 0, 'mode': mode.storageValue},
       );
-      return result == "SUCCESS";
+      return result == 'SUCCESS';
     } on PlatformException catch (e) {
       print('设置当前对话ID失败: ${e.message}');
       return false;

--- a/ui/lib/services/scheduled_task_scheduler_service.dart
+++ b/ui/lib/services/scheduled_task_scheduler_service.dart
@@ -4,7 +4,6 @@ import 'package:ui/models/scheduled_task.dart';
 import 'package:ui/models/conversation_model.dart';
 import 'package:ui/services/scheduled_task_storage_service.dart';
 import 'package:ui/services/assists_core_service.dart';
-import 'package:ui/services/conversation_history_service.dart';
 import 'package:ui/services/conversation_service.dart';
 
 /// 定时任务调度服务
@@ -244,24 +243,10 @@ class ScheduledTaskSchedulerService {
           if (normalizedConversationId == null) {
             throw Exception('SubAgent conversation create failed');
           }
-          final historyMessages =
-              await ConversationHistoryService.getConversationMessages(
-                normalizedConversationId,
-                mode: ConversationMode.subagent,
-              );
-          final historyPayload = historyMessages.map((message) {
-            final role = switch (message.user) {
-              1 => 'user',
-              2 => 'assistant',
-              _ => 'system',
-            };
-            return {'role': role, 'content': message.text ?? ''};
-          }).toList();
           await AssistsMessageService.createAgentTask(
             taskId:
                 'subagent_schedule_${DateTime.now().millisecondsSinceEpoch}_${task.id}',
             userMessage: prompt,
-            conversationHistory: historyPayload,
             conversationId: normalizedConversationId,
             conversationMode: ConversationMode.subagent.storageValue,
             scheduledTaskId: task.id,

--- a/ui/test/services/conversation_history_service_test.dart
+++ b/ui/test/services/conversation_history_service_test.dart
@@ -1,17 +1,56 @@
-import 'dart:convert';
-
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:ui/models/chat_message_model.dart';
-import 'package:ui/models/conversation_model.dart';
 import 'package:ui/models/conversation_thread_target.dart';
+import 'package:ui/models/conversation_model.dart';
 import 'package:ui/services/conversation_history_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  const channel = MethodChannel('cn.com.omnimind.bot/AssistCoreEvent');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  late Map<String, List<Map<String, dynamic>>> nativeMessages;
+
+  String threadKey(int conversationId, ConversationMode mode) {
+    return '${mode.storageValue}:$conversationId';
+  }
+
+  List<Map<String, dynamic>> normalizeMessageList(dynamic raw) {
+    return ((raw as List?) ?? const <dynamic>[])
+        .whereType<Map>()
+        .map((item) => Map<String, dynamic>.from(item.cast<String, dynamic>()))
+        .toList();
+  }
+
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
+    nativeMessages = <String, List<Map<String, dynamic>>>{};
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      final args =
+          Map<String, dynamic>.from((call.arguments as Map?) ?? const {});
+      final conversationId = (args['conversationId'] as num?)?.toInt() ?? 0;
+      final mode = ConversationMode.fromStorageValue(args['mode'] as String?);
+      final key = threadKey(conversationId, mode);
+      switch (call.method) {
+        case 'replaceConversationMessages':
+          nativeMessages[key] = normalizeMessageList(args['messages']);
+          return 'SUCCESS';
+        case 'getConversationMessages':
+          return nativeMessages[key] ?? <Map<String, dynamic>>[];
+        case 'clearConversationMessages':
+          nativeMessages.remove(key);
+          return 'SUCCESS';
+        default:
+          return null;
+      }
+    });
+  });
+
+  tearDown(() async {
+    messenger.setMockMethodCallHandler(channel, null);
   });
 
   test('stores current conversation ids independently per mode', () async {
@@ -108,30 +147,7 @@ void main() {
     },
   );
 
-  test('supports legacy normal-mode storage fallback', () async {
-    final legacyMessages = <Map<String, dynamic>>[
-      ChatMessageModel.userMessage('legacy normal message').toJson(),
-    ];
-    SharedPreferences.setMockInitialValues(<String, Object>{
-      'current_conversation_id': 15,
-      'conversation_messages_15': jsonEncode(legacyMessages),
-    });
-
-    expect(
-      await ConversationHistoryService.getCurrentConversationId(
-        mode: ConversationMode.normal,
-      ),
-      15,
-    );
-    final messages = await ConversationHistoryService.getConversationMessages(
-      15,
-      mode: ConversationMode.normal,
-    );
-    expect(messages, hasLength(1));
-    expect(messages.single.text, 'legacy normal message');
-  });
-
-  test('stores conversation messages independently per mode', () async {
+  test('stores conversation messages independently per mode through native', () async {
     await ConversationHistoryService.saveConversationMessages(
       1,
       <ChatMessageModel>[ChatMessageModel.userMessage('normal thread')],
@@ -156,5 +172,24 @@ void main() {
 
     expect(normalMessages.single.text, 'normal thread');
     expect(openClawMessages.single.text, 'openclaw thread');
+  });
+
+  test('clears conversation messages through native', () async {
+    await ConversationHistoryService.saveConversationMessages(
+      7,
+      <ChatMessageModel>[ChatMessageModel.userMessage('to be cleared')],
+      mode: ConversationMode.subagent,
+    );
+
+    await ConversationHistoryService.clearConversationMessages(
+      7,
+      mode: ConversationMode.subagent,
+    );
+
+    final messages = await ConversationHistoryService.getConversationMessages(
+      7,
+      mode: ConversationMode.subagent,
+    );
+    expect(messages, isEmpty);
   });
 }

--- a/ui/test/services/conversation_service_test.dart
+++ b/ui/test/services/conversation_service_test.dart
@@ -1,9 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:ui/models/chat_message_model.dart';
 import 'package:ui/models/conversation_model.dart';
 import 'package:ui/models/conversation_thread_target.dart';
 import 'package:ui/services/conversation_history_service.dart';
@@ -15,15 +12,47 @@ void main() {
   const channel = MethodChannel('cn.com.omnimind.bot/AssistCoreEvent');
   final messenger =
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  late List<Map<String, dynamic>> nativeConversations;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
+    nativeConversations = <Map<String, dynamic>>[];
     messenger.setMockMethodCallHandler(channel, (call) async {
+      final args =
+          Map<String, dynamic>.from((call.arguments as Map?) ?? const {});
       switch (call.method) {
         case 'getConversations':
-          return <Object?>[];
+          return nativeConversations;
+        case 'createConversation':
+          final nextId = nativeConversations.fold<int>(
+                0,
+                (maxId, item) => item['id'] as int > maxId
+                    ? item['id'] as int
+                    : maxId,
+              ) +
+              1;
+          nativeConversations.add({
+            'id': nextId,
+            'title': args['title'] ?? '新对话',
+            'mode': args['mode'] ?? ConversationMode.normal.storageValue,
+            'summary': args['summary'],
+            'status': 0,
+            'lastMessage': null,
+            'messageCount': 0,
+            'createdAt': 1,
+            'updatedAt': 1,
+          });
+          return nextId;
+        case 'updateConversation':
+        case 'updateConversationTitle':
+        case 'completeConversation':
         case 'setCurrentConversationId':
+          return 'SUCCESS';
         case 'deleteConversation':
+          final conversationId = (args['conversationId'] as num?)?.toInt();
+          nativeConversations.removeWhere(
+            (item) => item['id'] == conversationId,
+          );
           return 'SUCCESS';
         default:
           return null;
@@ -35,52 +64,56 @@ void main() {
     messenger.setMockMethodCallHandler(channel, null);
   });
 
-  test(
-    'derives openclaw conversations from mode-aware message storage',
-    () async {
-      await ConversationHistoryService.saveConversationMessages(
-        42,
-        <ChatMessageModel>[ChatMessageModel.userMessage('openclaw hello')],
-        mode: ConversationMode.openclaw,
-      );
+  test('loads conversations from native source', () async {
+    nativeConversations = <Map<String, dynamic>>[
+      {
+        'id': 42,
+        'title': 'openclaw hello',
+        'mode': ConversationMode.openclaw.storageValue,
+        'summary': null,
+        'status': 0,
+        'lastMessage': 'openclaw hello',
+        'messageCount': 2,
+        'createdAt': 1,
+        'updatedAt': 2,
+      },
+    ];
 
-      final conversations = await ConversationService.getAllConversations();
+    final conversations = await ConversationService.getAllConversations();
 
-      expect(conversations, hasLength(1));
-      expect(conversations.single.id, 42);
-      expect(conversations.single.mode, ConversationMode.openclaw);
-      expect(conversations.single.title, 'openclaw hello');
-    },
-  );
+    expect(conversations, hasLength(1));
+    expect(conversations.single.id, 42);
+    expect(conversations.single.mode, ConversationMode.openclaw);
+    expect(conversations.single.title, 'openclaw hello');
+  });
 
   test(
     'deletes only the targeted thread metadata and keeps other modes intact',
     () async {
-      final conversations = <ConversationModel>[
-        ConversationModel(
-          id: 1,
-          mode: ConversationMode.normal,
-          title: 'normal thread',
-          status: 0,
-          messageCount: 0,
-          createdAt: 1,
-          updatedAt: 1,
-        ),
-        ConversationModel(
-          id: 2,
-          mode: ConversationMode.openclaw,
-          title: 'openclaw thread',
-          status: 0,
-          messageCount: 0,
-          createdAt: 2,
-          updatedAt: 2,
-        ),
+      nativeConversations = <Map<String, dynamic>>[
+        {
+          'id': 1,
+          'title': 'normal thread',
+          'mode': ConversationMode.normal.storageValue,
+          'summary': null,
+          'status': 0,
+          'lastMessage': null,
+          'messageCount': 0,
+          'createdAt': 1,
+          'updatedAt': 1,
+        },
+        {
+          'id': 2,
+          'title': 'openclaw thread',
+          'mode': ConversationMode.openclaw.storageValue,
+          'summary': null,
+          'status': 0,
+          'lastMessage': null,
+          'messageCount': 0,
+          'createdAt': 2,
+          'updatedAt': 2,
+        },
       ];
-      SharedPreferences.setMockInitialValues(<String, Object>{
-        'local_conversation_list': jsonEncode(
-          conversations.map((conversation) => conversation.toJson()).toList(),
-        ),
-      });
       await ConversationHistoryService.saveCurrentConversationId(
         1,
         mode: ConversationMode.normal,


### PR DESCRIPTION
… conversation entries

- Implemented AgentConversationEntryDao with methods for upserting, querying, and deleting conversation entries.
- Updated AppDatabase to include the new AgentConversationEntry entity and incremented the database version.
- Added migration from version 7 to 8 to create the agent_conversation_entries table and associated indexes.
- Enhanced DatabaseHelper with new methods for managing agent conversation entries.
- Updated conversation management logic in the UI to utilize the new database structure.
- Refactored conversation history service to interact with the new native methods for conversation message management.
- Updated tests to cover new functionality and ensure proper integration with the native layer.

## 变更摘要

将聊天记录中的消息记录落库

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [√] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
