### PR TITLE
fix(scene-model): auto refresh model list and keep manual refresh hidden

### DIFF
--- a/ui/lib/features/home/pages/scene_model_setting/scene_model_setting_page.dart
+++ b/ui/lib/features/home/pages/scene_model_setting/scene_model_setting_page.dart
@@ -35,6 +35,8 @@ class SceneModelSettingPage extends StatefulWidget {
 }
 
 class _SceneModelSettingPageState extends State<SceneModelSettingPage> {
+  static const bool _showManualRefreshButton = false;
+
   static const List<String> _sceneOrder = [
     'scene.dispatch.model',
     'scene.vlm.operation.primary',
@@ -164,6 +166,9 @@ class _SceneModelSettingPageState extends State<SceneModelSettingPage> {
         _profiles = profilesPayload.profiles;
         _providerModelsByProfileId = enriched;
       });
+      if (_profiles.any((profile) => profile.configured)) {
+        unawaited(_refreshProviderModels());
+      }
     } catch (_) {
       if (!mounted) return;
       showToast('加载场景配置失败', type: ToastType.error);
@@ -204,6 +209,7 @@ class _SceneModelSettingPageState extends State<SceneModelSettingPage> {
     try {
       final nextModels = <String, List<ProviderModelOption>>{};
       var refreshedCount = 0;
+      final failedProfiles = <String>[];
       for (final profile in _profiles) {
         if (!profile.configured) {
           nextModels[profile.id] =
@@ -212,29 +218,49 @@ class _SceneModelSettingPageState extends State<SceneModelSettingPage> {
               );
           continue;
         }
-        final remoteModels = await ModelProviderConfigService.fetchModels(
-          apiBase: profile.baseUrl,
-          apiKey: profile.apiKey,
-          profileId: profile.id,
-        );
-        final manualModelIds =
-            await ModelProviderConfigService.getManualModelIds(
-              profileId: profile.id,
-            );
-        nextModels[profile.id] = ModelProviderConfigService.mergeModelOptions(
-          remoteModels: remoteModels,
-          manualModelIds: manualModelIds,
-        );
-        refreshedCount += remoteModels.length;
+        try {
+          final remoteModels = await ModelProviderConfigService.fetchModels(
+            apiBase: profile.baseUrl,
+            apiKey: profile.apiKey,
+            profileId: profile.id,
+          );
+          final manualModelIds =
+              await ModelProviderConfigService.getManualModelIds(
+                profileId: profile.id,
+              );
+          nextModels[profile.id] = ModelProviderConfigService.mergeModelOptions(
+            remoteModels: remoteModels,
+            manualModelIds: manualModelIds,
+          );
+          refreshedCount += remoteModels.length;
+        } catch (e) {
+          //允许部分成功，不让一个 Provider 的失败拖垮整次刷新。
+          nextModels[profile.id] =
+              await ModelProviderConfigService.getStoredModelOptionsForProfile(
+                profile.id,
+              );
+          failedProfiles.add(profile.name);
+        }
       }
 
       if (!mounted) return;
+      // 一次性更新页面模型数据
       setState(() {
         _providerModelsByProfileId = _mergeBindingModels(
           providerModelsByProfileId: nextModels,
           bindings: _bindings,
         );
       });
+      if (failedProfiles.isNotEmpty) {
+        final preview = failedProfiles.take(2).join(', ');
+        final extraCount = failedProfiles.length - 2;
+        final suffix = extraCount > 0 ? ' (+$extraCount)' : '';
+        showToast(
+          '已部分更新，但有 Provider 失败：$preview$suffix',
+          type: ToastType.warning,
+        );
+        return;
+      }
       showToast(
         refreshedCount == 0 ? '当前没有可用模型' : '已更新 $refreshedCount 个模型',
         type: refreshedCount == 0 ? ToastType.warning : ToastType.success,
@@ -556,7 +582,8 @@ class _SceneModelSettingPageState extends State<SceneModelSettingPage> {
                                 ),
                               ),
                             ),
-                            OutlinedButton.icon(
+                            if (_showManualRefreshButton)
+                              OutlinedButton.icon(
                               onPressed: _isRefreshingModels
                                   ? null
                                   : _refreshProviderModels,


### PR DESCRIPTION
## 变更摘要

解决手动更新模型提供商问题，改为每次切换到页面后自动更新。

## 变更类型

- [ ] 重构


## 关联 Issue

#issue59

## 主要改动

1.增加切换页面更新 
2. 隐藏手动更新
3. 支持部分更新成功

## 测试说明


- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
![095f5ccccb8a3e605b9c0a79d68cd306](https://github.com/user-attachments/assets/28e20d3b-231a-4486-b84c-97f197adf783)

```

## UI 变更（如有）

无
## 风险与回滚

无
## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
