### PR TITLE
#issue50,problme;fix(公共文件访问权限): map public storage permission name fo…

### DIFF
--- a/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
+++ b/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
@@ -28,6 +28,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         '无障碍权限': kAccessibilityPermissionId,
         '悬浮窗权限': kOverlayPermissionId,
         '应用列表读取权限': kInstalledAppsPermissionId,
+        '公共文件访问': kPublicStoragePermissionId,
       };
 
   String? _lastAgentTaskId;

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -96,6 +96,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         '无障碍权限': kAccessibilityPermissionId,
         '悬浮窗权限': kOverlayPermissionId,
         '应用列表读取权限': kInstalledAppsPermissionId,
+        '公共文件访问': kPublicStoragePermissionId,
       };
 
   String _agentTextBaseId(String taskId) => '$taskId-text';


### PR DESCRIPTION
…r first-time authorize card

## 变更摘要

修复公共文件访问后需要重新打开应用
## 变更类型

- [ ] Bug 修复


## 关联 Issue

issue50
## 主要改动

1. 增加公共文件访问，与悬浮窗等权限并列 

## 测试说明

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
![3242adf8c3062cbb56e2d50308170849](https://github.com/user-attachments/assets/b8ae9b47-b807-421b-90ac-9aa4ef0f6f3e)


请粘贴测试命令、关键日志或验证步骤```

## UI 变更（如有）

无
## 风险与回滚

无
## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
