### PR TITLE
fix(llm): 自定义提供商 URL 不再插入 /v1 路径段

### DIFF
--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -301,20 +301,12 @@ object HttpController {
 
     private fun buildOpenAIChatCompletionsUrl(apiBase: String): String {
         val base = apiBase.trim().trimEnd('/')
-        return if (base.endsWith("/v1", ignoreCase = true)) {
-            "$base/chat/completions"
-        } else {
-            "$base/v1/chat/completions"
-        }
+        return "$base/chat/completions"
     }
 
     private fun buildOpenAIModelsUrl(apiBase: String): String {
         val base = apiBase.trim().trimEnd('/')
-        return if (base.endsWith("/v1", ignoreCase = true)) {
-            "$base/models"
-        } else {
-            "$base/v1/models"
-        }
+        return "$base/models"
     }
 
     private suspend fun prepareLocalProviderIfNeeded(resolved: ResolvedSceneRequest) {

--- a/ui/lib/services/model_provider_config_service.dart
+++ b/ui/lib/services/model_provider_config_service.dart
@@ -596,7 +596,7 @@ class ModelProviderConfigService {
     return _buildRequestUrl(
       value,
       suffixAfterV1: '/chat/completions',
-      suffixWithVersion: '/v1/chat/completions',
+      suffixWithVersion: '/chat/completions',
     );
   }
 


### PR DESCRIPTION
## 变更摘要

自定义提供商 URL 不再插入 /v1 路径段

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

https://github.com/omnimind-ai/OpenOmniBot/issues/113

## 主要改动

- HttpController：buildOpenAIChatCompletionsUrl / buildOpenAIModelsUrl 统一为 base + /chat/completions、base + /models（与已规范化 base 一致）
- model_provider_config_service：suffixWithVersion 改为 /chat/completions，与原生侧拼接规则对齐

## 测试说明

本地配置了GLM的模型自测了下是能跑通的

- [x] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [x] 已执行相关测试
- [x] 已手动验证关键路径

测试细节：

## UI 变更（如有）

无

## 风险与回滚

可能对存量已储存配置产生影响，需要评估下改动影响范围

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
