### PR TITLE
feat: Add support for stopping agent tool calls and handle interruptions

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/AgentToolExecutionControl.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/AgentToolExecutionControl.kt
@@ -1,0 +1,78 @@
+package cn.com.omnimind.bot.agent
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+
+data class AgentToolProgressSnapshot(
+    val summary: String = "",
+    val extras: Map<String, Any?> = emptyMap()
+)
+
+class ManualToolStopCancellationException(
+    message: String = "Tool execution stopped manually"
+) : CancellationException(message)
+
+interface AgentRunControl {
+    fun beginToolExecution(
+        toolName: String,
+        toolCallId: String
+    ): AgentToolExecutionHandle
+}
+
+interface AgentToolExecutionHandle {
+    val generation: Long
+    val toolName: String
+    val toolCallId: String
+
+    fun bindCardId(cardId: String)
+
+    fun currentCardId(): String?
+
+    fun bindExecutionJob(job: Job)
+
+    fun bindStopAction(action: (suspend () -> Unit)?)
+
+    fun recordProgress(summary: String, extras: Map<String, Any?> = emptyMap())
+
+    fun latestProgressSnapshot(): AgentToolProgressSnapshot
+
+    fun isManualStopRequested(): Boolean
+
+    fun throwIfStopRequested()
+
+    fun complete()
+}
+
+object NoOpAgentRunControl : AgentRunControl {
+    override fun beginToolExecution(
+        toolName: String,
+        toolCallId: String
+    ): AgentToolExecutionHandle {
+        return NoOpAgentToolExecutionHandle(toolName = toolName, toolCallId = toolCallId)
+    }
+}
+
+private class NoOpAgentToolExecutionHandle(
+    override val toolName: String,
+    override val toolCallId: String
+) : AgentToolExecutionHandle {
+    override val generation: Long = 0L
+
+    override fun bindCardId(cardId: String) = Unit
+
+    override fun currentCardId(): String? = null
+
+    override fun bindExecutionJob(job: Job) = Unit
+
+    override fun bindStopAction(action: (suspend () -> Unit)?) = Unit
+
+    override fun recordProgress(summary: String, extras: Map<String, Any?>) = Unit
+
+    override fun latestProgressSnapshot(): AgentToolProgressSnapshot = AgentToolProgressSnapshot()
+
+    override fun isManualStopRequested(): Boolean = false
+
+    override fun throwIfStopRequested() = Unit
+
+    override fun complete() = Unit
+}

--- a/app/src/main/java/cn/com/omnimind/bot/agent/ToolExecutionStatusResolver.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/ToolExecutionStatusResolver.kt
@@ -14,6 +14,8 @@ internal fun resolveToolExecutionStatus(result: ToolExecutionResult): String {
             else -> AgentConversationHistoryRepository.STATUS_ERROR
         }
 
+        is ToolExecutionResult.Interrupted -> AgentConversationHistoryRepository.STATUS_INTERRUPTED
+
         is ToolExecutionResult.ScheduleResult -> if (result.success) {
             AgentConversationHistoryRepository.STATUS_SUCCESS
         } else {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/browser/BrowserUseEngine.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/browser/BrowserUseEngine.kt
@@ -533,6 +533,17 @@ class BrowserUseEngine(
         )
     }
 
+    suspend fun requestInterruptCurrentAction() {
+        withContext(Dispatchers.Main.immediate) {
+            tabs.values.forEach { tab ->
+                runCatching { tab.webView.stopLoading() }
+                tab.isLoading = false
+                tab.loadWaiter?.cancel(ManualToolStopCancellationException())
+                tab.loadWaiter = null
+            }
+        }
+    }
+
     suspend fun captureActiveFramePng(): ByteArray? {
         val tab = activeTabId?.let { tabs[it] } ?: tabs.values.lastOrNull() ?: return null
         activeTabId = tab.tabId

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -444,7 +444,7 @@ class AgentConversationHistoryRepository(
         val cardData = linkedMapOf<String, Any?>(
             "type" to "agent_tool_summary",
             "taskId" to payload["taskId"],
-            "cardId" to messageId,
+            "cardId" to payload["cardId"]?.toString().orEmpty().ifEmpty { messageId },
             "toolName" to payload["toolName"]?.toString().orEmpty(),
             "displayName" to payload["displayName"]?.toString().orEmpty(),
             "toolTitle" to payload["toolTitle"]?.toString().orEmpty(),
@@ -460,6 +460,8 @@ class AgentConversationHistoryRepository(
             "terminalOutputDelta" to payload["terminalOutputDelta"]?.toString().orEmpty(),
             "terminalSessionId" to payload["terminalSessionId"],
             "terminalStreamState" to payload["terminalStreamState"]?.toString().orEmpty(),
+            "interruptedBy" to payload["interruptedBy"]?.toString(),
+            "interruptionReason" to payload["interruptionReason"]?.toString(),
             "timedOut" to (payload["timedOut"] == true),
             "workspaceId" to payload["workspaceId"],
             "artifacts" to toListOfStringAnyMap(payload["artifacts"]),

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -292,6 +292,7 @@ internal object AgentConversationHistorySupport {
 
         return linkedMapOf<String, Any?>(
             "taskId" to chooseAny("taskId"),
+            "cardId" to chooseText("cardId"),
             "toolName" to chooseText("toolName"),
             "displayName" to chooseText("displayName"),
             "toolTitle" to chooseText("toolTitle"),
@@ -308,6 +309,8 @@ internal object AgentConversationHistorySupport {
             "terminalOutputDelta" to terminalOutputDelta,
             "terminalSessionId" to chooseAny("terminalSessionId"),
             "terminalStreamState" to chooseText("terminalStreamState"),
+            "interruptedBy" to chooseText("interruptedBy"),
+            "interruptionReason" to chooseText("interruptionReason"),
             "timedOut" to (incoming["timedOut"] ?: existing["timedOut"] ?: false),
             "workspaceId" to chooseAny("workspaceId"),
             "artifacts" to toListOfStringAnyMap(incoming["artifacts"]).ifEmpty {
@@ -426,6 +429,12 @@ internal object AgentConversationHistorySupport {
                 MAX_TOOL_SUMMARY_CHARS
             )
         )
+        payload["interruptedBy"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+            content["interruptedBy"] = it
+        }
+        payload["interruptionReason"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+            content["interruptionReason"] = it
+        }
         payload["serverName"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
             content["serverName"] = it
         }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentEventAdapter.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentEventAdapter.kt
@@ -21,6 +21,7 @@ class AgentEventAdapter(
             is ToolExecutionResult.McpResult,
             is ToolExecutionResult.MemoryResult,
             is ToolExecutionResult.TerminalResult,
+            is ToolExecutionResult.Interrupted,
             is ToolExecutionResult.ContextResult -> AgentOutputKind.TOOL_RESULT
             is ToolExecutionResult.Error -> AgentOutputKind.NONE
         }
@@ -35,6 +36,7 @@ class AgentEventAdapter(
             result is ToolExecutionResult.McpResult ||
             result is ToolExecutionResult.MemoryResult ||
             result is ToolExecutionResult.TerminalResult ||
+            result is ToolExecutionResult.Interrupted ||
             result is ToolExecutionResult.ContextResult
     }
 
@@ -142,6 +144,22 @@ class AgentEventAdapter(
                 "summary" to result.summaryText,
                 "previewJson" to result.previewJson,
                 "rawResultJson" to result.rawResultJson
+            )
+
+            is ToolExecutionResult.Interrupted -> mapOf(
+                "toolName" to descriptor.name,
+                "displayName" to descriptor.displayName,
+                "toolType" to descriptor.toolType,
+                "success" to false,
+                "status" to "interrupted",
+                "summary" to result.summaryText,
+                "previewJson" to result.previewJson,
+                "rawResultJson" to result.rawResultJson,
+                "interruptedBy" to result.interruptedBy,
+                "interruptionReason" to result.interruptionReason,
+                "terminalOutput" to result.terminalOutput,
+                "terminalSessionId" to result.terminalSessionId,
+                "terminalStreamState" to result.terminalStreamState
             )
 
             is ToolExecutionResult.Error -> mapOf(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentModels.kt
@@ -138,6 +138,21 @@ sealed class ToolExecutionResult {
         override val actions: List<ArtifactAction> = emptyList()
     ) : ToolExecutionResult()
 
+    data class Interrupted(
+        val toolName: String,
+        val summaryText: String = "工具调用已被用户手动停止",
+        val previewJson: String = "{}",
+        val rawResultJson: String = "{}",
+        val interruptedBy: String = "user",
+        val interruptionReason: String = "manual_stop",
+        val terminalOutput: String = "",
+        val terminalSessionId: String? = null,
+        val terminalStreamState: String = "interrupted",
+        override val artifacts: List<ArtifactRef> = emptyList(),
+        override val workspaceId: String? = null,
+        override val actions: List<ArtifactAction> = emptyList()
+    ) : ToolExecutionResult()
+
     data class ContextResult(
         val toolName: String,
         val summaryText: String,

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -6,7 +6,9 @@ import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionStreamOptions
 import cn.com.omnimind.baselib.llm.contentText
 import cn.com.omnimind.baselib.util.OmniLog
+import kotlinx.coroutines.async
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -213,14 +215,38 @@ class AgentOrchestrator(
                         break
                     }
 
-                    callback.onToolCallStart(toolCall.function.name, parsedArgs)
-                    val result = toolRouter.execute(
-                        toolCall = toolCall,
-                        args = parsedArgs,
-                        runtimeDescriptor = descriptor,
-                        env = input.executionEnv,
-                        callback = callback
+                    val toolHandle = input.executionEnv.runControl.beginToolExecution(
+                        toolName = toolCall.function.name,
+                        toolCallId = toolCall.id
                     )
+                    callback.onToolCallStart(toolCall.function.name, parsedArgs)
+                    val result = try {
+                        coroutineScope {
+                            val deferred = async {
+                                toolRouter.execute(
+                                    toolCall = toolCall,
+                                    args = parsedArgs,
+                                    runtimeDescriptor = descriptor,
+                                    env = input.executionEnv,
+                                    callback = callback,
+                                    toolHandle = toolHandle
+                                )
+                            }
+                            toolHandle.bindExecutionJob(deferred)
+                            deferred.await()
+                        }
+                    } catch (error: CancellationException) {
+                        if (toolHandle.isManualStopRequested()) {
+                            buildInterruptedToolResult(
+                                toolName = toolCall.function.name,
+                                toolHandle = toolHandle
+                            )
+                        } else {
+                            throw error
+                        }
+                    } finally {
+                        toolHandle.complete()
+                    }
 
                     executedTools.add(result)
                     val failureLearning = buildFailureLearningPayload(
@@ -342,6 +368,57 @@ class AgentOrchestrator(
                 content = content
             )
         )
+    }
+
+    private fun buildInterruptedToolResult(
+        toolName: String,
+        toolHandle: AgentToolExecutionHandle
+    ): ToolExecutionResult.Interrupted {
+        val snapshot = toolHandle.latestProgressSnapshot()
+        val rawPayload = linkedMapOf<String, Any?>(
+            "toolName" to toolName,
+            "status" to "interrupted",
+            "summary" to "工具调用已被用户手动停止",
+            "interruptedBy" to "user",
+            "interruptionReason" to "manual_stop"
+        ).apply {
+            if (snapshot.summary.isNotBlank()) {
+                put("lastProgress", snapshot.summary)
+            }
+            snapshot.extras.forEach { (key, value) ->
+                put(key, value)
+            }
+        }
+        val encodedPayload = json.encodeToString(mapToJsonElement(rawPayload))
+        return ToolExecutionResult.Interrupted(
+            toolName = toolName,
+            summaryText = "工具调用已被用户手动停止",
+            previewJson = encodedPayload,
+            rawResultJson = encodedPayload,
+            terminalOutput = snapshot.extras["terminalOutput"]?.toString().orEmpty().ifBlank {
+                snapshot.extras["terminalOutputDelta"]?.toString().orEmpty()
+            },
+            terminalSessionId = snapshot.extras["terminalSessionId"]?.toString(),
+            terminalStreamState = snapshot.extras["terminalStreamState"]?.toString()
+                ?.takeIf { it.isNotBlank() }
+                ?: "interrupted"
+        )
+    }
+
+    private fun mapToJsonElement(value: Any?): JsonElement {
+        return when (value) {
+            null -> kotlinx.serialization.json.JsonNull
+            is JsonElement -> value
+            is Map<*, *> -> JsonObject(
+                value.entries.associate { (key, item) ->
+                    key.toString() to mapToJsonElement(item)
+                }
+            )
+            is List<*> -> JsonArray(value.map { mapToJsonElement(it) })
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            else -> JsonPrimitive(value.toString())
+        }
     }
 
     private fun buildFailureLearningPayload(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeContracts.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeContracts.kt
@@ -14,6 +14,7 @@ interface AgentExecutionEnvironment {
     val workspaceMemoryService: WorkspaceMemoryService
     val conversationMode: String
     val terminalEnvironment: Map<String, String>
+    val runControl: AgentRunControl
 }
 
 data class DefaultAgentExecutionEnvironment(
@@ -27,7 +28,8 @@ data class DefaultAgentExecutionEnvironment(
     override val workspaceManager: AgentWorkspaceManager,
     override val workspaceMemoryService: WorkspaceMemoryService,
     override val conversationMode: String,
-    override val terminalEnvironment: Map<String, String> = emptyMap()
+    override val terminalEnvironment: Map<String, String> = emptyMap(),
+    override val runControl: AgentRunControl = NoOpAgentRunControl
 ) : AgentExecutionEnvironment
 
 interface AgentToolCatalog {
@@ -44,7 +46,8 @@ interface AgentToolExecutor {
         args: JsonObject,
         runtimeDescriptor: AgentToolRegistry.RuntimeToolDescriptor,
         env: AgentExecutionEnvironment,
-        callback: AgentCallback
+        callback: AgentCallback,
+        toolHandle: AgentToolExecutionHandle
     ): ToolExecutionResult
 
     suspend fun dispose() = Unit

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
@@ -55,7 +55,8 @@ class OmniAgentExecutor(
         conversationMode: String,
         modelOverride: AgentModelOverride?,
         terminalEnvironment: Map<String, String>,
-        callback: AgentCallback
+        callback: AgentCallback,
+        runControl: AgentRunControl = NoOpAgentRunControl
     ): AgentResult {
         var toolRouter: AgentToolRouter? = null
         return try {
@@ -149,7 +150,8 @@ class OmniAgentExecutor(
                         workspaceManager = workspaceManager,
                         workspaceMemoryService = memoryService,
                         conversationMode = conversationMode,
-                        terminalEnvironment = terminalEnvironment
+                        terminalEnvironment = terminalEnvironment,
+                        runControl = runControl
                     )
                 )
             )

--- a/app/src/main/java/cn/com/omnimind/bot/agent/skill/SelfImprovingSkillFailureHook.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/skill/SelfImprovingSkillFailureHook.kt
@@ -49,6 +49,7 @@ object SelfImprovingSkillFailureHook {
         return when (result) {
             is ToolExecutionResult.Error -> true
             is ToolExecutionResult.TerminalResult -> !result.success
+            is ToolExecutionResult.Interrupted -> false
             is ToolExecutionResult.ContextResult -> !result.success
             is ToolExecutionResult.MemoryResult -> !result.success
             is ToolExecutionResult.McpResult -> !result.success
@@ -145,6 +146,7 @@ object SelfImprovingSkillFailureHook {
         return when (result) {
             is ToolExecutionResult.Error -> result.message
             is ToolExecutionResult.TerminalResult -> result.summaryText
+            is ToolExecutionResult.Interrupted -> result.summaryText
             is ToolExecutionResult.ContextResult -> result.summaryText
             is ToolExecutionResult.MemoryResult -> result.summaryText
             is ToolExecutionResult.McpResult -> result.summaryText
@@ -157,6 +159,11 @@ object SelfImprovingSkillFailureHook {
         return when (result) {
             is ToolExecutionResult.Error -> result.message
             is ToolExecutionResult.TerminalResult -> {
+                result.rawResultJson.ifBlank {
+                    result.terminalOutput.ifBlank { result.summaryText }
+                }
+            }
+            is ToolExecutionResult.Interrupted -> {
                 result.rawResultJson.ifBlank {
                     result.terminalOutput.ifBlank { result.summaryText }
                 }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentToolRouter.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentToolRouter.kt
@@ -97,9 +97,13 @@ class AgentToolRouter(
         callback: AgentCallback,
         toolName: String,
         progress: String,
-        extras: Map<String, Any?> = emptyMap()
+        extras: Map<String, Any?> = emptyMap(),
+        toolHandle: AgentToolExecutionHandle? = null
     ) {
+        toolHandle?.throwIfStopRequested()
+        toolHandle?.recordProgress(progress, extras)
         callback.onToolCallProgress(toolName, progress, extras)
+        toolHandle?.throwIfStopRequested()
         ensureRunActive()
     }
 
@@ -163,7 +167,8 @@ class AgentToolRouter(
         args: JsonObject,
         runtimeDescriptor: AgentToolRegistry.RuntimeToolDescriptor,
         env: AgentExecutionEnvironment,
-        callback: AgentCallback
+        callback: AgentCallback,
+        toolHandle: AgentToolExecutionHandle
     ): ToolExecutionResult {
         ensureRunActive()
         return when (toolCall.function.name) {
@@ -190,7 +195,8 @@ class AgentToolRouter(
                 args = args,
                 workspace = env.workspaceDescriptor,
                 terminalEnvironment = env.terminalEnvironment,
-                callback = callback
+                callback = callback,
+                toolHandle = toolHandle
             )
             "terminal_session_start" -> executeTerminalSessionStart(
                 args = args,
@@ -202,7 +208,8 @@ class AgentToolRouter(
                 args = args,
                 workspace = env.workspaceDescriptor,
                 terminalEnvironment = env.terminalEnvironment,
-                callback = callback
+                callback = callback,
+                toolHandle = toolHandle
             )
             "terminal_session_read" -> executeTerminalSessionRead(
                 args = args,
@@ -217,7 +224,8 @@ class AgentToolRouter(
             "browser_use" -> executeBrowserUse(
                 args = args,
                 env = env,
-                callback = callback
+                callback = callback,
+                toolHandle = toolHandle
             )
             "file_read" -> executeFileRead(args, env.workspaceDescriptor, callback)
             "file_write" -> executeFileWrite(args, env.workspaceDescriptor, callback)
@@ -342,23 +350,28 @@ class AgentToolRouter(
     private suspend fun executeBrowserUse(
         args: JsonObject,
         env: AgentExecutionEnvironment,
-        callback: AgentCallback
+        callback: AgentCallback,
+        toolHandle: AgentToolExecutionHandle
     ): ToolExecutionResult {
         val toolName = "browser_use"
         return try {
             requireWorkspaceStorageAccess(callback)?.let { return it }
             val request = BrowserUseRequest.fromJson(args)
-            reportToolProgress(
-                callback,
-                toolName,
-                request.toolTitle,
-                mapOf("summary" to request.toolTitle)
-            )
             val engine = LiveAgentBrowserSessionManager.acquireEngine(
                 context = context,
                 workspaceManager = workspaceManager,
                 agentRunId = env.agentRunId,
                 workspace = env.workspaceDescriptor
+            )
+            toolHandle.bindStopAction {
+                engine.requestInterruptCurrentAction()
+            }
+            reportToolProgress(
+                callback,
+                toolName,
+                request.toolTitle,
+                mapOf("summary" to request.toolTitle),
+                toolHandle = toolHandle
             )
             val outcome = engine.execute(request)
             val payload = linkedMapOf<String, Any?>(
@@ -543,10 +556,15 @@ class AgentToolRouter(
         args: JsonObject,
         workspace: AgentWorkspaceDescriptor,
         terminalEnvironment: Map<String, String>,
-        callback: AgentCallback
+        callback: AgentCallback,
+        toolHandle: AgentToolExecutionHandle
     ): ToolExecutionResult {
         val toolName = "terminal_execute"
         return try {
+            var runningProcess: Process? = null
+            toolHandle.bindStopAction {
+                runCatching { runningProcess?.destroyForcibly() }
+            }
             reportToolProgress(
                 callback,
                 toolName,
@@ -554,7 +572,8 @@ class AgentToolRouter(
                 mapOf(
                     "summary" to "正在调用内嵌 Alpine 终端执行命令",
                     "terminalStreamState" to "starting"
-                )
+                ),
+                toolHandle = toolHandle
             )
             val rawArgs = parseTerminalExecuteArgs(args)
             val parsedArgs = rawArgs.copy(
@@ -572,6 +591,12 @@ class AgentToolRouter(
                     timeoutSeconds = parsedArgs.timeoutSeconds,
                     environment = terminalEnvironment
                 ),
+                onProcessStarted = { process ->
+                    runningProcess = process
+                    if (toolHandle.isManualStopRequested()) {
+                        runCatching { process.destroyForcibly() }
+                    }
+                },
                 onLiveUpdate = { update ->
                     reportToolProgress(
                         callback,
@@ -590,7 +615,8 @@ class AgentToolRouter(
                             "terminalSessionId" to update.sessionId,
                             "terminalOutputDelta" to update.outputDelta,
                             "terminalStreamState" to update.streamState
-                        )
+                        ),
+                        toolHandle = toolHandle
                     )
                 }
             )
@@ -698,7 +724,8 @@ class AgentToolRouter(
         args: JsonObject,
         workspace: AgentWorkspaceDescriptor,
         terminalEnvironment: Map<String, String>,
-        callback: AgentCallback
+        callback: AgentCallback,
+        toolHandle: AgentToolExecutionHandle
     ): ToolExecutionResult {
         val toolName = "terminal_session_exec"
         return try {
@@ -721,8 +748,12 @@ class AgentToolRouter(
                     "summary" to "正在向终端会话发送命令",
                     "terminalSessionId" to sessionId,
                     "terminalStreamState" to "starting"
-                )
+                ),
+                toolHandle = toolHandle
             )
+            toolHandle.bindStopAction {
+                EmbeddedTerminalRuntime.stopSession(context, sessionId)
+            }
             val result = EmbeddedTerminalRuntime.executeSessionCommand(
                 context = context,
                 sessionId = sessionId,
@@ -741,7 +772,8 @@ class AgentToolRouter(
                             "terminalSessionId" to update.sessionId,
                             "terminalOutputDelta" to update.outputDelta,
                             "terminalStreamState" to update.streamState
-                        )
+                        ),
+                        toolHandle = toolHandle
                     )
                 }
             )

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -55,8 +55,12 @@ import cn.com.omnimind.bot.agent.AgentResult
 import cn.com.omnimind.bot.agent.AgentConversationHistoryRepository
 import cn.com.omnimind.bot.agent.AgentRuntimeContextRepository
 import cn.com.omnimind.bot.agent.AgentScheduleToolBridge
+import cn.com.omnimind.bot.agent.AgentRunControl
+import cn.com.omnimind.bot.agent.AgentToolExecutionHandle
+import cn.com.omnimind.bot.agent.AgentToolProgressSnapshot
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
 import cn.com.omnimind.bot.agent.LiveAgentBrowserSessionManager
+import cn.com.omnimind.bot.agent.ManualToolStopCancellationException
 import cn.com.omnimind.bot.agent.OmniAgentExecutor
 import cn.com.omnimind.bot.agent.SkillIndexEntry
 import cn.com.omnimind.bot.agent.SkillIndexService
@@ -326,13 +330,163 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         var isError: Boolean = false
     )
 
+    private class ActiveAgentRunContext(
+        private val taskId: String,
+        val job: Job
+    ) : AgentRunControl {
+        private val lock = Any()
+        private var generationCounter = 0L
+        private var activeTool: ManagedToolExecutionHandle? = null
+
+        override fun beginToolExecution(
+            toolName: String,
+            toolCallId: String
+        ): AgentToolExecutionHandle {
+            return synchronized(lock) {
+                ManagedToolExecutionHandle(
+                    owner = this,
+                    generation = ++generationCounter,
+                    toolName = toolName,
+                    toolCallId = toolCallId
+                ).also { handle ->
+                    activeTool = handle
+                }
+            }
+        }
+
+        fun bindActiveToolCardId(cardId: String) {
+            synchronized(lock) {
+                activeTool?.bindCardId(cardId)
+            }
+        }
+
+        suspend fun requestManualToolStop(cardId: String): Boolean {
+            val handle = synchronized(lock) {
+                activeTool?.takeIf { it.matchesCardId(cardId) }
+            } ?: return false
+            return handle.requestManualStop()
+        }
+
+        fun clearTool(handle: ManagedToolExecutionHandle) {
+            synchronized(lock) {
+                if (activeTool === handle) {
+                    activeTool = null
+                }
+            }
+        }
+    }
+
+    private class ManagedToolExecutionHandle(
+        private val owner: ActiveAgentRunContext,
+        override val generation: Long,
+        override val toolName: String,
+        override val toolCallId: String
+    ) : AgentToolExecutionHandle {
+        private val lock = Any()
+        private var cardId: String? = null
+        private var job: Job? = null
+        private var stopAction: (suspend () -> Unit)? = null
+        private var latestSnapshot = AgentToolProgressSnapshot()
+        private var completed = false
+        private var manualStopRequested = false
+
+        override fun bindCardId(cardId: String) {
+            synchronized(lock) {
+                this.cardId = cardId.trim().ifEmpty { null }
+            }
+        }
+
+        fun matchesCardId(expectedCardId: String): Boolean {
+            val normalized = expectedCardId.trim()
+            if (normalized.isEmpty()) {
+                return false
+            }
+            return synchronized(lock) {
+                cardId == normalized && !completed
+            }
+        }
+
+        override fun currentCardId(): String? {
+            return synchronized(lock) { cardId }
+        }
+
+        override fun bindExecutionJob(job: Job) {
+            synchronized(lock) {
+                this.job = job
+            }
+        }
+
+        override fun bindStopAction(action: (suspend () -> Unit)?) {
+            synchronized(lock) {
+                stopAction = action
+            }
+        }
+
+        override fun recordProgress(summary: String, extras: Map<String, Any?>) {
+            synchronized(lock) {
+                if (!manualStopRequested) {
+                    latestSnapshot = AgentToolProgressSnapshot(
+                        summary = summary,
+                        extras = LinkedHashMap(extras)
+                    )
+                }
+            }
+        }
+
+        override fun latestProgressSnapshot(): AgentToolProgressSnapshot {
+            return synchronized(lock) { latestSnapshot }
+        }
+
+        override fun isManualStopRequested(): Boolean {
+            return synchronized(lock) { manualStopRequested }
+        }
+
+        override fun throwIfStopRequested() {
+            if (isManualStopRequested()) {
+                throw ManualToolStopCancellationException()
+            }
+        }
+
+        suspend fun requestManualStop(): Boolean {
+            val currentStopAction: (suspend () -> Unit)?
+            val currentJob: Job?
+            synchronized(lock) {
+                if (completed) {
+                    return false
+                }
+                if (manualStopRequested) {
+                    return true
+                }
+                manualStopRequested = true
+                currentStopAction = stopAction
+                currentJob = job
+            }
+            runCatching {
+                currentStopAction?.invoke()
+            }.onFailure {
+                OmniLog.w("[AssistsCoreManager]", "manual tool stop action failed: ${it.message}")
+            }
+            currentJob?.cancel(ManualToolStopCancellationException())
+            return true
+        }
+
+        override fun complete() {
+            synchronized(lock) {
+                completed = true
+                stopAction = null
+                job = null
+            }
+            owner.clearTool(this)
+        }
+    }
+
     // 用于存储需要等待用户操作的回调结果
     private lateinit var channel: MethodChannel
     private var mainJob: CoroutineScope = CoroutineScope(Dispatchers.Main)
     private var workJob: CoroutineScope = CoroutineScope(Dispatchers.Default)
     private val activeAgentLock = Any()
 
-    private val activeAgentJobs: MutableMap<String, Job> = mutableMapOf()
+    private val activeAgentRuns: MutableMap<String, ActiveAgentRunContext> = mutableMapOf()
     private val chatTaskPersistenceStates: MutableMap<String, ChatTaskPersistenceState> =
         mutableMapOf()
     private val conversationDomainService by lazy { ConversationDomainService(context) }
@@ -341,9 +495,9 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     private var currentConversationId: Long? = null
     private var currentConversationMode: String = "normal"
 
-    private fun registerActiveAgentJob(taskId: String, job: Job) {
+    private fun registerActiveAgentRun(taskId: String, context: ActiveAgentRunContext) {
         synchronized(activeAgentLock) {
-            activeAgentJobs[taskId] = job
+            activeAgentRuns[taskId] = context
         }
     }
 
@@ -367,8 +521,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
     private fun clearActiveAgentJob(taskId: String, job: Job) {
         synchronized(activeAgentLock) {
-            if (activeAgentJobs[taskId] == job) {
-                activeAgentJobs.remove(taskId)
+            if (activeAgentRuns[taskId]?.job == job) {
+                activeAgentRuns.remove(taskId)
             }
         }
     }
@@ -391,11 +545,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     private fun cancelActiveAgentRun(taskId: String?, reason: String) {
         val jobsToCancel = synchronized(activeAgentLock) {
             if (taskId.isNullOrBlank()) {
-                val snapshot = activeAgentJobs.values.toList()
-                activeAgentJobs.clear()
+                val snapshot = activeAgentRuns.values.map { it.job }
+                activeAgentRuns.clear()
                 snapshot
             } else {
-                val current = activeAgentJobs.remove(taskId)
+                val current = activeAgentRuns.remove(taskId)?.job
                 if (current == null) emptyList() else listOf(current)
             }
         }
@@ -512,13 +666,13 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
     fun hasActiveAgentRuns(): Boolean {
         return synchronized(activeAgentLock) {
-            activeAgentJobs.isNotEmpty()
+            activeAgentRuns.isNotEmpty()
         }
     }
 
     fun activeAgentTaskIds(): List<String> {
         return synchronized(activeAgentLock) {
-            activeAgentJobs.keys.toList()
+            activeAgentRuns.keys.toList()
         }
     }
 
@@ -702,6 +856,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val rawResultJson: String
         val success: Boolean
         val status: String
+        var interruptedBy: String? = null
+        var interruptionReason: String? = null
         when (result) {
             is ToolExecutionResult.ChatMessage -> {
                 summary = result.message
@@ -766,6 +922,15 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 success = result.success
                 status = resolveToolExecutionStatus(result)
             }
+            is ToolExecutionResult.Interrupted -> {
+                summary = result.summaryText
+                previewJson = result.previewJson
+                rawResultJson = result.rawResultJson
+                success = false
+                status = "interrupted"
+                interruptedBy = result.interruptedBy
+                interruptionReason = result.interruptionReason
+            }
             is ToolExecutionResult.ContextResult -> {
                 summary = result.summaryText
                 previewJson = result.previewJson
@@ -800,6 +965,13 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         extractToolTitle(argsJson)?.let { payload["toolTitle"] = it }
         if (result is ToolExecutionResult.TerminalResult) {
             payload["timedOut"] = result.timedOut
+            payload["terminalOutput"] = result.terminalOutput
+            payload["terminalSessionId"] = result.terminalSessionId
+            payload["terminalStreamState"] = result.terminalStreamState
+        }
+        if (result is ToolExecutionResult.Interrupted) {
+            payload["interruptedBy"] = interruptedBy
+            payload["interruptionReason"] = interruptionReason
             payload["terminalOutput"] = result.terminalOutput
             payload["terminalSessionId"] = result.terminalSessionId
             payload["terminalStreamState"] = result.terminalStreamState
@@ -911,6 +1083,48 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 OmniLog.e(TAG, "cancelRunningTask error: ${e.message}")
                 withContext(Dispatchers.Main) {
                     result.error("CANCEL_RUNNING_TASK_ERROR", e.message, null)
+                }
+            }
+        }
+    }
+
+    fun stopAgentToolCall(
+        call: MethodCall,
+        result: MethodChannel.Result
+    ) {
+        mainJob.launch {
+            try {
+                val taskId = call.argument<String>("taskId")?.trim().orEmpty()
+                val cardId = call.argument<String>("cardId")?.trim().orEmpty()
+                if (taskId.isBlank() || cardId.isBlank()) {
+                    withContext(Dispatchers.Main) {
+                        result.error(
+                            "INVALID_ARGUMENTS",
+                            "taskId and cardId are required",
+                            null
+                        )
+                    }
+                    return@launch
+                }
+                val runContext = synchronized(activeAgentLock) {
+                    activeAgentRuns[taskId]
+                }
+                val stopped = runContext?.requestManualToolStop(cardId) == true
+                withContext(Dispatchers.Main) {
+                    if (stopped) {
+                        result.success("SUCCESS")
+                    } else {
+                        result.error(
+                            "NO_MATCHING_ACTIVE_TOOL",
+                            "No running tool matches cardId=$cardId",
+                            null
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "stopAgentToolCall error: ${e.message}")
+                withContext(Dispatchers.Main) {
+                    result.error("STOP_AGENT_TOOL_CALL_ERROR", e.message, null)
                 }
             }
         }
@@ -3098,7 +3312,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         }
         val agentRunJob = SupervisorJob()
         val agentRunScope = CoroutineScope(agentRunJob + Dispatchers.Default)
-        registerActiveAgentJob(taskId, agentRunJob)
+        val agentRunContext = ActiveAgentRunContext(taskId = taskId, job = agentRunJob)
+        registerActiveAgentRun(taskId, agentRunContext)
 
         agentRunScope.launch {
             var historyRepository: AgentConversationHistoryRepository? = null
@@ -3435,7 +3650,10 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         pushToolValue(activeToolArgs, toolName, argsJson)
                         val entryId = "$taskId-tool-${++toolSequence}"
                         pushToolValue(activeToolEntryIds, toolName, entryId)
-                        val payload = buildToolStartPayload(toolName, argsJson)
+                        agentRunContext.bindActiveToolCardId(entryId)
+                        val payload = buildToolStartPayload(toolName, argsJson).toMutableMap().apply {
+                            put("cardId", entryId)
+                        }
                         upsertToolEvent(
                             entryId = entryId,
                             payload = payload,
@@ -3461,7 +3679,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             progress,
                             peekToolValue(activeToolArgs, toolName),
                             extras
-                        )
+                        ).toMutableMap().apply {
+                            if (entryId.isNotBlank()) {
+                                put("cardId", entryId)
+                            }
+                        }
                         upsertToolEvent(
                             entryId = entryId,
                             payload = payload,
@@ -3481,10 +3703,13 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         result: ToolExecutionResult
                     ) {
                         val argsJson = popToolValue(activeToolArgs, toolName)
-                        val payload = buildToolCompletePayload(toolName, result, argsJson)
                         val entryId = popToolValue(activeToolEntryIds, toolName).ifBlank {
                             "$taskId-tool-${++toolSequence}"
                         }
+                        val payload = buildToolCompletePayload(toolName, result, argsJson)
+                            .toMutableMap().apply {
+                                put("cardId", entryId)
+                            }
                         val success = payload["success"] != false
                         upsertToolEvent(
                             entryId = entryId,
@@ -3753,7 +3978,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     resolvedConversationMode,
                     modelOverride,
                     terminalEnvironment,
-                    callback
+                    callback,
+                    runControl = agentRunContext
                 )
             } catch (e: CancellationException) {
                 OmniLog.i(TAG, "createAgentTask cancelled: ${e.message}")

--- a/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalRuntime.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalRuntime.kt
@@ -509,6 +509,7 @@ object EmbeddedTerminalRuntime {
         workingDirectory: String?,
         timeoutSeconds: Int,
         environment: Map<String, String> = emptyMap(),
+        onProcessStarted: ((Process) -> Unit)? = null,
         onLiveUpdate: suspend (TermuxLiveUpdate) -> Unit = {}
     ): CommandResult {
         val status = ensureCommandEnvironmentReady(context) { progress ->
@@ -555,6 +556,7 @@ object EmbeddedTerminalRuntime {
             command = wrappedCommand,
             executorKey = buildExecutorKey(workingDirectory),
             timeoutMs = timeoutSeconds * 1000L,
+            onProcessStarted = onProcessStarted,
             onOutputChunk = { chunk ->
                 val cleanedChunk = sanitizeTerminalNoise(chunk)
                 if (cleanedChunk.isBlank()) {

--- a/app/src/main/java/cn/com/omnimind/bot/termux/TermuxCommandRunner.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/termux/TermuxCommandRunner.kt
@@ -86,6 +86,7 @@ object TermuxCommandRunner {
     suspend fun execute(
         context: Context,
         spec: TermuxCommandSpec,
+        onProcessStarted: ((Process) -> Unit)? = null,
         onLiveUpdate: suspend (TermuxLiveUpdate) -> Unit = {}
     ): TermuxCommandResult {
         val normalizedSpec = normalizeSpec(spec)
@@ -95,6 +96,7 @@ object TermuxCommandRunner {
             workingDirectory = normalizedSpec.workingDirectory,
             timeoutSeconds = normalizedSpec.timeoutSeconds,
             environment = normalizedSpec.environment,
+            onProcessStarted = onProcessStarted,
             onLiveUpdate = onLiveUpdate
         )
 

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
@@ -177,6 +177,9 @@ class AssistsCoreChannel {
                 "cancelRunningTask" -> {
                     assistsCoreManager!!.cancelRunningTask( call, result)
                 }
+                "stopAgentToolCall" -> {
+                    assistsCoreManager!!.stopAgentToolCall(call, result)
+                }
                 "isCompanionTaskRunning" -> {
                     assistsCoreManager!!.isCompanionTaskRunning( call, result)
                 }

--- a/app/src/main/java/com/ai/assistance/operit/terminal/TerminalManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/terminal/TerminalManager.kt
@@ -229,6 +229,7 @@ class TerminalManager private constructor(
         command: String,
         executorKey: String,
         timeoutMs: Long,
+        onProcessStarted: ((Process) -> Unit)? = null,
         onOutputChunk: suspend (String) -> Unit = {}
     ): HiddenExecResult {
         if (!initializeEnvironment()) {
@@ -251,6 +252,7 @@ class TerminalManager private constructor(
                     error = error.message ?: "Failed to start Alpine shell."
                 )
             }
+            onProcessStarted?.invoke(process)
 
             kotlinx.coroutines.coroutineScope {
                 val outputChannel = Channel<String>(Channel.UNLIMITED)

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -1,6 +1,7 @@
 package cn.com.omnimind.bot.agent
 
 import cn.com.omnimind.baselib.llm.ChatCompletionUsage
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -184,6 +185,80 @@ class AgentOrchestratorTest {
 
         assertEquals(listOf("terminal_execute"), toolExecutor.executeCalls)
         assertEquals(2, llmClient.requests.size)
+    }
+
+    @Test
+    fun interruptedToolResultFeedsNextRoundAndKeepsAgentAlive() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    toolCalls = listOf(
+                        toolCall(
+                            name = "terminal_execute",
+                            arguments = """{"command":"sleep 30"}"""
+                        )
+                    )
+                ),
+                assistantTurn(content = "工具已被用户手动停止，我改为直接说明当前状态。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "terminal_execute" to listOf(
+                    ToolExecutionResult.Interrupted(
+                        toolName = "terminal_execute",
+                        summaryText = "工具调用已被用户手动停止",
+                        previewJson = """{"status":"interrupted"}""",
+                        rawResultJson = """{"status":"interrupted","interruptedBy":"user"}""",
+                    )
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("执行 sleep 30"),
+                executionEnv = FakeExecutionEnvironment("执行 sleep 30")
+            )
+        )
+
+        assertEquals(2, llmClient.requests.size)
+        assertEquals("tool", llmClient.requests[1].messages.last().role)
+        assertTrue(callback.finalChatMessages().last().contains("用户手动停止"))
+    }
+
+    @Test
+    fun toolHandleIsCreatedBeforeToolStartCallbackBindsCardId() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    toolCalls = listOf(
+                        toolCall(
+                            name = "browser_use",
+                            arguments = """{"action":"navigate","url":"https://example.com"}"""
+                        )
+                    )
+                ),
+                assistantTurn(content = "已收到浏览器工具结果。")
+            )
+        )
+        val runControl = TrackingRunControl()
+        val callback = CardBindingCallback(runControl, "task-tool-1")
+
+        createOrchestrator(llmClient, FakeToolExecutor()).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("打开页面"),
+                executionEnv = FakeExecutionEnvironment(
+                    "打开页面",
+                    runControl = runControl
+                )
+            )
+        )
+
+        assertEquals("task-tool-1", runControl.lastHandle?.currentCardId())
     }
 
     @Test
@@ -436,7 +511,8 @@ class AgentOrchestratorTest {
             args: JsonObject,
             runtimeDescriptor: AgentToolRegistry.RuntimeToolDescriptor,
             env: AgentExecutionEnvironment,
-            callback: AgentCallback
+            callback: AgentCallback,
+            toolHandle: AgentToolExecutionHandle
         ): ToolExecutionResult {
             executeCalls += toolCall.function.name
             val queue = queuedResults[toolCall.function.name]
@@ -448,7 +524,7 @@ class AgentOrchestratorTest {
         }
     }
 
-    private class RecordingCallback : AgentCallback {
+    private open class RecordingCallback : AgentCallback {
         val chatMessages = mutableListOf<Pair<String, Boolean>>()
         val promptTokenUpdates = mutableListOf<Int>()
         val errors = mutableListOf<String>()
@@ -460,7 +536,7 @@ class AgentOrchestratorTest {
 
         override suspend fun onThinkingUpdate(thinking: String) = Unit
 
-        override suspend fun onToolCallStart(toolName: String, arguments: JsonObject) = Unit
+        open override suspend fun onToolCallStart(toolName: String, arguments: JsonObject) = Unit
 
         override suspend fun onToolCallProgress(
             toolName: String,
@@ -519,9 +595,19 @@ class AgentOrchestratorTest {
         }
     }
 
+    private class CardBindingCallback(
+        private val runControl: TrackingRunControl,
+        private val cardId: String
+    ) : RecordingCallback() {
+        override suspend fun onToolCallStart(toolName: String, arguments: JsonObject) {
+            runControl.bindCurrentCardId(cardId)
+        }
+    }
+
     private class FakeExecutionEnvironment(
         override val userMessage: String,
-        override val conversationMode: String = "normal"
+        override val conversationMode: String = "normal",
+        override val runControl: AgentRunControl = NoOpAgentRunControl
     ) : AgentExecutionEnvironment {
         override val agentRunId: String = "test-run"
         override val currentPackageName: String? = null
@@ -538,5 +624,54 @@ class AgentOrchestratorTest {
         override val workspaceMemoryService: WorkspaceMemoryService
             get() = throw UnsupportedOperationException("unused in test")
         override val terminalEnvironment: Map<String, String> = emptyMap()
+    }
+
+    private class TrackingRunControl : AgentRunControl {
+        var lastHandle: TrackingHandle? = null
+
+        override fun beginToolExecution(
+            toolName: String,
+            toolCallId: String
+        ): AgentToolExecutionHandle {
+            return TrackingHandle(
+                toolName = toolName,
+                toolCallId = toolCallId
+            ).also { handle ->
+                lastHandle = handle
+            }
+        }
+
+        fun bindCurrentCardId(cardId: String) {
+            lastHandle?.bindCardId(cardId)
+        }
+    }
+
+    private class TrackingHandle(
+        override val toolName: String,
+        override val toolCallId: String
+    ) : AgentToolExecutionHandle {
+        override val generation: Long = 1L
+        private var cardId: String? = null
+
+        override fun bindCardId(cardId: String) {
+            this.cardId = cardId
+        }
+
+        override fun currentCardId(): String? = cardId
+
+        override fun bindExecutionJob(job: Job) = Unit
+
+        override fun bindStopAction(action: (suspend () -> Unit)?) = Unit
+
+        override fun recordProgress(summary: String, extras: Map<String, Any?>) = Unit
+
+        override fun latestProgressSnapshot(): AgentToolProgressSnapshot =
+            AgentToolProgressSnapshot()
+
+        override fun isManualStopRequested(): Boolean = false
+
+        override fun throwIfStopRequested() = Unit
+
+        override fun complete() = Unit
     }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/ToolExecutionStatusResolverTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/ToolExecutionStatusResolverTest.kt
@@ -32,4 +32,17 @@ class ToolExecutionStatusResolverTest {
             )
         )
     }
+
+    @Test
+    fun `manual interruption resolves to interrupted status`() {
+        assertEquals(
+            AgentConversationHistoryRepository.STATUS_INTERRUPTED,
+            resolveToolExecutionStatus(
+                ToolExecutionResult.Interrupted(
+                    toolName = "terminal_execute",
+                    summaryText = "工具调用已被用户手动停止"
+                )
+            )
+        )
+    }
 }

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -1158,6 +1158,16 @@ abstract class _ChatPageStateBase extends State<ChatPage>
     );
   }
 
+  Future<bool> _handleToolActivityStopRequested(
+    String taskId,
+    String cardId,
+  ) async {
+    return AssistsMessageService.stopAgentToolCall(
+      taskId: taskId,
+      cardId: cardId,
+    );
+  }
+
   String _buildOpenClawSessionKey(int conversationId) {
     final normalizedUserId = _openClawUserId.trim();
     if (normalizedUserId.isNotEmpty) {

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -641,6 +641,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                 expanded: _isToolActivityExpanded,
                 onExpandedChanged: _setToolActivityExpanded,
                 suppressSurfaceShadow: suppressToolActivitySurfaceShadow,
+                onStopToolCall: _handleToolActivityStopRequested,
               ),
             ),
           ),

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -813,7 +813,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     _finalizePendingAgentTextIfNeeded(runtime, taskId);
     runtime.currentThinkingStage = ThinkingStage.toolCall.value;
     runtime.toolCardSequence += 1;
-    runtime.activeToolCardId = '$taskId-tool-${runtime.toolCardSequence}';
+    runtime.activeToolCardId = _resolveToolCardId(runtime, taskId, event);
     _upsertToolCard(
       runtime: runtime,
       taskId: taskId,
@@ -851,7 +851,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
 
     _updateToolLayerState(runtime, event);
 
-    final cardId = runtime.activeToolCardId;
+    final cardId = _resolveExistingToolCardId(runtime, event);
     if (cardId == null) return;
     _upsertToolCard(
       runtime: runtime,
@@ -876,7 +876,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     final runtime = _runtimeForTask(event.taskId);
     if (binding == null || runtime == null) return;
     final taskId = runtime.currentDispatchTaskId ?? runtime.lastAgentTaskId;
-    final cardId = runtime.activeToolCardId;
+    final cardId = _resolveExistingToolCardId(runtime, event);
     if (taskId == null || taskId != event.taskId || cardId == null) return;
 
     _updateToolLayerState(runtime, event);
@@ -892,7 +892,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       resultPreviewJson: event.resultPreviewJson,
       rawResultJson: event.rawResultJson,
     );
-    runtime.activeToolCardId = null;
+    if (runtime.activeToolCardId == cardId) {
+      runtime.activeToolCardId = null;
+    }
     _updateBrowserSessionSnapshot(runtime, event);
     notifyListeners();
     schedulePersistRuntimeConversation(
@@ -1862,6 +1864,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       'toolTitle': event.toolTitle.isNotEmpty
           ? event.toolTitle
           : (existingCardData['toolTitle'] ?? '').toString(),
+      'cardId': event.cardId.isNotEmpty
+          ? event.cardId
+          : (existingCardData['cardId'] ?? cardId).toString(),
       'toolType': event.toolType,
       'serverName': event.serverName,
       'status': status,
@@ -1888,6 +1893,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
           ? event.terminalStreamState
           : (existingCardData['terminalStreamState'] ?? '').toString(),
       'workspaceId': event.workspaceId ?? existingCardData['workspaceId'],
+      'interruptedBy': event.interruptedBy ?? existingCardData['interruptedBy'],
+      'interruptionReason':
+          event.interruptionReason ?? existingCardData['interruptionReason'],
       'artifacts': event.artifacts.isNotEmpty
           ? event.artifacts
           : (existingCardData['artifacts'] ?? const []),
@@ -1912,6 +1920,29 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         content: {'cardData': cardData, 'id': cardId},
       );
     }
+  }
+
+  String _resolveToolCardId(
+    ChatConversationRuntimeState runtime,
+    String taskId,
+    AgentToolEventData event,
+  ) {
+    final explicit = event.cardId.trim();
+    if (explicit.isNotEmpty) {
+      return explicit;
+    }
+    return '$taskId-tool-${runtime.toolCardSequence}';
+  }
+
+  String? _resolveExistingToolCardId(
+    ChatConversationRuntimeState runtime,
+    AgentToolEventData event,
+  ) {
+    final explicit = event.cardId.trim();
+    if (explicit.isNotEmpty) {
+      return explicit;
+    }
+    return runtime.activeToolCardId;
   }
 
   String _resolveTerminalOutput({

--- a/ui/lib/features/home/pages/chat/widgets/chat_tool_activity_strip.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_tool_activity_strip.dart
@@ -22,6 +22,9 @@ const ValueKey<String> kChatToolActivityPreviewKey = ValueKey<String>(
 const ValueKey<String> kChatToolActivityToggleKey = ValueKey<String>(
   'chat-tool-activity-toggle',
 );
+const ValueKey<String> kChatToolActivityStopKey = ValueKey<String>(
+  'chat-tool-activity-stop',
+);
 
 const double _kToolActivityRowHeight = 32;
 const double _kToolActivitySurfaceRadius = 18;
@@ -32,7 +35,7 @@ const double _kToolActivitySurfaceHorizontalInset = 20;
 const double _kToolActivityDrawerMaxHeight = 264;
 const double _kToolActivityTypeSlotWidth = 34;
 const double _kToolActivityStatusSlotWidth = 42;
-const double _kToolActivityTrailingSlotWidth = 18;
+const double _kToolActivityTrailingSlotWidth = 24;
 const double _kToolActivityAttachedBorderReveal = 1.5;
 const Color _kToolActivitySurfaceColor = Color(0xFFF9FCFF);
 const BorderRadius _kToolActivitySurfaceBorderRadius = BorderRadius.only(
@@ -52,6 +55,7 @@ class ChatToolActivityStrip extends StatefulWidget {
     this.expanded,
     this.onExpandedChanged,
     this.suppressSurfaceShadow = false,
+    this.onStopToolCall,
   });
 
   final List<ChatMessageModel> messages;
@@ -60,6 +64,7 @@ class ChatToolActivityStrip extends StatefulWidget {
   final bool? expanded;
   final ValueChanged<bool>? onExpandedChanged;
   final bool suppressSurfaceShadow;
+  final Future<bool> Function(String taskId, String cardId)? onStopToolCall;
 
   @override
   State<ChatToolActivityStrip> createState() => _ChatToolActivityStripState();
@@ -69,6 +74,7 @@ class _ChatToolActivityStripState extends State<ChatToolActivityStrip> {
   bool _expanded = false;
   double? _lastReportedOccupiedHeight;
   final Set<int> _heldPointerIds = <int>{};
+  String? _pendingStopCardId;
 
   bool get _resolvedExpanded => widget.expanded ?? _expanded;
 
@@ -83,6 +89,7 @@ class _ChatToolActivityStripState extends State<ChatToolActivityStrip> {
     }
 
     final activeCardId = _cardIdentity(activeCard);
+    _schedulePendingStopResetIfNeeded(activeCardId: activeCardId);
     final historyCards = cards
         .where((card) => _cardIdentity(card) != activeCardId)
         .toList(growable: false);
@@ -136,6 +143,10 @@ class _ChatToolActivityStripState extends State<ChatToolActivityStrip> {
                 suppressShadow: widget.suppressSurfaceShadow,
                 leadingInset: isExpanded ? 0 : collapsedLeadingInset,
                 onToggle: () => _handleExpandedChanged(!isExpanded),
+                onStopToolCall: widget.onStopToolCall == null
+                    ? null
+                    : () => _handleStopToolCall(activeCard),
+                isStopPending: _pendingStopCardId == activeCardId,
                 onOpenCard: (cardData) =>
                     _openCardDetailDialog(context, cardData: cardData),
                 onHistoryPointerDown: _handleHistoryPointerDown,
@@ -180,6 +191,7 @@ class _ChatToolActivityStripState extends State<ChatToolActivityStrip> {
   @override
   void didUpdateWidget(covariant ChatToolActivityStrip oldWidget) {
     super.didUpdateWidget(oldWidget);
+    _schedulePendingStopResetIfNeeded();
     if (widget.messages.isEmpty && _lastReportedOccupiedHeight != 0) {
       _reportOccupiedHeight(0);
     }
@@ -243,6 +255,76 @@ class _ChatToolActivityStripState extends State<ChatToolActivityStrip> {
     });
   }
 
+  void _schedulePendingStopResetIfNeeded({String? activeCardId}) {
+    final pendingCardId = _pendingStopCardId;
+    if (pendingCardId == null) {
+      return;
+    }
+    final cards = extractAgentToolCards(widget.messages);
+    Map<String, dynamic>? pendingCard;
+    for (final card in cards) {
+      if (_cardIdentity(card) == pendingCardId) {
+        pendingCard = card;
+        break;
+      }
+    }
+    final resolvedActiveCard = resolveActiveAgentToolCard(cards);
+    final normalizedActiveCardId =
+        activeCardId ??
+        (resolvedActiveCard == null ? null : _cardIdentity(resolvedActiveCard));
+    final stillPending =
+        pendingCard != null &&
+        (pendingCard['status'] ?? '').toString() == 'running' &&
+        normalizedActiveCardId == pendingCardId;
+    if (stillPending) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _pendingStopCardId != pendingCardId) {
+        return;
+      }
+      setState(() {
+        _pendingStopCardId = null;
+      });
+    });
+  }
+
+  Future<void> _handleStopToolCall(Map<String, dynamic> cardData) async {
+    final onStopToolCall = widget.onStopToolCall;
+    if (onStopToolCall == null) {
+      return;
+    }
+    final taskId = (cardData['taskId'] ?? '').toString().trim();
+    final cardId = _cardIdentity(cardData);
+    if (taskId.isEmpty || cardId.isEmpty || _pendingStopCardId == cardId) {
+      return;
+    }
+    setState(() {
+      _pendingStopCardId = cardId;
+    });
+
+    var success = false;
+    try {
+      success = await onStopToolCall(taskId, cardId);
+    } catch (_) {
+      success = false;
+    }
+    if (!mounted) {
+      return;
+    }
+    if (success) {
+      return;
+    }
+    setState(() {
+      if (_pendingStopCardId == cardId) {
+        _pendingStopCardId = null;
+      }
+    });
+    ScaffoldMessenger.maybeOf(
+      context,
+    )?.showSnackBar(const SnackBar(content: Text('停止工具调用失败，请稍后重试')));
+  }
+
   void _handleHistoryPointerDown(int pointer) {
     if (_heldPointerIds.add(pointer)) {
       ToolCardDetailGestureGate.holdPointer(pointer);
@@ -301,6 +383,8 @@ class _ActivityDrawerSurface extends StatelessWidget {
     required this.suppressShadow,
     required this.leadingInset,
     required this.onToggle,
+    required this.isStopPending,
+    required this.onStopToolCall,
     required this.onOpenCard,
     required this.onHistoryPointerDown,
     required this.onHistoryPointerEnd,
@@ -314,6 +398,8 @@ class _ActivityDrawerSurface extends StatelessWidget {
   final bool suppressShadow;
   final double leadingInset;
   final VoidCallback onToggle;
+  final bool isStopPending;
+  final VoidCallback? onStopToolCall;
   final ValueChanged<Map<String, dynamic>> onOpenCard;
   final ValueChanged<int> onHistoryPointerDown;
   final ValueChanged<int> onHistoryPointerEnd;
@@ -378,24 +464,27 @@ class _ActivityDrawerSurface extends StatelessWidget {
               margin: const EdgeInsets.only(left: 18, right: 10),
               color: dividerColor,
             ),
-            GestureDetector(
-              behavior: HitTestBehavior.opaque,
+            ToolActivityRow(
+              card: activeCard,
+              leadingInset: leadingInset,
               onTap: canExpand ? onToggle : null,
-              child: ToolActivityRow(
-                card: activeCard,
-                leadingInset: leadingInset,
-                trailing: canExpand
-                    ? _ActivityBarTrailing(
-                        expanded: expanded,
-                        onToggle: onToggle,
-                      )
-                    : null,
-              ),
+              trailing: _supportsToolStop(activeCard) && onStopToolCall != null
+                  ? _ToolStopButton(
+                      enabled: !isStopPending,
+                      onTap: onStopToolCall,
+                    )
+                  : canExpand
+                  ? _ActivityBarTrailing(expanded: expanded, onToggle: onToggle)
+                  : null,
             ),
           ],
         ),
       ),
     );
+  }
+
+  bool _supportsToolStop(Map<String, dynamic> cardData) {
+    return (cardData['status'] ?? '').toString() == 'running';
   }
 }
 
@@ -421,6 +510,65 @@ class _ActivityBarTrailing extends StatelessWidget {
           duration: const Duration(milliseconds: 220),
           curve: Curves.easeOutCubic,
           child: Icon(Icons.keyboard_arrow_up_rounded, size: 14, color: color),
+        ),
+      ),
+    );
+  }
+}
+
+class _ToolStopButton extends StatelessWidget {
+  const _ToolStopButton({required this.enabled, required this.onTap});
+
+  final bool enabled;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.omniPalette;
+    final baseColor = context.isDarkTheme
+        ? palette.textSecondary
+        : const Color(0xFF657891);
+    final foregroundColor = enabled
+        ? baseColor
+        : baseColor.withValues(alpha: 0.42);
+    final borderColor = enabled
+        ? foregroundColor.withValues(alpha: 0.48)
+        : foregroundColor.withValues(alpha: 0.3);
+    final backgroundColor = context.isDarkTheme
+        ? palette.surfaceElevated.withValues(alpha: enabled ? 0.88 : 0.72)
+        : Colors.white.withValues(alpha: enabled ? 0.9 : 0.72);
+
+    return Tooltip(
+      message: enabled ? '停止工具' : '正在停止工具',
+      child: GestureDetector(
+        key: kChatToolActivityStopKey,
+        behavior: HitTestBehavior.opaque,
+        onTap: enabled ? onTap : null,
+        child: SizedBox(
+          width: _kToolActivityTrailingSlotWidth,
+          height: _kToolActivityRowHeight,
+          child: Center(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 180),
+              width: 18,
+              height: 18,
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                shape: BoxShape.circle,
+                border: Border.all(color: borderColor, width: 1),
+              ),
+              alignment: Alignment.center,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 180),
+                width: 6.5,
+                height: 6.5,
+                decoration: BoxDecoration(
+                  color: foregroundColor,
+                  borderRadius: BorderRadius.circular(1.8),
+                ),
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -492,11 +640,13 @@ class ToolActivityRow extends StatelessWidget {
     super.key,
     required this.card,
     this.leadingInset = 0,
+    this.onTap,
     this.trailing,
   });
 
   final Map<String, dynamic> card;
   final double leadingInset;
+  final VoidCallback? onTap;
   final Widget? trailing;
 
   @override
@@ -528,50 +678,65 @@ class ToolActivityRow extends StatelessWidget {
                     28;
             return Row(
               children: [
-                _StatusDot(status: status),
-                const SizedBox(width: 6),
                 Expanded(
-                  child: Text(
-                    resolveAgentToolTitle(card),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: primaryTextColor,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      letterSpacing: -0.2,
-                      height: 1.05,
-                    ),
-                  ),
-                ),
-                SizedBox(width: showTypeLabel ? 6 : 0),
-                SizedBox(
-                  width: showTypeLabel ? _kToolActivityTypeSlotWidth : 0,
-                  child: showTypeLabel
-                      ? Align(
-                          alignment: Alignment.centerRight,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onTap,
+                    child: Row(
+                      children: [
+                        _StatusDot(status: status),
+                        const SizedBox(width: 6),
+                        Expanded(
                           child: Text(
-                            toolTypeLabel,
+                            resolveAgentToolTitle(card),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
-                            textAlign: TextAlign.right,
                             style: TextStyle(
-                              color: secondaryTextColor,
-                              fontSize: 9,
+                              color: primaryTextColor,
+                              fontSize: 11,
                               fontWeight: FontWeight.w600,
-                              letterSpacing: -0.1,
+                              letterSpacing: -0.2,
                               height: 1.05,
                             ),
                           ),
-                        )
-                      : null,
-                ),
-                const SizedBox(width: 4),
-                SizedBox(
-                  width: _kToolActivityStatusSlotWidth,
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: _StatusTag(status: status, label: statusLabel),
+                        ),
+                        SizedBox(width: showTypeLabel ? 6 : 0),
+                        SizedBox(
+                          width: showTypeLabel
+                              ? _kToolActivityTypeSlotWidth
+                              : 0,
+                          child: showTypeLabel
+                              ? Align(
+                                  alignment: Alignment.centerRight,
+                                  child: Text(
+                                    toolTypeLabel,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    textAlign: TextAlign.right,
+                                    style: TextStyle(
+                                      color: secondaryTextColor,
+                                      fontSize: 9,
+                                      fontWeight: FontWeight.w600,
+                                      letterSpacing: -0.1,
+                                      height: 1.05,
+                                    ),
+                                  ),
+                                )
+                              : null,
+                        ),
+                        const SizedBox(width: 4),
+                        SizedBox(
+                          width: _kToolActivityStatusSlotWidth,
+                          child: Align(
+                            alignment: Alignment.centerRight,
+                            child: _StatusTag(
+                              status: status,
+                              label: statusLabel,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
                 const SizedBox(width: 4),

--- a/ui/lib/services/assists_core_service.dart
+++ b/ui/lib/services/assists_core_service.dart
@@ -118,6 +118,7 @@ class ModelAvailabilityCheckResult {
 
 class AgentToolEventData {
   final String taskId;
+  final String cardId;
   final String toolName;
   final String displayName;
   final String toolTitle;
@@ -134,12 +135,15 @@ class AgentToolEventData {
   final String? terminalSessionId;
   final String terminalStreamState;
   final String? workspaceId;
+  final String? interruptedBy;
+  final String? interruptionReason;
   final List<Map<String, dynamic>> artifacts;
   final List<Map<String, dynamic>> actions;
   final bool success;
 
   const AgentToolEventData({
     required this.taskId,
+    this.cardId = '',
     required this.toolName,
     required this.displayName,
     this.toolTitle = '',
@@ -156,6 +160,8 @@ class AgentToolEventData {
     this.terminalSessionId,
     this.terminalStreamState = '',
     this.workspaceId,
+    this.interruptedBy,
+    this.interruptionReason,
     this.artifacts = const [],
     this.actions = const [],
     this.success = true,
@@ -165,6 +171,7 @@ class AgentToolEventData {
     final raw = map ?? const {};
     return AgentToolEventData(
       taskId: (raw['taskId'] ?? '').toString(),
+      cardId: (raw['cardId'] ?? '').toString(),
       toolName: (raw['toolName'] ?? '').toString(),
       displayName: (raw['displayName'] ?? raw['toolName'] ?? '').toString(),
       toolTitle: (raw['toolTitle'] ?? '').toString(),
@@ -181,6 +188,8 @@ class AgentToolEventData {
       terminalSessionId: raw['terminalSessionId']?.toString(),
       terminalStreamState: (raw['terminalStreamState'] ?? '').toString(),
       workspaceId: raw['workspaceId']?.toString(),
+      interruptedBy: raw['interruptedBy']?.toString(),
+      interruptionReason: raw['interruptionReason']?.toString(),
       artifacts: ((raw['artifacts'] as List?) ?? const [])
           .whereType<Map>()
           .map((item) => item.map((k, v) => MapEntry(k.toString(), v)))
@@ -802,6 +811,23 @@ class AssistsMessageService {
       return result == "SUCCESS";
     } on PlatformException catch (e) {
       print('取消运行中任务失败: ${e.message}');
+      return false;
+    }
+  }
+
+  /// 停止当前 Agent 正在执行的工具调用，但不终止整轮 Agent 响应
+  static Future<bool> stopAgentToolCall({
+    required String taskId,
+    required String cardId,
+  }) async {
+    try {
+      final result = await assistCore.invokeMethod(
+        'stopAgentToolCall',
+        <String, String>{'taskId': taskId, 'cardId': cardId},
+      );
+      return result == "SUCCESS";
+    } on PlatformException catch (e) {
+      print('停止工具调用失败: ${e.message}');
       return false;
     }
   }

--- a/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
+++ b/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
@@ -722,6 +722,103 @@ void main() {
     expect(snapshot?.userAgentProfile, 'desktop_safari');
   });
 
+  test('uses cardId from tool events when completing interrupted tools', () async {
+    const conversationId = 6501;
+    const taskId = 'agent-interrupted-tool-task';
+    const cardId = 'agent-interrupted-tool-task-tool-9';
+
+    final runtime = coordinator.ensureRuntime(
+      conversationId: conversationId,
+      mode: kChatRuntimeModeNormal,
+    );
+    runtime.currentDispatchTaskId = taskId;
+    coordinator.registerTask(
+      taskId: taskId,
+      conversationId: conversationId,
+      mode: kChatRuntimeModeNormal,
+    );
+
+    await emitPlatformEvent('onAgentToolCallStart', <String, dynamic>{
+      'taskId': taskId,
+      'cardId': cardId,
+      'toolName': 'terminal_execute',
+      'displayName': 'terminal_execute',
+      'toolType': 'terminal',
+      'summary': '执行长命令',
+      'argsJson': jsonEncode(<String, dynamic>{'command': 'sleep 30'}),
+    });
+
+    await emitPlatformEvent('onAgentToolCallComplete', <String, dynamic>{
+      'taskId': taskId,
+      'cardId': cardId,
+      'toolName': 'terminal_execute',
+      'displayName': 'terminal_execute',
+      'toolType': 'terminal',
+      'status': 'interrupted',
+      'summary': '工具调用已被用户手动停止',
+      'success': false,
+      'interruptedBy': 'user',
+      'interruptionReason': 'manual_stop',
+    });
+
+    final toolMessage = runtime.messages.firstWhere((message) => message.id == cardId);
+
+    expect(toolMessage.cardData?['status'], 'interrupted');
+    expect(toolMessage.cardData?['interruptedBy'], 'user');
+    expect(toolMessage.cardData?['interruptionReason'], 'manual_stop');
+    expect(runtime.activeToolCardId, isNull);
+  });
+
+  test('continues assistant output after interrupted tool completes', () async {
+    const conversationId = 6502;
+    const taskId = 'agent-interrupted-continue-task';
+    const cardId = 'agent-interrupted-continue-task-tool-2';
+
+    final runtime = coordinator.ensureRuntime(
+      conversationId: conversationId,
+      mode: kChatRuntimeModeNormal,
+    );
+    runtime.currentDispatchTaskId = taskId;
+    coordinator.registerTask(
+      taskId: taskId,
+      conversationId: conversationId,
+      mode: kChatRuntimeModeNormal,
+    );
+
+    await emitPlatformEvent('onAgentToolCallStart', <String, dynamic>{
+      'taskId': taskId,
+      'cardId': cardId,
+      'toolName': 'browser_use',
+      'displayName': 'browser_use',
+      'toolType': 'browser',
+      'summary': '打开页面',
+    });
+
+    await emitPlatformEvent('onAgentToolCallComplete', <String, dynamic>{
+      'taskId': taskId,
+      'cardId': cardId,
+      'toolName': 'browser_use',
+      'displayName': 'browser_use',
+      'toolType': 'browser',
+      'status': 'interrupted',
+      'summary': '工具调用已被用户手动停止',
+      'success': false,
+      'interruptedBy': 'user',
+      'interruptionReason': 'manual_stop',
+    });
+
+    await emitPlatformEvent('onAgentChatMessage', <String, dynamic>{
+      'taskId': taskId,
+      'message': '浏览器工具已停止，我先直接告诉你页面当前不可达。',
+      'isFinal': false,
+    });
+
+    final textMessage = runtime.messages.firstWhere(
+      (message) => message.id == '$taskId-text',
+    );
+    expect(textMessage.text, contains('浏览器工具已停止'));
+  });
+
   test('applies initial island layer when a runtime is created late', () {
     const conversationId = 7001;
 

--- a/ui/test/features/home/pages/chat/widgets/chat_tool_activity_strip_test.dart
+++ b/ui/test/features/home/pages/chat/widgets/chat_tool_activity_strip_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -251,6 +252,115 @@ void main() {
       find.descendant(of: dialog, matching: find.textContaining('终端 · 成功')),
       findsNothing,
     );
+  });
+
+  testWidgets('running active tool shows stop button and taps stop only', (
+    tester,
+  ) async {
+    var stopCalls = 0;
+    var lastTaskId = '';
+    var lastCardId = '';
+    var expanded = false;
+    final messages = [
+      ChatMessageModel.cardMessage({
+        'type': 'agent_tool_summary',
+        'taskId': 'task-stop-1',
+        'cardId': 'task-stop-1-tool-1',
+        'status': 'running',
+        'toolType': 'terminal',
+        'toolTitle': '停止中的工具',
+        'summary': '终端正在运行',
+      }, id: 'task-stop-1-tool-1'),
+      ChatMessageModel.cardMessage({
+        'type': 'agent_tool_summary',
+        'taskId': 'task-stop-1',
+        'cardId': 'task-stop-1-tool-0',
+        'status': 'success',
+        'toolType': 'workspace',
+        'toolTitle': '历史工具',
+        'summary': '历史结果',
+      }, id: 'task-stop-1-tool-0'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            return Scaffold(
+              body: ChatToolActivityStrip(
+                messages: messages,
+                expanded: expanded,
+                onExpandedChanged: (value) => setState(() => expanded = value),
+                onStopToolCall: (taskId, cardId) async {
+                  stopCalls += 1;
+                  lastTaskId = taskId;
+                  lastCardId = cardId;
+                  return true;
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(kChatToolActivityStopKey), findsOneWidget);
+
+    await tester.tap(find.byKey(kChatToolActivityStopKey));
+    await tester.pump();
+
+    expect(stopCalls, 1);
+    expect(lastTaskId, 'task-stop-1');
+    expect(lastCardId, 'task-stop-1-tool-1');
+    expect(expanded, isFalse);
+    expect(
+      find.byKey(kChatToolActivityPreviewKey).hitTestable(),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('stop button stays disabled while stop request is pending', (
+    tester,
+  ) async {
+    final completer = Completer<bool>();
+    var stopCalls = 0;
+    final messages = [
+      ChatMessageModel.cardMessage({
+        'type': 'agent_tool_summary',
+        'taskId': 'task-stop-pending',
+        'cardId': 'task-stop-pending-tool-1',
+        'status': 'running',
+        'toolType': 'terminal',
+        'toolTitle': '等待停止',
+        'summary': '终端正在运行',
+      }, id: 'task-stop-pending-tool-1'),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ChatToolActivityStrip(
+            messages: messages,
+            onStopToolCall: (_, __) {
+              stopCalls += 1;
+              return completer.future;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(kChatToolActivityStopKey));
+    await tester.pump();
+    await tester.tap(find.byKey(kChatToolActivityStopKey));
+    await tester.pump();
+
+    expect(stopCalls, 1);
+
+    completer.complete(true);
+    await tester.pumpAndSettle();
   });
 
   testWidgets('expanded history row opens its own tool detail', (tester) async {


### PR DESCRIPTION
- Enhanced `EmbeddedTerminalRuntime`, `TermuxCommandRunner`, and `TerminalManager` to accept a callback for process start events.
- Implemented `stopAgentToolCall` method in `AssistsMessageService` to allow manual interruption of running tools.
- Updated `AssistsCoreChannel` to handle new stop agent tool call requests.
- Modified `ChatConversationRuntimeCoordinator` to manage tool card IDs and handle tool interruptions.
- Introduced `AgentToolExecutionControl` to manage tool execution states and progress.
- Added tests to verify the behavior of tool interruptions and stopping functionality in various scenarios.
- Updated UI components to reflect the ability to stop running tools and handle stop requests.

## 变更摘要

<!-- 用 1-3 句话描述本次改动解决了什么问题 -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
