### PR TITLE
feat(issue102 storage): add storage usage analysis page with system-a…

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/ChannelManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/ChannelManager.kt
@@ -27,6 +27,7 @@ class ChannelManager {
     private var remoteMcpConfigChannel: RemoteMcpConfigChannel = RemoteMcpConfigChannel()
     private var overlayChannel: OverlayChannel = OverlayChannel()
     private var browserSessionChannel: BrowserSessionChannel = BrowserSessionChannel()
+    private var storageUsageChannel: StorageUsageChannel = StorageUsageChannel()
     fun getUIRouterChannel(): UIRouterChannel {
         return uiRouterChannel
     }
@@ -53,6 +54,7 @@ class ChannelManager {
         remoteMcpConfigChannel.setChannel(flutterEngine)
         overlayChannel.setChannel(flutterEngine)
         browserSessionChannel.setChannel(flutterEngine)
+        storageUsageChannel.setChannel(flutterEngine)
     }
 
     fun onCreate(context: Context) {
@@ -68,6 +70,7 @@ class ChannelManager {
         mnnLocalModelsChannel.onCreate(context)
         mcpServerChannel.onCreate(context)
         remoteMcpConfigChannel.onCreate()
+        storageUsageChannel.onCreate(context)
     }
 
     fun clearChannel() {
@@ -88,6 +91,7 @@ class ChannelManager {
         remoteMcpConfigChannel.clear()
         overlayChannel.clear()
         browserSessionChannel.clear()
+        storageUsageChannel.clear()
     }
 
 

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/StorageUsageChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/StorageUsageChannel.kt
@@ -1,0 +1,1207 @@
+package cn.com.omnimind.bot.ui.channel
+
+import android.app.usage.StorageStatsManager
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.os.Process
+import android.os.storage.StorageManager
+import cn.com.omnimind.baselib.util.OmniLog
+import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.util.ArrayDeque
+
+class StorageUsageChannel {
+    companion object {
+        private const val TAG = "StorageUsageChannel"
+        private const val CHANNEL_NAME = "cn.com.omnimind.bot/StorageUsage"
+
+        private const val DATABASE_NAME_PREFIX = "omnibot_cache_database"
+        private const val DATABASE_PRIMARY_NAME = "${DATABASE_NAME_PREFIX}oss"
+
+        private const val STORAGE_METRICS_PREFS = "storage_usage_metrics"
+        private const val STORAGE_METRICS_HISTORY_KEY = "history_v1"
+        private const val MAX_HISTORY_SIZE = 30
+        private const val DEFAULT_HISTORY_OUTPUT_SIZE = 10
+    }
+
+    private var methodChannel: MethodChannel? = null
+    private var appContext: Context? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    fun onCreate(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    fun setChannel(flutterEngine: FlutterEngine) {
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL_NAME)
+        methodChannel?.setMethodCallHandler(::handleMethodCall)
+    }
+
+    fun clear() {
+        methodChannel?.setMethodCallHandler(null)
+        methodChannel = null
+        appContext = null
+    }
+
+    private fun handleMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "getStorageUsageSummary" -> {
+                scope.launch {
+                    runCatching {
+                        val context = requireContext()
+                        withContext(Dispatchers.IO) {
+                            analyzeStorageUsage(context, persistSnapshot = true)
+                        }
+                    }.onSuccess { payload ->
+                        result.success(payload.summary)
+                    }.onFailure { error ->
+                        OmniLog.e(TAG, "Analyze storage usage failed", error)
+                        result.error("STORAGE_ANALYZE_FAILED", error.message, null)
+                    }
+                }
+            }
+
+            "clearStorageUsageCategory" -> {
+                scope.launch {
+                    runCatching {
+                        val categoryId = call.argument<String>("categoryId")?.trim().orEmpty()
+                        if (categoryId.isEmpty()) {
+                            error("categoryId is required")
+                        }
+                        val olderThanDays =
+                            (call.argument<Number>("olderThanDays")?.toInt() ?: 0).takeIf { it > 0 }
+                        val context = requireContext()
+                        withContext(Dispatchers.IO) {
+                            clearCategory(context, categoryId, olderThanDays)
+                        }
+                    }.onSuccess {
+                        result.success(it)
+                    }.onFailure { error ->
+                        OmniLog.e(TAG, "Clear storage category failed", error)
+                        result.error("STORAGE_CLEAR_FAILED", error.message, null)
+                    }
+                }
+            }
+
+            "applyStorageCleanupStrategy" -> {
+                scope.launch {
+                    runCatching {
+                        val strategyId = call.argument<String>("strategyId")?.trim().orEmpty()
+                        if (strategyId.isEmpty()) {
+                            error("strategyId is required")
+                        }
+                        val olderThanDays =
+                            (call.argument<Number>("olderThanDays")?.toInt() ?: 0).takeIf { it > 0 }
+                        val targetReleaseBytes =
+                            call.argument<Number>("targetReleaseBytes")?.toLong() ?: 0L
+                        val context = requireContext()
+                        withContext(Dispatchers.IO) {
+                            applyCleanupStrategy(
+                                context = context,
+                                strategyId = strategyId,
+                                overrideOlderThanDays = olderThanDays,
+                                targetReleaseBytes = targetReleaseBytes,
+                            )
+                        }
+                    }.onSuccess {
+                        result.success(it)
+                    }.onFailure { error ->
+                        OmniLog.e(TAG, "Apply storage cleanup strategy failed", error)
+                        result.error("STORAGE_STRATEGY_FAILED", error.message, null)
+                    }
+                }
+            }
+
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun requireContext(): Context {
+        return appContext ?: error("StorageUsageChannel is not initialized")
+    }
+
+    private data class AnalysisPayload(
+        val summary: Map<String, Any?>,
+        val categoryBytes: Map<String, Long>,
+        val categoryCleanable: Map<String, Boolean>,
+    )
+
+    private data class StoragePaths(
+        val dataDir: File,
+        val workspaceRoot: File,
+        val workspaceInternalRoot: File,
+        val workspaceLegacyInternalRoot: File,
+        val workspaceLegacyExternalRoot: File,
+        val cacheInternalDir: File,
+        val cacheExternalDir: File?,
+        val sharedDraftsDir: File,
+        val mcpInboxDir: File,
+        val localModelsRoot: File,
+        val localModelsMmapDir: File,
+        val localModelsTempsDir: File,
+        val localModelsBuiltinTempsDir: File,
+        val terminalLocalRoot: File,
+        val terminalProotFile: File,
+        val terminalLibFile: File,
+        val terminalAlpineArchive: File,
+        val appBinaryFiles: List<File>,
+        val databaseFiles: List<File>,
+    )
+
+    private data class CategoryEntry(
+        val id: String,
+        val name: String,
+        val description: String,
+        val bytes: Long,
+        val cleanable: Boolean,
+        val riskLevel: String,
+        val cleanupHint: String? = null,
+        val order: Int,
+    )
+
+    private data class SnapshotPoint(
+        val generatedAt: Long,
+        val totalBytes: Long,
+        val cleanableBytes: Long,
+    )
+
+    private data class SnapshotBundle(
+        val history: List<SnapshotPoint>,
+        val trend: Map<String, Any?>,
+    )
+
+    private data class CleanupOutcome(
+        val success: Boolean,
+        val failedPaths: List<String> = emptyList(),
+        val deletedItems: Int = 0,
+    ) {
+        fun merge(next: CleanupOutcome): CleanupOutcome {
+            return CleanupOutcome(
+                success = this.success && next.success,
+                failedPaths = this.failedPaths + next.failedPaths,
+                deletedItems = this.deletedItems + next.deletedItems,
+            )
+        }
+    }
+
+    private data class StrategyAction(
+        val categoryId: String,
+        val olderThanDays: Int? = null,
+        val required: Boolean = true,
+    )
+
+    private data class SystemStorageStats(
+        val codeBytes: Long,
+        val dataBytes: Long,
+        val cacheBytes: Long,
+        val totalBytes: Long,
+    )
+
+    private data class CleanupStrategyPreset(
+        val id: String,
+        val name: String,
+        val description: String,
+        val riskLevel: String,
+        val olderThanDays: Int? = null,
+        val targetReleaseBytes: Long? = null,
+        val actions: List<StrategyAction>,
+    )
+
+    private fun analyzeStorageUsage(
+        context: Context,
+        persistSnapshot: Boolean,
+    ): AnalysisPayload {
+        val paths = resolveStoragePaths(context)
+        val appBinaryScanBytes = sumUniquePaths(paths.appBinaryFiles)
+        val dataDirScanBytes = sumUniquePaths(listOf(paths.dataDir))
+
+        val cacheInternalBytes = sumUniquePaths(listOf(paths.cacheInternalDir))
+        val cacheExternalBytes = sumUniquePaths(listOfNotNull(paths.cacheExternalDir))
+        val cacheScanBytes = cacheInternalBytes + cacheExternalBytes
+
+        val systemStats = querySystemStorageStats(context)
+        val appBinaryBytes = systemStats?.codeBytes ?: appBinaryScanBytes
+        val userDataBytes = systemStats?.dataBytes ?: dataDirScanBytes
+        val summaryCacheBytes = systemStats?.cacheBytes ?: cacheScanBytes
+        val cacheCategoryBytes = maxOf(cacheScanBytes, summaryCacheBytes)
+
+        val databaseBytes = sumUniquePaths(paths.databaseFiles)
+        val conversationEstimateBytes = estimateConversationHistoryBytes().coerceAtMost(databaseBytes)
+        val databaseOtherBytes = (databaseBytes - conversationEstimateBytes).coerceAtLeast(0L)
+
+        val workspaceBrowserBytes = sumUniquePaths(listOf(File(paths.workspaceInternalRoot, "browser")))
+        val workspaceOffloadsBytes = sumUniquePaths(listOf(File(paths.workspaceInternalRoot, "offloads")))
+        val workspaceAttachmentsBytes = sumUniquePaths(listOf(File(paths.workspaceInternalRoot, "attachments")))
+        val workspaceSharedBytes = sumUniquePaths(listOf(File(paths.workspaceInternalRoot, "shared")))
+        val workspaceMemoryBytes = sumUniquePaths(listOf(File(paths.workspaceInternalRoot, "memory")))
+        val workspaceUserFilesBytes = sumWorkspaceUserFiles(paths.workspaceRoot)
+
+        val localModelsFilesBytes = sumUniquePaths(listOf(paths.localModelsRoot))
+        val localModelsCacheBytes = sumUniquePaths(
+            listOf(paths.localModelsMmapDir, paths.localModelsTempsDir, paths.localModelsBuiltinTempsDir)
+        )
+
+        val terminalLocalBytes = sumUniquePaths(listOf(paths.terminalLocalRoot))
+        val terminalBootstrapBytes = sumUniquePaths(
+            listOf(paths.terminalProotFile, paths.terminalLibFile, paths.terminalAlpineArchive)
+        )
+
+        val sharedDraftsBytes = sumUniquePaths(listOf(paths.sharedDraftsDir))
+        val mcpInboxBytes = sumUniquePaths(listOf(paths.mcpInboxDir))
+        val legacyWorkspaceBytes = sumUniquePaths(
+            listOf(paths.workspaceLegacyInternalRoot, paths.workspaceLegacyExternalRoot)
+        )
+
+        val externalKnownBytes = listOf(
+            if (isUnderRoot(paths.cacheExternalDir, paths.dataDir)) 0L else cacheExternalBytes,
+            if (isUnderRoot(paths.workspaceLegacyExternalRoot, paths.dataDir)) 0L else measurePathSize(paths.workspaceLegacyExternalRoot),
+        ).sum()
+
+        val baseCategories = listOf(
+            CategoryEntry(
+                id = "app_binary",
+                name = "应用安装包",
+                description = "应用安装文件占用（APK/AAB split）",
+                bytes = appBinaryBytes,
+                cleanable = false,
+                riskLevel = "info",
+                order = 1,
+            ),
+            CategoryEntry(
+                id = "cache",
+                name = "缓存",
+                description = "临时文件与图片缓存，可安全清理",
+                bytes = cacheCategoryBytes,
+                cleanable = true,
+                riskLevel = "safe",
+                cleanupHint = "清理后会在使用中自动重新生成",
+                order = 2,
+            ),
+            CategoryEntry(
+                id = "conversation_history",
+                name = "会话历史",
+                description = "对话与工具执行历史（估算）",
+                bytes = conversationEstimateBytes,
+                cleanable = true,
+                riskLevel = "dangerous",
+                cleanupHint = "会删除历史消息记录，且不可恢复",
+                order = 3,
+            ),
+            CategoryEntry(
+                id = "database_other",
+                name = "数据库其他占用",
+                description = "索引与系统表等数据库占用",
+                bytes = databaseOtherBytes,
+                cleanable = false,
+                riskLevel = "info",
+                order = 4,
+            ),
+            CategoryEntry(
+                id = "workspace_browser",
+                name = "Workspace 浏览器产物",
+                description = "浏览器截图、下载文件和中间产物",
+                bytes = workspaceBrowserBytes,
+                cleanable = true,
+                riskLevel = "safe",
+                cleanupHint = "会删除浏览器工具相关的中间文件",
+                order = 5,
+            ),
+            CategoryEntry(
+                id = "workspace_offloads",
+                name = "Workspace Offloads",
+                description = "工具离线输出与临时文件",
+                bytes = workspaceOffloadsBytes,
+                cleanable = true,
+                riskLevel = "safe",
+                cleanupHint = "仅删除离线产物，不影响核心功能",
+                order = 6,
+            ),
+            CategoryEntry(
+                id = "workspace_attachments",
+                name = "Workspace 附件",
+                description = "历史任务使用的附件文件",
+                bytes = workspaceAttachmentsBytes,
+                cleanable = true,
+                riskLevel = "caution",
+                cleanupHint = "可能影响历史任务对附件的回看",
+                order = 7,
+            ),
+            CategoryEntry(
+                id = "workspace_shared",
+                name = "Workspace 共享区",
+                description = "跨任务共享的工作区文件",
+                bytes = workspaceSharedBytes,
+                cleanable = true,
+                riskLevel = "caution",
+                cleanupHint = "可能影响后续任务复用共享文件",
+                order = 8,
+            ),
+            CategoryEntry(
+                id = "workspace_memory",
+                name = "Workspace 记忆数据",
+                description = "长期/短期记忆与索引数据",
+                bytes = workspaceMemoryBytes,
+                cleanable = false,
+                riskLevel = "info",
+                order = 9,
+            ),
+            CategoryEntry(
+                id = "workspace_user_files",
+                name = "Workspace 用户文件",
+                description = "用户主动保存到 workspace 的文件",
+                bytes = workspaceUserFilesBytes,
+                cleanable = false,
+                riskLevel = "info",
+                order = 10,
+            ),
+            CategoryEntry(
+                id = "local_models_files",
+                name = "本地模型文件",
+                description = ".mnnmodels 下的模型文件",
+                bytes = localModelsFilesBytes,
+                cleanable = true,
+                riskLevel = "dangerous",
+                cleanupHint = "会删除模型文件，后续需重新下载",
+                order = 11,
+            ),
+            CategoryEntry(
+                id = "local_models_cache",
+                name = "模型推理缓存",
+                description = "mmap 与本地推理临时目录",
+                bytes = localModelsCacheBytes,
+                cleanable = true,
+                riskLevel = "caution",
+                cleanupHint = "清理后会在推理时重新生成",
+                order = 12,
+            ),
+            CategoryEntry(
+                id = "terminal_runtime_local",
+                name = "终端运行时（local）",
+                description = "Alpine 终端 local 运行目录",
+                bytes = terminalLocalBytes,
+                cleanable = true,
+                riskLevel = "dangerous",
+                cleanupHint = "会删除终端 local 目录，需重新初始化",
+                order = 13,
+            ),
+            CategoryEntry(
+                id = "terminal_runtime_bootstrap",
+                name = "终端运行时（引导文件）",
+                description = "proot/lib/alpine 引导文件",
+                bytes = terminalBootstrapBytes,
+                cleanable = true,
+                riskLevel = "dangerous",
+                cleanupHint = "会删除终端引导文件，需重新初始化",
+                order = 14,
+            ),
+            CategoryEntry(
+                id = "shared_drafts",
+                name = "共享草稿",
+                description = "外部分享导入的草稿缓存",
+                bytes = sharedDraftsBytes,
+                cleanable = true,
+                riskLevel = "safe",
+                cleanupHint = "会删除未发送的草稿附件",
+                order = 15,
+            ),
+            CategoryEntry(
+                id = "mcp_inbox",
+                name = "MCP 收件箱",
+                description = "MCP 文件传输接收目录",
+                bytes = mcpInboxBytes,
+                cleanable = true,
+                riskLevel = "safe",
+                cleanupHint = "会删除 MCP 收件箱中的文件",
+                order = 16,
+            ),
+            CategoryEntry(
+                id = "legacy_workspace",
+                name = "旧版遗留数据",
+                description = "升级后可能残留的旧 workspace 目录",
+                bytes = legacyWorkspaceBytes,
+                cleanable = true,
+                riskLevel = "caution",
+                cleanupHint = "建议确认无用后再清理",
+                order = 17,
+            ),
+        )
+
+        val knownBytes = baseCategories.sumOf { it.bytes }
+        val scanTotalBytes = appBinaryScanBytes + dataDirScanBytes + externalKnownBytes
+        val baselineTotalBytes = systemStats?.totalBytes ?: scanTotalBytes
+        val totalBytes = maxOf(baselineTotalBytes, knownBytes)
+        val otherUserDataBytes = (totalBytes - knownBytes).coerceAtLeast(0L)
+
+        val categories = (baseCategories + CategoryEntry(
+            id = "other_user_data",
+            name = "其他数据",
+            description = "未命中分类规则的数据",
+            bytes = otherUserDataBytes,
+            cleanable = false,
+            riskLevel = "info",
+            order = 99,
+        )).sortedByDescending { it.bytes }
+
+        val cleanableBytes = categories.filter { it.cleanable }.sumOf { it.bytes }
+        val generatedAt = System.currentTimeMillis()
+        val snapshots = buildSnapshotBundle(
+            context = context,
+            generatedAt = generatedAt,
+            totalBytes = totalBytes,
+            cleanableBytes = cleanableBytes,
+            persist = persistSnapshot,
+        )
+
+        val summary = mapOf(
+            "generatedAt" to generatedAt,
+            "totalBytes" to totalBytes,
+            "appBinaryBytes" to appBinaryBytes,
+            "userDataBytes" to userDataBytes,
+            "cacheBytes" to summaryCacheBytes,
+            "cleanableBytes" to cleanableBytes,
+            "packageName" to context.packageName,
+            "metricsSource" to if (systemStats != null) "system_storage_stats" else "filesystem_estimate",
+            "scanTotalBytes" to scanTotalBytes,
+            "systemTotalBytes" to (systemStats?.totalBytes ?: 0L),
+            "trend" to snapshots.trend,
+            "history" to snapshots.history.map { point ->
+                mapOf(
+                    "generatedAt" to point.generatedAt,
+                    "totalBytes" to point.totalBytes,
+                    "cleanableBytes" to point.cleanableBytes,
+                )
+            },
+            "strategyPresets" to cleanupStrategyPresets().map { preset ->
+                mapOf(
+                    "id" to preset.id,
+                    "name" to preset.name,
+                    "description" to preset.description,
+                    "riskLevel" to preset.riskLevel,
+                    "olderThanDays" to preset.olderThanDays,
+                    "targetReleaseBytes" to (preset.targetReleaseBytes ?: 0L),
+                )
+            },
+            "categories" to categories.map { category ->
+                mapOf(
+                    "id" to category.id,
+                    "name" to category.name,
+                    "description" to category.description,
+                    "bytes" to category.bytes,
+                    "cleanable" to category.cleanable,
+                    "riskLevel" to category.riskLevel,
+                    "cleanupHint" to category.cleanupHint,
+                    "order" to category.order,
+                )
+            },
+        )
+
+        return AnalysisPayload(
+            summary = summary,
+            categoryBytes = categories.associate { it.id to it.bytes },
+            categoryCleanable = categories.associate { it.id to it.cleanable },
+        )
+    }
+
+    private fun querySystemStorageStats(context: Context): SystemStorageStats? {
+        val manager = context.getSystemService(StorageStatsManager::class.java) ?: return null
+        return runCatching {
+            val stats = manager.queryStatsForPackage(
+                StorageManager.UUID_DEFAULT,
+                context.packageName,
+                Process.myUserHandle(),
+            )
+            val codeBytes = stats.appBytes.coerceAtLeast(0L)
+            val dataBytes = stats.dataBytes.coerceAtLeast(0L)
+            val cacheBytes = stats.cacheBytes.coerceAtLeast(0L)
+            SystemStorageStats(
+                codeBytes = codeBytes,
+                dataBytes = dataBytes,
+                cacheBytes = cacheBytes,
+                totalBytes = (codeBytes + dataBytes + cacheBytes).coerceAtLeast(0L),
+            )
+        }.onFailure {
+            OmniLog.e(TAG, "Query system storage stats failed", it)
+        }.getOrNull()
+    }
+
+    private fun clearCategory(
+        context: Context,
+        categoryId: String,
+        olderThanDays: Int?,
+    ): Map<String, Any?> {
+        val before = analyzeStorageUsage(context, persistSnapshot = false)
+        val beforeBytes = before.categoryBytes[categoryId] ?: error("Unknown category: $categoryId")
+        if (before.categoryCleanable[categoryId] != true) {
+            error("Category is not cleanable: $categoryId")
+        }
+
+        val outcome = clearCategoryInternal(
+            context = context,
+            categoryId = categoryId,
+            olderThanDays = olderThanDays,
+        )
+        val after = analyzeStorageUsage(context, persistSnapshot = true)
+        val afterBytes = after.categoryBytes[categoryId] ?: 0L
+        val releasedBytes = (beforeBytes - afterBytes).coerceAtLeast(0L)
+        val manualActionHint = manualActionHintForCategory(categoryId)
+
+        return mapOf(
+            "categoryId" to categoryId,
+            "success" to outcome.success,
+            "beforeBytes" to beforeBytes,
+            "afterBytes" to afterBytes,
+            "releasedBytes" to releasedBytes,
+            "failedPaths" to outcome.failedPaths,
+            "retryable" to outcome.failedPaths.isNotEmpty(),
+            "manualActionHint" to manualActionHint,
+            "summary" to after.summary,
+        )
+    }
+
+    private fun applyCleanupStrategy(
+        context: Context,
+        strategyId: String,
+        overrideOlderThanDays: Int?,
+        targetReleaseBytes: Long,
+    ): Map<String, Any?> {
+        val strategy = cleanupStrategyPresets().firstOrNull { it.id == strategyId }
+            ?: error("Unknown strategy: $strategyId")
+        val before = analyzeStorageUsage(context, persistSnapshot = false)
+        var current = before
+        val actionResults = mutableListOf<Map<String, Any?>>()
+        var totalReleased = 0L
+        var allSuccess = true
+
+        for (action in strategy.actions) {
+            val categoryId = action.categoryId
+            val beforeBytes = current.categoryBytes[categoryId] ?: 0L
+            val canClean = current.categoryCleanable[categoryId] == true
+            if (!canClean) {
+                if (action.required) {
+                    allSuccess = false
+                }
+                actionResults.add(
+                    mapOf(
+                        "categoryId" to categoryId,
+                        "success" to !action.required,
+                        "releasedBytes" to 0L,
+                        "failedPaths" to emptyList<String>(),
+                        "manualActionHint" to if (action.required) {
+                            "该分类当前不可清理"
+                        } else {
+                            "该分类已跳过（可选项）"
+                        },
+                    )
+                )
+                continue
+            }
+
+            val olderThanDays = overrideOlderThanDays ?: action.olderThanDays ?: strategy.olderThanDays
+            val outcome = clearCategoryInternal(
+                context = context,
+                categoryId = categoryId,
+                olderThanDays = olderThanDays,
+            )
+            val next = analyzeStorageUsage(context, persistSnapshot = false)
+            val afterBytes = next.categoryBytes[categoryId] ?: 0L
+            val released = (beforeBytes - afterBytes).coerceAtLeast(0L)
+            totalReleased += released
+            current = next
+
+            if (!outcome.success && action.required) {
+                allSuccess = false
+            }
+
+            actionResults.add(
+                mapOf(
+                    "categoryId" to categoryId,
+                    "success" to outcome.success,
+                    "releasedBytes" to released,
+                    "failedPaths" to outcome.failedPaths,
+                    "manualActionHint" to manualActionHintForCategory(categoryId),
+                )
+            )
+
+            val target = if (targetReleaseBytes > 0) targetReleaseBytes else (strategy.targetReleaseBytes ?: 0L)
+            if (target > 0L && totalReleased >= target) {
+                break
+            }
+        }
+
+        val finalSummary = analyzeStorageUsage(context, persistSnapshot = true)
+
+        return mapOf(
+            "strategyId" to strategy.id,
+            "strategyName" to strategy.name,
+            "success" to allSuccess,
+            "releasedBytes" to totalReleased,
+            "actionResults" to actionResults,
+            "summary" to finalSummary.summary,
+        )
+    }
+
+    private fun cleanupStrategyPresets(): List<CleanupStrategyPreset> {
+        return listOf(
+            CleanupStrategyPreset(
+                id = "safe_quick",
+                name = "安全快速清理",
+                description = "优先清理低风险缓存与临时产物",
+                riskLevel = "safe",
+                olderThanDays = 3,
+                actions = listOf(
+                    StrategyAction("cache"),
+                    StrategyAction("workspace_browser"),
+                    StrategyAction("workspace_offloads"),
+                    StrategyAction("shared_drafts"),
+                    StrategyAction("mcp_inbox"),
+                    StrategyAction("local_models_cache", required = false),
+                ),
+            ),
+            CleanupStrategyPreset(
+                id = "balance_deep",
+                name = "平衡深度清理",
+                description = "释放更多空间，保留核心模型与用户文件",
+                riskLevel = "caution",
+                olderThanDays = 7,
+                actions = listOf(
+                    StrategyAction("cache"),
+                    StrategyAction("workspace_browser"),
+                    StrategyAction("workspace_offloads"),
+                    StrategyAction("workspace_attachments"),
+                    StrategyAction("workspace_shared"),
+                    StrategyAction("shared_drafts"),
+                    StrategyAction("mcp_inbox"),
+                    StrategyAction("legacy_workspace", required = false),
+                    StrategyAction("local_models_cache", required = false),
+                ),
+            ),
+            CleanupStrategyPreset(
+                id = "free_1gb_priority",
+                name = "目标释放 1GB",
+                description = "按高收益顺序清理，尽量达到 1GB 释放目标",
+                riskLevel = "dangerous",
+                targetReleaseBytes = 1024L * 1024L * 1024L,
+                actions = listOf(
+                    StrategyAction("cache"),
+                    StrategyAction("workspace_browser"),
+                    StrategyAction("workspace_offloads"),
+                    StrategyAction("local_models_cache"),
+                    StrategyAction("terminal_runtime_local", required = false),
+                    StrategyAction("terminal_runtime_bootstrap", required = false),
+                    StrategyAction("local_models_files", required = false),
+                ),
+            ),
+        )
+    }
+
+    private fun clearCategoryInternal(
+        context: Context,
+        categoryId: String,
+        olderThanDays: Int?,
+    ): CleanupOutcome {
+        val cutoffMillis = olderThanDays?.let { System.currentTimeMillis() - it * 24L * 60L * 60L * 1000L }
+        return when (categoryId) {
+            "cache" -> mergeOutcomes(
+                if (cutoffMillis != null) clearDirectoryContentsByAge(context.cacheDir, cutoffMillis) else clearDirectoryContents(context.cacheDir),
+                if (cutoffMillis != null) clearDirectoryContentsByAge(context.externalCacheDir, cutoffMillis) else clearDirectoryContents(context.externalCacheDir),
+            )
+
+            "workspace_browser" -> clearWorkspaceInternalSubDir(context, "browser", cutoffMillis)
+            "workspace_offloads" -> clearWorkspaceInternalSubDir(context, "offloads", cutoffMillis)
+            "workspace_attachments" -> clearWorkspaceInternalSubDir(context, "attachments", cutoffMillis)
+            "workspace_shared" -> clearWorkspaceInternalSubDir(context, "shared", cutoffMillis)
+
+            "shared_drafts" -> {
+                val directory = File(context.filesDir, "shared_open_drafts")
+                if (cutoffMillis != null) clearDirectoryContentsByAge(directory, cutoffMillis) else clearDirectoryContents(directory)
+            }
+
+            "mcp_inbox" -> {
+                val directory = File(context.filesDir, "mcp_inbox")
+                if (cutoffMillis != null) clearDirectoryContentsByAge(directory, cutoffMillis) else clearDirectoryContents(directory)
+            }
+
+            "legacy_workspace" -> mergeOutcomes(
+                clearDirectoryContents(File(context.filesDir, "workspace")),
+                clearDirectoryContents(File(AgentWorkspaceManager.LEGACY_EXTERNAL_ROOT_PATH)),
+            )
+
+            "terminal_runtime_local" -> clearDirectoryContents(File(context.applicationInfo.dataDir, "local"))
+            "terminal_runtime_bootstrap" -> mergeOutcomes(
+                clearDirectoryContents(File(context.filesDir, "proot")),
+                clearDirectoryContents(File(context.filesDir, "libtalloc.so.2")),
+                clearDirectoryContents(File(context.filesDir, "alpine.tar.gz")),
+            )
+            "terminal_runtime" -> mergeOutcomes(
+                clearCategoryInternal(context, "terminal_runtime_local", olderThanDays),
+                clearCategoryInternal(context, "terminal_runtime_bootstrap", olderThanDays),
+            )
+
+            "local_models_files" -> clearDirectoryContents(File(context.filesDir, ".mnnmodels"))
+            "local_models_cache" -> mergeOutcomes(
+                clearDirectoryContents(File(context.filesDir, "tmps")),
+                clearDirectoryContents(File(context.filesDir, "local_temps")),
+                clearDirectoryContents(File(context.filesDir, "builtin_temps")),
+            )
+            "local_models" -> mergeOutcomes(
+                clearCategoryInternal(context, "local_models_files", olderThanDays),
+                clearCategoryInternal(context, "local_models_cache", olderThanDays),
+            )
+
+            "conversation_history" -> clearConversationHistory()
+            else -> CleanupOutcome(success = false, failedPaths = listOf("unknown:$categoryId"))
+        }
+    }
+
+    private fun clearWorkspaceInternalSubDir(
+        context: Context,
+        subDirName: String,
+        cutoffMillis: Long?,
+    ): CleanupOutcome {
+        val root = AgentWorkspaceManager.internalRootDirectory(context)
+        val dir = File(root, subDirName)
+        return if (cutoffMillis != null) {
+            clearDirectoryContentsByAge(dir, cutoffMillis)
+        } else {
+            clearDirectoryContents(dir)
+        }
+    }
+
+    private fun clearConversationHistory(): CleanupOutcome {
+        val context = appContext ?: return CleanupOutcome(success = false, failedPaths = listOf("context_unavailable"))
+        val dbFile = resolvePrimaryDatabaseFile(context)
+        if (!dbFile.exists()) {
+            return CleanupOutcome(success = true)
+        }
+
+        return runCatching {
+            SQLiteDatabase.openDatabase(
+                dbFile.absolutePath,
+                null,
+                SQLiteDatabase.OPEN_READWRITE,
+            ).use { sqliteDb ->
+                sqliteDb.beginTransaction()
+                try {
+                    safeExecSql(sqliteDb, "DELETE FROM agent_conversation_entries")
+                    safeExecSql(sqliteDb, "DELETE FROM conversations")
+                    safeExecSql(sqliteDb, "DELETE FROM messages")
+                    sqliteDb.setTransactionSuccessful()
+                } finally {
+                    sqliteDb.endTransaction()
+                }
+                safeExecSql(sqliteDb, "PRAGMA wal_checkpoint(TRUNCATE)")
+                safeExecSql(sqliteDb, "VACUUM")
+            }
+            CleanupOutcome(success = true)
+        }.onFailure {
+            OmniLog.e(TAG, "Clear conversation history failed", it)
+        }.getOrElse {
+            CleanupOutcome(success = false, failedPaths = listOf(dbFile.absolutePath))
+        }
+    }
+
+    private fun manualActionHintForCategory(categoryId: String): String {
+        return when (categoryId) {
+            "conversation_history" -> "如历史未释放，请重新进入页面执行“重新分析”"
+            "local_models_files", "local_models" -> "模型被清理后，可在“本地模型服务”页面重新下载"
+            "terminal_runtime_local", "terminal_runtime_bootstrap", "terminal_runtime" ->
+                "终端运行时被清理后，可在 Alpine 环境页重新初始化"
+            else -> "若清理失败，可稍后重试或重启应用后再次清理"
+        }
+    }
+
+    private fun buildSnapshotBundle(
+        context: Context,
+        generatedAt: Long,
+        totalBytes: Long,
+        cleanableBytes: Long,
+        persist: Boolean,
+    ): SnapshotBundle {
+        val history = loadSnapshotHistory(context).toMutableList()
+        val previous = history.lastOrNull()
+        val nextPoint = SnapshotPoint(
+            generatedAt = generatedAt,
+            totalBytes = totalBytes,
+            cleanableBytes = cleanableBytes,
+        )
+        val finalHistory = if (persist) {
+            history.add(nextPoint)
+            val trimmed = history.takeLast(MAX_HISTORY_SIZE)
+            saveSnapshotHistory(context, trimmed)
+            trimmed
+        } else {
+            history.toList()
+        }
+        val outputHistory = finalHistory.takeLast(DEFAULT_HISTORY_OUTPUT_SIZE)
+        val trend = mapOf(
+            "hasPrevious" to (previous != null),
+            "deltaTotalBytes" to if (previous == null) 0L else (totalBytes - previous.totalBytes),
+            "deltaCleanableBytes" to if (previous == null) 0L else (cleanableBytes - previous.cleanableBytes),
+            "previousGeneratedAt" to (previous?.generatedAt ?: 0L),
+            "previousTotalBytes" to (previous?.totalBytes ?: 0L),
+            "previousCleanableBytes" to (previous?.cleanableBytes ?: 0L),
+        )
+        return SnapshotBundle(
+            history = outputHistory,
+            trend = trend,
+        )
+    }
+
+    private fun loadSnapshotHistory(context: Context): List<SnapshotPoint> {
+        val prefs = context.getSharedPreferences(STORAGE_METRICS_PREFS, Context.MODE_PRIVATE)
+        val raw = prefs.getString(STORAGE_METRICS_HISTORY_KEY, null) ?: return emptyList()
+        return runCatching {
+            val array = JSONArray(raw)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val item = array.optJSONObject(index) ?: continue
+                    add(
+                        SnapshotPoint(
+                            generatedAt = item.optLong("generatedAt", 0L),
+                            totalBytes = item.optLong("totalBytes", 0L),
+                            cleanableBytes = item.optLong("cleanableBytes", 0L),
+                        )
+                    )
+                }
+            }.filter { it.generatedAt > 0L }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun saveSnapshotHistory(context: Context, history: List<SnapshotPoint>) {
+        runCatching {
+            val array = JSONArray()
+            history.forEach { point ->
+                array.put(
+                    JSONObject().apply {
+                        put("generatedAt", point.generatedAt)
+                        put("totalBytes", point.totalBytes)
+                        put("cleanableBytes", point.cleanableBytes)
+                    }
+                )
+            }
+            context.getSharedPreferences(STORAGE_METRICS_PREFS, Context.MODE_PRIVATE)
+                .edit()
+                .putString(STORAGE_METRICS_HISTORY_KEY, array.toString())
+                .apply()
+        }.onFailure {
+            OmniLog.e(TAG, "Save snapshot history failed", it)
+        }
+    }
+
+    private fun estimateConversationHistoryBytes(): Long {
+        val context = appContext ?: return 0L
+        val dbFile = resolvePrimaryDatabaseFile(context)
+        if (!dbFile.exists()) {
+            return 0L
+        }
+
+        return runCatching {
+            SQLiteDatabase.openDatabase(
+                dbFile.absolutePath,
+                null,
+                SQLiteDatabase.OPEN_READONLY,
+            ).use { sqliteDb ->
+                val entries = querySingleLong(
+                    sqliteDb,
+                    """
+                        SELECT IFNULL(SUM(
+                            LENGTH(payloadJson) +
+                            LENGTH(summary) +
+                            LENGTH(entryId) +
+                            LENGTH(entryType) +
+                            LENGTH(status)
+                        ), 0)
+                        FROM agent_conversation_entries
+                    """.trimIndent()
+                )
+                val conversations = querySingleLong(
+                    sqliteDb,
+                    """
+                        SELECT IFNULL(SUM(
+                            LENGTH(title) +
+                            LENGTH(summary) +
+                            LENGTH(lastMessage) +
+                            LENGTH(mode) +
+                            LENGTH(contextSummary)
+                        ), 0)
+                        FROM conversations
+                    """.trimIndent()
+                )
+                val messages = querySingleLong(
+                    sqliteDb,
+                    """
+                        SELECT IFNULL(SUM(
+                            LENGTH(messageId) +
+                            LENGTH(content)
+                        ), 0)
+                        FROM messages
+                    """.trimIndent()
+                )
+                (entries + conversations + messages).coerceAtLeast(0L)
+            }
+        }.onFailure {
+            OmniLog.e(TAG, "Estimate conversation history bytes failed", it)
+        }.getOrDefault(0L)
+    }
+
+    private fun resolveStoragePaths(context: Context): StoragePaths {
+        val dataDir = File(context.applicationInfo.dataDir)
+        val workspaceRoot = AgentWorkspaceManager.rootDirectory(context)
+        val workspaceInternalRoot = AgentWorkspaceManager.internalRootDirectory(context)
+        val appBinaryFiles = buildList {
+            add(File(context.applicationInfo.sourceDir))
+            context.applicationInfo.splitSourceDirs?.forEach { add(File(it)) }
+        }
+
+        val databaseNameCandidates = context.databaseList()
+            .filter { it.startsWith(DATABASE_NAME_PREFIX) }
+            .ifEmpty { listOf(DATABASE_PRIMARY_NAME) }
+
+        val databaseFiles = buildList {
+            databaseNameCandidates.forEach { name ->
+                val base = context.getDatabasePath(name)
+                add(base)
+                add(File("${base.absolutePath}-wal"))
+                add(File("${base.absolutePath}-shm"))
+            }
+        }
+
+        return StoragePaths(
+            dataDir = dataDir,
+            workspaceRoot = workspaceRoot,
+            workspaceInternalRoot = workspaceInternalRoot,
+            workspaceLegacyInternalRoot = File(context.filesDir, "workspace"),
+            workspaceLegacyExternalRoot = File(AgentWorkspaceManager.LEGACY_EXTERNAL_ROOT_PATH),
+            cacheInternalDir = context.cacheDir,
+            cacheExternalDir = context.externalCacheDir,
+            sharedDraftsDir = File(context.filesDir, "shared_open_drafts"),
+            mcpInboxDir = File(context.filesDir, "mcp_inbox"),
+            localModelsRoot = File(context.filesDir, ".mnnmodels"),
+            localModelsMmapDir = File(context.filesDir, "tmps"),
+            localModelsTempsDir = File(context.filesDir, "local_temps"),
+            localModelsBuiltinTempsDir = File(context.filesDir, "builtin_temps"),
+            terminalLocalRoot = File(dataDir, "local"),
+            terminalProotFile = File(context.filesDir, "proot"),
+            terminalLibFile = File(context.filesDir, "libtalloc.so.2"),
+            terminalAlpineArchive = File(context.filesDir, "alpine.tar.gz"),
+            appBinaryFiles = appBinaryFiles,
+            databaseFiles = databaseFiles,
+        )
+    }
+
+    private fun resolvePrimaryDatabaseFile(context: Context): File {
+        return context.getDatabasePath(DATABASE_PRIMARY_NAME)
+    }
+
+    private fun safeExecSql(database: SQLiteDatabase, sql: String) {
+        runCatching { database.execSQL(sql) }
+            .onFailure { OmniLog.e(TAG, "Execute SQL failed: $sql", it) }
+    }
+
+    private fun querySingleLong(database: SQLiteDatabase, sql: String): Long {
+        return runCatching {
+            database.rawQuery(sql, null).use { cursor ->
+                if (cursor.moveToFirst() && !cursor.isNull(0)) {
+                    cursor.getLong(0)
+                } else {
+                    0L
+                }
+            }
+        }.getOrDefault(0L)
+    }
+
+    private fun sumWorkspaceUserFiles(workspaceRoot: File): Long {
+        if (!workspaceRoot.exists() || !workspaceRoot.isDirectory) {
+            return 0L
+        }
+        return workspaceRoot
+            .listFiles()
+            .orEmpty()
+            .filterNot { it.name == ".omnibot" }
+            .sumOf { measurePathSize(it) }
+    }
+
+    private fun sumUniquePaths(paths: List<File>): Long {
+        if (paths.isEmpty()) {
+            return 0L
+        }
+        val visited = hashSetOf<String>()
+        var total = 0L
+        paths.forEach { path ->
+            val key = canonicalPath(path)
+            if (visited.add(key)) {
+                total += measurePathSize(path)
+            }
+        }
+        return total
+    }
+
+    private fun measurePathSize(path: File?): Long {
+        if (path == null || !path.exists()) {
+            return 0L
+        }
+        return runCatching {
+            if (path.isFile) {
+                path.length().coerceAtLeast(0L)
+            } else {
+                measureDirectorySize(path)
+            }
+        }.getOrDefault(0L)
+    }
+
+    private fun measureDirectorySize(root: File): Long {
+        if (!root.exists()) {
+            return 0L
+        }
+        if (root.isFile) {
+            return root.length().coerceAtLeast(0L)
+        }
+
+        val stack = ArrayDeque<File>()
+        val visited = hashSetOf<String>()
+        var total = 0L
+        stack.add(root)
+        while (stack.isNotEmpty()) {
+            val current = stack.removeLast()
+            val canonical = canonicalPath(current)
+            if (!visited.add(canonical)) {
+                continue
+            }
+            if (current.isFile) {
+                total += current.length().coerceAtLeast(0L)
+                continue
+            }
+            if (!current.isDirectory) {
+                continue
+            }
+            current.listFiles()?.forEach { child ->
+                if (child.isFile) {
+                    total += child.length().coerceAtLeast(0L)
+                } else {
+                    stack.add(child)
+                }
+            }
+        }
+        return total
+    }
+
+    private fun clearDirectoryContents(directory: File?): CleanupOutcome {
+        if (directory == null || !directory.exists()) {
+            return CleanupOutcome(success = true)
+        }
+        if (!directory.isDirectory) {
+            val deleted = deletePath(directory)
+            return CleanupOutcome(
+                success = deleted,
+                failedPaths = if (deleted) emptyList() else listOf(directory.absolutePath),
+                deletedItems = if (deleted) 1 else 0,
+            )
+        }
+
+        val failedPaths = mutableListOf<String>()
+        var deletedItems = 0
+        directory.listFiles().orEmpty().forEach { child ->
+            val deleted = deletePath(child)
+            if (deleted) {
+                deletedItems += 1
+            } else {
+                failedPaths.add(child.absolutePath)
+            }
+        }
+        return CleanupOutcome(
+            success = failedPaths.isEmpty(),
+            failedPaths = failedPaths,
+            deletedItems = deletedItems,
+        )
+    }
+
+    private fun clearDirectoryContentsByAge(
+        directory: File?,
+        cutoffMillis: Long,
+    ): CleanupOutcome {
+        if (directory == null || !directory.exists()) {
+            return CleanupOutcome(success = true)
+        }
+        if (directory.isFile) {
+            if (directory.lastModified() <= cutoffMillis) {
+                val deleted = deletePath(directory)
+                return CleanupOutcome(
+                    success = deleted,
+                    failedPaths = if (deleted) emptyList() else listOf(directory.absolutePath),
+                    deletedItems = if (deleted) 1 else 0,
+                )
+            }
+            return CleanupOutcome(success = true, deletedItems = 0)
+        }
+
+        val failedPaths = mutableListOf<String>()
+        var deletedItems = 0
+
+        directory.walkBottomUp().forEach { path ->
+            if (path == directory) return@forEach
+            if (path.lastModified() > cutoffMillis) return@forEach
+            if (path.isDirectory && path.listFiles()?.isNotEmpty() == true) return@forEach
+            val deleted = deletePath(path)
+            if (deleted) {
+                deletedItems += 1
+            } else {
+                failedPaths.add(path.absolutePath)
+            }
+        }
+        return CleanupOutcome(
+            success = failedPaths.isEmpty(),
+            failedPaths = failedPaths,
+            deletedItems = deletedItems,
+        )
+    }
+
+    private fun mergeOutcomes(vararg outcomes: CleanupOutcome): CleanupOutcome {
+        var merged = CleanupOutcome(success = true)
+        outcomes.forEach { outcome ->
+            merged = merged.merge(outcome)
+        }
+        return merged
+    }
+
+    private fun deletePath(path: File?): Boolean {
+        if (path == null || !path.exists()) {
+            return true
+        }
+        val maxAttempts = 2
+        var attempt = 0
+        while (attempt < maxAttempts) {
+            val deleted = runCatching {
+                if (path.isDirectory) path.deleteRecursively() else path.delete()
+            }.getOrDefault(false)
+            if (deleted || !path.exists()) {
+                return true
+            }
+            attempt += 1
+            runCatching { Thread.sleep(60L * attempt) }
+        }
+        return false
+    }
+
+    private fun isUnderRoot(path: File?, root: File): Boolean {
+        if (path == null) {
+            return false
+        }
+        val target = canonicalPath(path)
+        val rootPath = canonicalPath(root)
+        return target == rootPath || target.startsWith("$rootPath${File.separator}")
+    }
+
+    private fun canonicalPath(file: File): String {
+        return runCatching { file.canonicalPath }.getOrDefault(file.absolutePath)
+    }
+}

--- a/ui/lib/features/home/pages/settings/settings_page.dart
+++ b/ui/lib/features/home/pages/settings/settings_page.dart
@@ -481,6 +481,14 @@ class _SettingsPageState extends State<SettingsPage> {
             },
           ),
           _SettingItem(
+            icon: Icons.storage_outlined,
+            title: '存储占用',
+            subtitle: '查看空间占用明细，支持分项清理',
+            onTap: () {
+              GoRouterManager.push('/home/storage_usage');
+            },
+          ),
+          _SettingItem(
             icon: Icons.info_outline,
             iconSvg: 'assets/home/about_icon.svg',
             title: '关于小万',

--- a/ui/lib/features/home/pages/settings/storage_usage_page.dart
+++ b/ui/lib/features/home/pages/settings/storage_usage_page.dart
@@ -1,0 +1,688 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:ui/services/storage_usage_service.dart';
+import 'package:ui/theme/app_colors.dart';
+import 'package:ui/utils/ui.dart';
+import 'package:ui/widgets/common_app_bar.dart';
+
+class StorageUsagePage extends StatefulWidget {
+  const StorageUsagePage({super.key});
+
+  @override
+  State<StorageUsagePage> createState() => _StorageUsagePageState();
+}
+
+class _StorageUsagePageState extends State<StorageUsagePage> {
+  bool _loading = true;
+  String? _error;
+  String? _clearingCategoryId;
+  String? _applyingStrategyId;
+  StorageUsageSummary? _summary;
+
+  static const List<Color> _palette = [
+    Color(0xFF2C7FEB),
+    Color(0xFF00A870),
+    Color(0xFFF59E0B),
+    Color(0xFFEF4444),
+    Color(0xFF8B5CF6),
+    Color(0xFF14B8A6),
+    Color(0xFFEC4899),
+    Color(0xFF6366F1),
+    Color(0xFF84CC16),
+    Color(0xFF64748B),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSummary();
+  }
+
+  Future<void> _loadSummary({bool silent = false}) async {
+    if (!silent) {
+      setState(() {
+        _loading = true;
+        _error = null;
+      });
+    }
+    try {
+      final summary = await StorageUsageService.getStorageUsageSummary();
+      if (!mounted) return;
+      setState(() {
+        _summary = summary;
+        _loading = false;
+        _error = null;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = '存储分析失败，请重试';
+      });
+    }
+  }
+
+  Future<void> _onClearCategory(StorageUsageCategory category) async {
+    final olderThanDays = await _showClearOptionsDialog(category);
+    if (olderThanDays == null) return;
+
+    setState(() {
+      _clearingCategoryId = category.id;
+    });
+    try {
+      final result = await StorageUsageService.clearCategory(
+        category.id,
+        olderThanDays: olderThanDays > 0 ? olderThanDays : null,
+      );
+      if (!mounted) return;
+      if (result.summary != null) {
+        setState(() {
+          _summary = result.summary;
+        });
+      } else {
+        await _loadSummary(silent: true);
+      }
+
+      if (result.success) {
+        showToast(
+          '已清理${category.name}，释放 ${_formatBytes(result.releasedBytes)}',
+          type: ToastType.success,
+        );
+      } else {
+        final hint = (result.manualActionHint ?? '').trim();
+        showToast(
+          hint.isNotEmpty ? '部分清理失败：$hint' : '部分文件清理失败，请稍后重试',
+          type: ToastType.error,
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      showToast('清理失败，请稍后重试', type: ToastType.error);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _clearingCategoryId = null;
+        });
+      }
+    }
+  }
+
+  Future<int?> _showClearOptionsDialog(StorageUsageCategory category) async {
+    int selected = 0;
+    final canRetention = category.riskLevel != 'dangerous';
+    return showDialog<int>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: Text('清理${category.name}'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(category.cleanupHint ?? '确认清理该分类数据吗？'),
+                  if (canRetention) ...[
+                    const SizedBox(height: 12),
+                    const Text('清理范围'),
+                    const SizedBox(height: 6),
+                    Wrap(
+                      spacing: 8,
+                      children: [
+                        ChoiceChip(
+                          label: const Text('全部'),
+                          selected: selected == 0,
+                          onSelected: (_) => setDialogState(() => selected = 0),
+                        ),
+                        ChoiceChip(
+                          label: const Text('7天前'),
+                          selected: selected == 7,
+                          onSelected: (_) => setDialogState(() => selected = 7),
+                        ),
+                        ChoiceChip(
+                          label: const Text('30天前'),
+                          selected: selected == 30,
+                          onSelected: (_) => setDialogState(() => selected = 30),
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(null),
+                  child: const Text('取消'),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(selected),
+                  child: const Text('确认清理'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _applyStrategy(StorageCleanupStrategyPreset preset) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('执行策略：${preset.name}'),
+          content: Text(preset.description),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('开始执行'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      _applyingStrategyId = preset.id;
+    });
+    try {
+      final result = await StorageUsageService.applyCleanupStrategy(preset.id);
+      if (!mounted) return;
+      if (result.summary != null) {
+        setState(() {
+          _summary = result.summary;
+        });
+      } else {
+        await _loadSummary(silent: true);
+      }
+
+      final failedCount = result.actionResults.where((item) => !item.success).length;
+      if (failedCount == 0) {
+        showToast(
+          '策略执行完成，释放 ${_formatBytes(result.releasedBytes)}',
+          type: ToastType.success,
+        );
+      } else {
+        showToast(
+          '策略完成，释放 ${_formatBytes(result.releasedBytes)}，$failedCount 项未完全成功',
+          type: ToastType.error,
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      showToast('策略执行失败，请稍后重试', type: ToastType.error);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _applyingStrategyId = null;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = _summary;
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: const CommonAppBar(title: '存储占用', primary: true),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : summary == null
+          ? _buildErrorView()
+          : RefreshIndicator(
+              onRefresh: _loadSummary,
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                children: [
+                  _buildOverviewCard(summary),
+                  const SizedBox(height: 12),
+                  _buildTrendCard(summary),
+                  const SizedBox(height: 12),
+                  _buildStrategyCard(summary),
+                  const SizedBox(height: 12),
+                  _buildPieCard(summary),
+                  const SizedBox(height: 12),
+                  _buildCategoryListCard(summary),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Widget _buildErrorView() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(_error ?? '加载失败', style: const TextStyle(color: AppColors.text70)),
+          const SizedBox(height: 12),
+          ElevatedButton(onPressed: _loadSummary, child: const Text('重新分析')),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildOverviewCard(StorageUsageSummary summary) {
+    final sourceText = _metricsSourceText(summary.metricsSource);
+    final hasBothTotals =
+        summary.systemTotalBytes > 0 && summary.scanTotalBytes > 0;
+    final diffBytes = summary.systemTotalBytes - summary.scanTotalBytes;
+    return _buildCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('总占用', style: TextStyle(fontSize: 12, color: AppColors.text70)),
+          const SizedBox(height: 4),
+          Text(
+            _formatBytes(summary.totalBytes),
+            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(child: _buildMetricCell('应用大小', _formatBytes(summary.appBinaryBytes))),
+              Expanded(child: _buildMetricCell('用户数据', _formatBytes(summary.userDataBytes))),
+              Expanded(child: _buildMetricCell('可清理', _formatBytes(summary.cleanableBytes))),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            '统计口径：$sourceText',
+            style: const TextStyle(fontSize: 11, color: AppColors.text70),
+          ),
+          if (summary.packageName.isNotEmpty) ...[
+            const SizedBox(height: 2),
+            Text(
+              '当前包名：${summary.packageName}',
+              style: const TextStyle(fontSize: 11, color: AppColors.text70),
+            ),
+          ],
+          if (hasBothTotals && diffBytes != 0) ...[
+            const SizedBox(height: 2),
+            Text(
+              '系统口径与扫描口径差异：${_signedBytes(diffBytes)}',
+              style: const TextStyle(fontSize: 11, color: AppColors.text70),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTrendCard(StorageUsageSummary summary) {
+    final trend = summary.trend;
+    final totalDeltaText = _signedBytes(trend.deltaTotalBytes);
+    final cleanableDeltaText = _signedBytes(trend.deltaCleanableBytes);
+    final hasPrev = trend.hasPrevious;
+    return _buildCard(
+      child: Row(
+        children: [
+          const Icon(Icons.trending_up, color: Color(0xFF2C7FEB)),
+          const SizedBox(width: 10),
+          Expanded(
+            child: hasPrev
+                ? Text(
+                    '较上次分析：总占用 $totalDeltaText，可清理 $cleanableDeltaText',
+                    style: const TextStyle(fontSize: 12, color: AppColors.text70),
+                  )
+                : const Text(
+                    '这是首次分析，后续将展示占用变化趋势',
+                    style: TextStyle(fontSize: 12, color: AppColors.text70),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStrategyCard(StorageUsageSummary summary) {
+    final presets = summary.strategyPresets;
+    if (presets.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return _buildCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '智能清理策略',
+            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 8),
+          ...presets.map((preset) {
+            final applying = _applyingStrategyId == preset.id;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          preset.name,
+                          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          preset.description,
+                          style: const TextStyle(fontSize: 12, color: AppColors.text70),
+                        ),
+                      ],
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: applying ? null : () => _applyStrategy(preset),
+                    child: applying
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('执行'),
+                  ),
+                ],
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPieCard(StorageUsageSummary summary) {
+    final categories = summary.categories.where((item) => item.bytes > 0).toList();
+    final colorMap = _buildCategoryColorMap(summary.categories);
+    final segments = _buildChartSegments(categories, colorMap);
+    return _buildCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('占用分析', style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
+          const SizedBox(height: 4),
+          Text(
+            '最后分析：${_formatDateTime(summary.generatedAt)}',
+            style: const TextStyle(fontSize: 12, color: AppColors.text70),
+          ),
+          const SizedBox(height: 12),
+          Center(
+            child: _StorageUsagePieChart(totalBytes: summary.totalBytes, segments: segments),
+          ),
+          const SizedBox(height: 8),
+          TextButton(onPressed: _loadSummary, child: const Text('重新分析')),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryListCard(StorageUsageSummary summary) {
+    final categories = summary.categories.where((item) => item.bytes > 0).toList();
+    final colorMap = _buildCategoryColorMap(summary.categories);
+    return _buildCard(
+      padding: EdgeInsets.zero,
+      child: Column(
+        children: categories.map((category) {
+          final percent = summary.totalBytes > 0
+              ? category.bytes / summary.totalBytes * 100
+              : 0.0;
+          final isClearing = _clearingCategoryId == category.id;
+          return Column(
+            children: [
+              ListTile(
+                leading: Container(
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: colorMap[category.id] ?? const Color(0xFF94A3B8),
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                title: Text(category.name, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                subtitle: Text('${category.description}\n占比 ${percent.toStringAsFixed(1)}%'),
+                trailing: category.cleanable
+                    ? TextButton(
+                        onPressed: isClearing ? null : () => _onClearCategory(category),
+                        child: isClearing
+                            ? const SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Text('清理'),
+                      )
+                    : null,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 50, right: 16, bottom: 10),
+                child: Row(
+                  children: [
+                    Text(
+                      _formatBytes(category.bytes),
+                      style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(width: 8),
+                    _buildRiskTag(category.riskLevel),
+                  ],
+                ),
+              ),
+              if (category != categories.last)
+                const Divider(height: 1, indent: 16, endIndent: 16),
+            ],
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _buildCard({required Widget child, EdgeInsetsGeometry? padding}) {
+    return Container(
+      decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16)),
+      padding: padding ?? const EdgeInsets.all(16),
+      child: child,
+    );
+  }
+
+  Widget _buildMetricCell(String title, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: const TextStyle(fontSize: 12, color: AppColors.text70)),
+        const SizedBox(height: 2),
+        Text(value, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+      ],
+    );
+  }
+
+  Widget _buildRiskTag(String riskLevel) {
+    late final String text;
+    late final Color bgColor;
+    late final Color fgColor;
+    switch (riskLevel) {
+      case 'safe':
+        text = '低风险';
+        bgColor = const Color(0xFFE6F8F0);
+        fgColor = const Color(0xFF0E9F6E);
+        break;
+      case 'caution':
+        text = '谨慎';
+        bgColor = const Color(0xFFFFF4E5);
+        fgColor = const Color(0xFFB76E00);
+        break;
+      case 'dangerous':
+        text = '高风险';
+        bgColor = const Color(0xFFFFECEC);
+        fgColor = const Color(0xFFCC3C3C);
+        break;
+      default:
+        text = '只读';
+        bgColor = const Color(0xFFF1F5F9);
+        fgColor = const Color(0xFF475569);
+        break;
+    }
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(color: bgColor, borderRadius: BorderRadius.circular(6)),
+      child: Text(text, style: TextStyle(fontSize: 10, color: fgColor)),
+    );
+  }
+
+  Map<String, Color> _buildCategoryColorMap(List<StorageUsageCategory> categories) {
+    final colorMap = <String, Color>{};
+    for (int index = 0; index < categories.length; index++) {
+      colorMap[categories[index].id] = _palette[index % _palette.length];
+    }
+    return colorMap;
+  }
+
+  List<_PieChartSegment> _buildChartSegments(
+    List<StorageUsageCategory> categories,
+    Map<String, Color> colorMap,
+  ) {
+    final sorted = [...categories]..sort((a, b) => b.bytes.compareTo(a.bytes));
+    if (sorted.length <= 7) {
+      return sorted
+          .map((item) => _PieChartSegment(item.name, item.bytes, colorMap[item.id] ?? const Color(0xFF94A3B8)))
+          .toList();
+    }
+    final head = sorted.take(6).toList();
+    final tailBytes = sorted.skip(6).fold<int>(0, (sum, item) => sum + item.bytes);
+    return [
+      ...head.map((item) => _PieChartSegment(item.name, item.bytes, colorMap[item.id] ?? const Color(0xFF94A3B8))),
+      _PieChartSegment('其他', tailBytes, const Color(0xFF94A3B8)),
+    ];
+  }
+
+  String _signedBytes(int bytes) {
+    if (bytes == 0) return '0 B';
+    final sign = bytes > 0 ? '+' : '-';
+    return '$sign${_formatBytes(bytes.abs())}';
+  }
+
+  String _metricsSourceText(String source) {
+    switch (source) {
+      case 'system_storage_stats':
+        return '系统统计（与系统设置更接近）';
+      case 'filesystem_estimate':
+      default:
+        return '目录扫描估算';
+    }
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    double size = bytes.toDouble();
+    int unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+      size /= 1024;
+      unitIndex++;
+    }
+    final fixed = size >= 100 ? size.toStringAsFixed(0) : size.toStringAsFixed(1);
+    return '$fixed ${units[unitIndex]}';
+  }
+
+  String _formatDateTime(int timestampMs) {
+    if (timestampMs <= 0) return '-';
+    final dt = DateTime.fromMillisecondsSinceEpoch(timestampMs);
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${dt.year}-${two(dt.month)}-${two(dt.day)} ${two(dt.hour)}:${two(dt.minute)}';
+  }
+}
+
+class _PieChartSegment {
+  const _PieChartSegment(this.label, this.bytes, this.color);
+  final String label;
+  final int bytes;
+  final Color color;
+}
+
+class _StorageUsagePieChart extends StatelessWidget {
+  const _StorageUsagePieChart({required this.totalBytes, required this.segments});
+
+  final int totalBytes;
+  final List<_PieChartSegment> segments;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 210,
+      height: 210,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CustomPaint(
+            size: const Size(210, 210),
+            painter: _StorageUsagePiePainter(segments: segments),
+          ),
+          Text(
+            _formatBytes(totalBytes),
+            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    double size = bytes.toDouble();
+    int unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+      size /= 1024;
+      unitIndex++;
+    }
+    final fixed = size >= 100 ? size.toStringAsFixed(0) : size.toStringAsFixed(1);
+    return '$fixed ${units[unitIndex]}';
+  }
+}
+
+class _StorageUsagePiePainter extends CustomPainter {
+  _StorageUsagePiePainter({required this.segments});
+  final List<_PieChartSegment> segments;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = math.min(size.width, size.height) / 2 - 12;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 20;
+
+    final total = segments.fold<int>(0, (sum, item) => sum + item.bytes);
+    if (total <= 0) {
+      paint.color = const Color(0xFFE2E8F0);
+      canvas.drawArc(rect, -math.pi / 2, math.pi * 2, false, paint);
+      return;
+    }
+    double start = -math.pi / 2;
+    for (final segment in segments) {
+      if (segment.bytes <= 0) continue;
+      final sweep = segment.bytes / total * math.pi * 2;
+      paint.color = segment.color;
+      canvas.drawArc(rect, start, sweep, false, paint);
+      start += sweep;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _StorageUsagePiePainter oldDelegate) {
+    if (segments.length != oldDelegate.segments.length) return true;
+    for (int i = 0; i < segments.length; i++) {
+      if (segments[i].bytes != oldDelegate.segments[i].bytes ||
+          segments[i].color != oldDelegate.segments[i].color) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/ui/lib/features/home/router_config.dart
+++ b/ui/lib/features/home/router_config.dart
@@ -16,6 +16,7 @@ import 'pages/command_overlay/command_overlay.dart';
 import 'pages/edit_profile/edit_profile_page.dart';
 import 'pages/settings/workspace_memory_setting_page.dart';
 import 'pages/settings/background_setting_page.dart';
+import 'pages/settings/storage_usage_page.dart';
 import 'pages/omnibot_workspace/omnibot_artifact_preview_page.dart';
 import 'pages/omnibot_workspace/omnibot_workspace_page.dart';
 import 'pages/webview/webview_page.dart';
@@ -308,6 +309,16 @@ List<GoRoute> homeRoutes = [
       key: state.pageKey,
       name: 'home/background_setting',
       child: const BackgroundSettingPage(),
+    ),
+  ),
+
+  GoRoute(
+    path: '/home/storage_usage',
+    name: 'home/storage_usage',
+    pageBuilder: (context, state) => GoRouterManager.buildActivitySlidePage(
+      key: state.pageKey,
+      name: 'home/storage_usage',
+      child: const StorageUsagePage(),
     ),
   ),
 

--- a/ui/lib/services/storage_usage_service.dart
+++ b/ui/lib/services/storage_usage_service.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/services.dart';
+
+class StorageUsageCategory {
+  const StorageUsageCategory({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.bytes,
+    required this.cleanable,
+    required this.riskLevel,
+    this.cleanupHint,
+    this.order = 0,
+  });
+
+  final String id;
+  final String name;
+  final String description;
+  final int bytes;
+  final bool cleanable;
+  final String riskLevel;
+  final String? cleanupHint;
+  final int order;
+
+  factory StorageUsageCategory.fromMap(Map<dynamic, dynamic> map) {
+    return StorageUsageCategory(
+      id: (map['id'] ?? '').toString(),
+      name: (map['name'] ?? '').toString(),
+      description: (map['description'] ?? '').toString(),
+      bytes: _asInt(map['bytes']),
+      cleanable: map['cleanable'] == true,
+      riskLevel: (map['riskLevel'] ?? 'info').toString(),
+      cleanupHint: map['cleanupHint']?.toString(),
+      order: _asInt(map['order']),
+    );
+  }
+
+  static int _asInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value?.toString() ?? '') ?? 0;
+  }
+}
+
+class StorageUsageTrend {
+  const StorageUsageTrend({
+    required this.hasPrevious,
+    required this.deltaTotalBytes,
+    required this.deltaCleanableBytes,
+    required this.previousGeneratedAt,
+    required this.previousTotalBytes,
+    required this.previousCleanableBytes,
+  });
+
+  final bool hasPrevious;
+  final int deltaTotalBytes;
+  final int deltaCleanableBytes;
+  final int previousGeneratedAt;
+  final int previousTotalBytes;
+  final int previousCleanableBytes;
+
+  factory StorageUsageTrend.fromMap(Map<dynamic, dynamic> map) {
+    return StorageUsageTrend(
+      hasPrevious: map['hasPrevious'] == true,
+      deltaTotalBytes: StorageUsageCategory._asInt(map['deltaTotalBytes']),
+      deltaCleanableBytes: StorageUsageCategory._asInt(
+        map['deltaCleanableBytes'],
+      ),
+      previousGeneratedAt: StorageUsageCategory._asInt(map['previousGeneratedAt']),
+      previousTotalBytes: StorageUsageCategory._asInt(map['previousTotalBytes']),
+      previousCleanableBytes: StorageUsageCategory._asInt(
+        map['previousCleanableBytes'],
+      ),
+    );
+  }
+}
+
+class StorageUsageHistoryPoint {
+  const StorageUsageHistoryPoint({
+    required this.generatedAt,
+    required this.totalBytes,
+    required this.cleanableBytes,
+  });
+
+  final int generatedAt;
+  final int totalBytes;
+  final int cleanableBytes;
+
+  factory StorageUsageHistoryPoint.fromMap(Map<dynamic, dynamic> map) {
+    return StorageUsageHistoryPoint(
+      generatedAt: StorageUsageCategory._asInt(map['generatedAt']),
+      totalBytes: StorageUsageCategory._asInt(map['totalBytes']),
+      cleanableBytes: StorageUsageCategory._asInt(map['cleanableBytes']),
+    );
+  }
+}
+
+class StorageCleanupStrategyPreset {
+  const StorageCleanupStrategyPreset({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.riskLevel,
+    required this.olderThanDays,
+    required this.targetReleaseBytes,
+  });
+
+  final String id;
+  final String name;
+  final String description;
+  final String riskLevel;
+  final int olderThanDays;
+  final int targetReleaseBytes;
+
+  factory StorageCleanupStrategyPreset.fromMap(Map<dynamic, dynamic> map) {
+    return StorageCleanupStrategyPreset(
+      id: (map['id'] ?? '').toString(),
+      name: (map['name'] ?? '').toString(),
+      description: (map['description'] ?? '').toString(),
+      riskLevel: (map['riskLevel'] ?? 'info').toString(),
+      olderThanDays: StorageUsageCategory._asInt(map['olderThanDays']),
+      targetReleaseBytes: StorageUsageCategory._asInt(map['targetReleaseBytes']),
+    );
+  }
+}
+
+class StorageUsageSummary {
+  const StorageUsageSummary({
+    required this.generatedAt,
+    required this.totalBytes,
+    required this.appBinaryBytes,
+    required this.userDataBytes,
+    required this.cacheBytes,
+    required this.cleanableBytes,
+    required this.categories,
+    required this.trend,
+    required this.history,
+    required this.strategyPresets,
+    required this.packageName,
+    required this.metricsSource,
+    required this.scanTotalBytes,
+    required this.systemTotalBytes,
+  });
+
+  final int generatedAt;
+  final int totalBytes;
+  final int appBinaryBytes;
+  final int userDataBytes;
+  final int cacheBytes;
+  final int cleanableBytes;
+  final List<StorageUsageCategory> categories;
+  final StorageUsageTrend trend;
+  final List<StorageUsageHistoryPoint> history;
+  final List<StorageCleanupStrategyPreset> strategyPresets;
+  final String packageName;
+  final String metricsSource;
+  final int scanTotalBytes;
+  final int systemTotalBytes;
+
+  factory StorageUsageSummary.fromMap(Map<dynamic, dynamic> map) {
+    final rawCategories = (map['categories'] as List<dynamic>? ?? const [])
+        .whereType<Map<dynamic, dynamic>>()
+        .map(StorageUsageCategory.fromMap)
+        .toList()
+      ..sort((a, b) => b.bytes.compareTo(a.bytes));
+    final rawHistory = (map['history'] as List<dynamic>? ?? const [])
+        .whereType<Map<dynamic, dynamic>>()
+        .map(StorageUsageHistoryPoint.fromMap)
+        .toList();
+    final rawPresets = (map['strategyPresets'] as List<dynamic>? ?? const [])
+        .whereType<Map<dynamic, dynamic>>()
+        .map(StorageCleanupStrategyPreset.fromMap)
+        .toList();
+    final trendMap = map['trend'];
+
+    return StorageUsageSummary(
+      generatedAt: StorageUsageCategory._asInt(map['generatedAt']),
+      totalBytes: StorageUsageCategory._asInt(map['totalBytes']),
+      appBinaryBytes: StorageUsageCategory._asInt(map['appBinaryBytes']),
+      userDataBytes: StorageUsageCategory._asInt(map['userDataBytes']),
+      cacheBytes: StorageUsageCategory._asInt(map['cacheBytes']),
+      cleanableBytes: StorageUsageCategory._asInt(map['cleanableBytes']),
+      categories: rawCategories,
+      trend: trendMap is Map
+          ? StorageUsageTrend.fromMap(Map<dynamic, dynamic>.from(trendMap))
+          : const StorageUsageTrend(
+              hasPrevious: false,
+              deltaTotalBytes: 0,
+              deltaCleanableBytes: 0,
+              previousGeneratedAt: 0,
+              previousTotalBytes: 0,
+              previousCleanableBytes: 0,
+            ),
+      history: rawHistory,
+      strategyPresets: rawPresets,
+      packageName: (map['packageName'] ?? '').toString(),
+      metricsSource: (map['metricsSource'] ?? 'filesystem_estimate').toString(),
+      scanTotalBytes: StorageUsageCategory._asInt(map['scanTotalBytes']),
+      systemTotalBytes: StorageUsageCategory._asInt(map['systemTotalBytes']),
+    );
+  }
+}
+
+class StorageUsageCleanupResult {
+  const StorageUsageCleanupResult({
+    required this.categoryId,
+    required this.success,
+    required this.beforeBytes,
+    required this.afterBytes,
+    required this.releasedBytes,
+    required this.failedPaths,
+    required this.retryable,
+    this.manualActionHint,
+    this.summary,
+  });
+
+  final String categoryId;
+  final bool success;
+  final int beforeBytes;
+  final int afterBytes;
+  final int releasedBytes;
+  final List<String> failedPaths;
+  final bool retryable;
+  final String? manualActionHint;
+  final StorageUsageSummary? summary;
+
+  factory StorageUsageCleanupResult.fromMap(Map<dynamic, dynamic> map) {
+    final summaryMap = map['summary'];
+    return StorageUsageCleanupResult(
+      categoryId: (map['categoryId'] ?? '').toString(),
+      success: map['success'] == true,
+      beforeBytes: StorageUsageCategory._asInt(map['beforeBytes']),
+      afterBytes: StorageUsageCategory._asInt(map['afterBytes']),
+      releasedBytes: StorageUsageCategory._asInt(map['releasedBytes']),
+      failedPaths: (map['failedPaths'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .toList(),
+      retryable: map['retryable'] == true,
+      manualActionHint: map['manualActionHint']?.toString(),
+      summary: summaryMap is Map
+          ? StorageUsageSummary.fromMap(
+              Map<dynamic, dynamic>.from(summaryMap as Map),
+            )
+          : null,
+    );
+  }
+}
+
+class StorageStrategyActionResult {
+  const StorageStrategyActionResult({
+    required this.categoryId,
+    required this.success,
+    required this.releasedBytes,
+    required this.failedPaths,
+    this.manualActionHint,
+  });
+
+  final String categoryId;
+  final bool success;
+  final int releasedBytes;
+  final List<String> failedPaths;
+  final String? manualActionHint;
+
+  factory StorageStrategyActionResult.fromMap(Map<dynamic, dynamic> map) {
+    return StorageStrategyActionResult(
+      categoryId: (map['categoryId'] ?? '').toString(),
+      success: map['success'] == true,
+      releasedBytes: StorageUsageCategory._asInt(map['releasedBytes']),
+      failedPaths: (map['failedPaths'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .toList(),
+      manualActionHint: map['manualActionHint']?.toString(),
+    );
+  }
+}
+
+class StorageUsageStrategyResult {
+  const StorageUsageStrategyResult({
+    required this.strategyId,
+    required this.strategyName,
+    required this.success,
+    required this.releasedBytes,
+    required this.actionResults,
+    this.summary,
+  });
+
+  final String strategyId;
+  final String strategyName;
+  final bool success;
+  final int releasedBytes;
+  final List<StorageStrategyActionResult> actionResults;
+  final StorageUsageSummary? summary;
+
+  factory StorageUsageStrategyResult.fromMap(Map<dynamic, dynamic> map) {
+    final summaryMap = map['summary'];
+    return StorageUsageStrategyResult(
+      strategyId: (map['strategyId'] ?? '').toString(),
+      strategyName: (map['strategyName'] ?? '').toString(),
+      success: map['success'] == true,
+      releasedBytes: StorageUsageCategory._asInt(map['releasedBytes']),
+      actionResults: (map['actionResults'] as List<dynamic>? ?? const [])
+          .whereType<Map<dynamic, dynamic>>()
+          .map(StorageStrategyActionResult.fromMap)
+          .toList(),
+      summary: summaryMap is Map
+          ? StorageUsageSummary.fromMap(Map<dynamic, dynamic>.from(summaryMap))
+          : null,
+    );
+  }
+}
+
+class StorageUsageService {
+  static const MethodChannel _channel = MethodChannel(
+    'cn.com.omnimind.bot/StorageUsage',
+  );
+
+  static Future<StorageUsageSummary> getStorageUsageSummary() async {
+    final result = await _channel.invokeMethod<dynamic>('getStorageUsageSummary');
+    if (result is! Map) {
+      throw PlatformException(
+        code: 'INVALID_STORAGE_USAGE_RESULT',
+        message: 'Storage summary result is invalid',
+      );
+    }
+    return StorageUsageSummary.fromMap(Map<dynamic, dynamic>.from(result));
+  }
+
+  static Future<StorageUsageCleanupResult> clearCategory(
+    String categoryId, {
+    int? olderThanDays,
+  }) async {
+    final result = await _channel.invokeMethod<dynamic>(
+      'clearStorageUsageCategory',
+      {
+        'categoryId': categoryId,
+        if (olderThanDays != null && olderThanDays > 0)
+          'olderThanDays': olderThanDays,
+      },
+    );
+    if (result is! Map) {
+      throw PlatformException(
+        code: 'INVALID_STORAGE_CLEAN_RESULT',
+        message: 'Storage cleanup result is invalid',
+      );
+    }
+    return StorageUsageCleanupResult.fromMap(
+      Map<dynamic, dynamic>.from(result),
+    );
+  }
+
+  static Future<StorageUsageStrategyResult> applyCleanupStrategy(
+    String strategyId, {
+    int? olderThanDays,
+    int? targetReleaseBytes,
+  }) async {
+    final result = await _channel.invokeMethod<dynamic>(
+      'applyStorageCleanupStrategy',
+      {
+        'strategyId': strategyId,
+        if (olderThanDays != null && olderThanDays > 0)
+          'olderThanDays': olderThanDays,
+        if (targetReleaseBytes != null && targetReleaseBytes > 0)
+          'targetReleaseBytes': targetReleaseBytes,
+      },
+    );
+    if (result is! Map) {
+      throw PlatformException(
+        code: 'INVALID_STORAGE_STRATEGY_RESULT',
+        message: 'Storage strategy result is invalid',
+      );
+    }
+    return StorageUsageStrategyResult.fromMap(
+      Map<dynamic, dynamic>.from(result),
+    );
+  }
+}


### PR DESCRIPTION
…ligned stats and cleanup strategies

## 变更摘要

本次新增了「存储占用」功能入口与页面，支持按分类展示应用存储占用（饼图 + 列表）并执行清理。
  同时将总量口径升级为优先对齐 Android 系统 StorageStats，显著降低应用内显示与系统设置页的差异。
  新增清理策略、趋势快照与清理结果回传，提升可解释性与可操作性。
## 变更类型

- [ ] 新功能


## 关联 Issue

issue102

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 新增设置页「存储占用」入口、路由与页面：展示总占用、分类饼图、分类列表，并支持单项清理。
  2. 统计口径以系统优先。


## 测试说明
与手机内存储大小进行了比对。

<img width="864" height="1920" alt="与小米系统存储层面大小比对" src="https://github.com/user-attachments/assets/c88ae332-eceb-4e13-a3da-1e84f63dc526" />




## UI 变更（如有）

有。
  存储占用页面新增：总览卡片、趋势卡片、策略清理区、饼图与分类清理列表
<img width="864" height="1920" alt="前端界面1" src="https://github.com/user-attachments/assets/e74dac2a-e52e-421d-91c8-ccae1c1db92e" />
<img width="864" height="1920" alt="前端界面2" src="https://github.com/user-attachments/assets/e5158f40-7bcf-4ec6-b1dd-c4a901db1dfe" />
<img width="864" height="1920" alt="前端界面3" src="https://github.com/user-attachments/assets/cb7152dd-c1b9-4052-a9b6-a02ee246e6a3" />
