### PR TITLE
fix(issue102 storage): 存储占用页改版,支持深色模式，支持l10n,补充本地模型占用统计。

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/StorageUsageChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/StorageUsageChannel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.os.Process
 import android.os.storage.StorageManager
+import cn.com.omnimind.baselib.i18n.AppLocaleManager
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
 import io.flutter.embedding.engine.FlutterEngine
@@ -32,6 +33,7 @@ class StorageUsageChannel {
         private const val STORAGE_METRICS_HISTORY_KEY = "history_v1"
         private const val MAX_HISTORY_SIZE = 30
         private const val DEFAULT_HISTORY_OUTPUT_SIZE = 10
+        private const val APP_BINARY_LIB_TOP_LIMIT = 5
     }
 
     private var methodChannel: MethodChannel? = null
@@ -146,7 +148,7 @@ class StorageUsageChannel {
         val cacheExternalDir: File?,
         val sharedDraftsDir: File,
         val mcpInboxDir: File,
-        val localModelsRoot: File,
+        val localModelsRoots: List<File>,
         val localModelsMmapDir: File,
         val localModelsTempsDir: File,
         val localModelsBuiltinTempsDir: File,
@@ -166,7 +168,13 @@ class StorageUsageChannel {
         val cleanable: Boolean,
         val riskLevel: String,
         val cleanupHint: String? = null,
+        val breakdown: List<CategoryBreakdownEntry> = emptyList(),
         val order: Int,
+    )
+
+    private data class CategoryBreakdownEntry(
+        val label: String,
+        val bytes: Long,
     )
 
     private data class SnapshotPoint(
@@ -234,6 +242,10 @@ class StorageUsageChannel {
         val userDataBytes = systemStats?.dataBytes ?: dataDirScanBytes
         val summaryCacheBytes = systemStats?.cacheBytes ?: cacheScanBytes
         val cacheCategoryBytes = maxOf(cacheScanBytes, summaryCacheBytes)
+        val appBinaryTopLibs = buildTopNativeLibBreakdown(
+            context = context,
+            topLimit = APP_BINARY_LIB_TOP_LIMIT,
+        )
 
         val databaseBytes = sumUniquePaths(paths.databaseFiles)
         val conversationEstimateBytes = estimateConversationHistoryBytes().coerceAtMost(databaseBytes)
@@ -246,7 +258,7 @@ class StorageUsageChannel {
         val workspaceMemoryBytes = sumUniquePaths(listOf(File(paths.workspaceInternalRoot, "memory")))
         val workspaceUserFilesBytes = sumWorkspaceUserFiles(paths.workspaceRoot)
 
-        val localModelsFilesBytes = sumUniquePaths(listOf(paths.localModelsRoot))
+        val localModelsFilesBytes = sumUniquePaths(paths.localModelsRoots)
         val localModelsCacheBytes = sumUniquePaths(
             listOf(paths.localModelsMmapDir, paths.localModelsTempsDir, paths.localModelsBuiltinTempsDir)
         )
@@ -271,10 +283,11 @@ class StorageUsageChannel {
             CategoryEntry(
                 id = "app_binary",
                 name = "应用安装包",
-                description = "应用安装文件占用（APK/AAB split）",
+                description = "应用安装文件与 Native 库占用",
                 bytes = appBinaryBytes,
                 cleanable = false,
                 riskLevel = "info",
+                breakdown = appBinaryTopLibs,
                 order = 1,
             ),
             CategoryEntry(
@@ -367,7 +380,7 @@ class StorageUsageChannel {
             CategoryEntry(
                 id = "local_models_files",
                 name = "本地模型文件",
-                description = ".mnnmodels 下的模型文件",
+                description = ".mnnmodels 与 workspace/.omnibot/models 下的模型文件",
                 bytes = localModelsFilesBytes,
                 cleanable = true,
                 riskLevel = "dangerous",
@@ -436,13 +449,14 @@ class StorageUsageChannel {
             ),
         )
 
-        val knownBytes = baseCategories.sumOf { it.bytes }
+        val localizedBaseCategories = baseCategories.map { localizeCategoryEntry(context, it) }
+        val knownBytes = localizedBaseCategories.sumOf { it.bytes }
         val scanTotalBytes = appBinaryScanBytes + dataDirScanBytes + externalKnownBytes
         val baselineTotalBytes = systemStats?.totalBytes ?: scanTotalBytes
         val totalBytes = maxOf(baselineTotalBytes, knownBytes)
         val otherUserDataBytes = (totalBytes - knownBytes).coerceAtLeast(0L)
 
-        val categories = (baseCategories + CategoryEntry(
+        val categories = (localizedBaseCategories + localizeCategoryEntry(context, CategoryEntry(
             id = "other_user_data",
             name = "其他数据",
             description = "未命中分类规则的数据",
@@ -450,7 +464,7 @@ class StorageUsageChannel {
             cleanable = false,
             riskLevel = "info",
             order = 99,
-        )).sortedByDescending { it.bytes }
+        ))).sortedByDescending { it.bytes }
 
         val cleanableBytes = categories.filter { it.cleanable }.sumOf { it.bytes }
         val generatedAt = System.currentTimeMillis()
@@ -481,7 +495,7 @@ class StorageUsageChannel {
                     "cleanableBytes" to point.cleanableBytes,
                 )
             },
-            "strategyPresets" to cleanupStrategyPresets().map { preset ->
+            "strategyPresets" to cleanupStrategyPresets(context).map { preset ->
                 mapOf(
                     "id" to preset.id,
                     "name" to preset.name,
@@ -500,6 +514,12 @@ class StorageUsageChannel {
                     "cleanable" to category.cleanable,
                     "riskLevel" to category.riskLevel,
                     "cleanupHint" to category.cleanupHint,
+                    "breakdown" to category.breakdown.map { item ->
+                        mapOf(
+                            "label" to item.label,
+                            "bytes" to item.bytes,
+                        )
+                    },
                     "order" to category.order,
                 )
             },
@@ -553,7 +573,7 @@ class StorageUsageChannel {
         val after = analyzeStorageUsage(context, persistSnapshot = true)
         val afterBytes = after.categoryBytes[categoryId] ?: 0L
         val releasedBytes = (beforeBytes - afterBytes).coerceAtLeast(0L)
-        val manualActionHint = manualActionHintForCategory(categoryId)
+        val manualActionHint = manualActionHintForCategory(context, categoryId)
 
         return mapOf(
             "categoryId" to categoryId,
@@ -574,7 +594,7 @@ class StorageUsageChannel {
         overrideOlderThanDays: Int?,
         targetReleaseBytes: Long,
     ): Map<String, Any?> {
-        val strategy = cleanupStrategyPresets().firstOrNull { it.id == strategyId }
+        val strategy = cleanupStrategyPresets(context).firstOrNull { it.id == strategyId }
             ?: error("Unknown strategy: $strategyId")
         val before = analyzeStorageUsage(context, persistSnapshot = false)
         var current = before
@@ -596,11 +616,7 @@ class StorageUsageChannel {
                         "success" to !action.required,
                         "releasedBytes" to 0L,
                         "failedPaths" to emptyList<String>(),
-                        "manualActionHint" to if (action.required) {
-                            "该分类当前不可清理"
-                        } else {
-                            "该分类已跳过（可选项）"
-                        },
+                        "manualActionHint" to categorySkipHint(context, action.required),
                     )
                 )
                 continue
@@ -628,7 +644,7 @@ class StorageUsageChannel {
                     "success" to outcome.success,
                     "releasedBytes" to released,
                     "failedPaths" to outcome.failedPaths,
-                    "manualActionHint" to manualActionHintForCategory(categoryId),
+                    "manualActionHint" to manualActionHintForCategory(context, categoryId),
                 )
             )
 
@@ -650,7 +666,7 @@ class StorageUsageChannel {
         )
     }
 
-    private fun cleanupStrategyPresets(): List<CleanupStrategyPreset> {
+    private fun cleanupStrategyPresets(context: Context): List<CleanupStrategyPreset> {
         return listOf(
             CleanupStrategyPreset(
                 id = "safe_quick",
@@ -701,7 +717,7 @@ class StorageUsageChannel {
                     StrategyAction("local_models_files", required = false),
                 ),
             ),
-        )
+        ).map { preset -> localizeStrategyPreset(context, preset) }
     }
 
     private fun clearCategoryInternal(
@@ -747,7 +763,7 @@ class StorageUsageChannel {
                 clearCategoryInternal(context, "terminal_runtime_bootstrap", olderThanDays),
             )
 
-            "local_models_files" -> clearDirectoryContents(File(context.filesDir, ".mnnmodels"))
+            "local_models_files" -> clearUniqueDirectories(resolveLocalModelRoots(context))
             "local_models_cache" -> mergeOutcomes(
                 clearDirectoryContents(File(context.filesDir, "tmps")),
                 clearDirectoryContents(File(context.filesDir, "local_temps")),
@@ -810,14 +826,174 @@ class StorageUsageChannel {
         }
     }
 
-    private fun manualActionHintForCategory(categoryId: String): String {
+    private fun manualActionHintForCategory(
+        context: Context,
+        categoryId: String,
+    ): String {
         return when (categoryId) {
-            "conversation_history" -> "如历史未释放，请重新进入页面执行“重新分析”"
-            "local_models_files", "local_models" -> "模型被清理后，可在“本地模型服务”页面重新下载"
+            "conversation_history" -> text(
+                context,
+                zh = "如历史未释放，请重新进入页面执行“重新分析”",
+                en = "If history size does not drop, open this page again and run Analyze again.",
+            )
+            "local_models_files", "local_models" -> text(
+                context,
+                zh = "模型被清理后，可在“本地模型服务”页面重新下载",
+                en = "After cleanup, model files can be downloaded again in Local Models.",
+            )
             "terminal_runtime_local", "terminal_runtime_bootstrap", "terminal_runtime" ->
-                "终端运行时被清理后，可在 Alpine 环境页重新初始化"
-            else -> "若清理失败，可稍后重试或重启应用后再次清理"
+                text(
+                    context,
+                    zh = "终端运行时被清理后，可在 Alpine 环境页重新初始化",
+                    en = "After cleanup, terminal runtime can be re-initialized in Alpine Environment.",
+                )
+            else -> text(
+                context,
+                zh = "若清理失败，可稍后重试或重启应用后再次清理",
+                en = "If cleanup fails, try again later or retry after restarting the app.",
+            )
         }
+    }
+
+    private fun categorySkipHint(context: Context, required: Boolean): String {
+        return if (required) {
+            text(
+                context,
+                zh = "该分类当前不可清理",
+                en = "This category is not cleanable right now.",
+            )
+        } else {
+            text(
+                context,
+                zh = "该分类已跳过（可选项）",
+                en = "Skipped this optional category.",
+            )
+        }
+    }
+
+    private fun localizeStrategyPreset(
+        context: Context,
+        preset: CleanupStrategyPreset,
+    ): CleanupStrategyPreset {
+        if (!AppLocaleManager.isEnglish(context)) {
+            return preset
+        }
+        return when (preset.id) {
+            "safe_quick" -> preset.copy(
+                name = "Safe quick cleanup",
+                description = "Prioritize low-risk cache and temporary artifacts.",
+            )
+            "balance_deep" -> preset.copy(
+                name = "Balanced deep cleanup",
+                description = "Free more space while keeping core models and user files.",
+            )
+            "free_1gb_priority" -> preset.copy(
+                name = "Target free 1 GB",
+                description = "Clean in high-yield order to approach 1 GB released.",
+            )
+            else -> preset
+        }
+    }
+
+    private fun localizeCategoryEntry(
+        context: Context,
+        entry: CategoryEntry,
+    ): CategoryEntry {
+        if (!AppLocaleManager.isEnglish(context)) {
+            return entry
+        }
+        return when (entry.id) {
+            "app_binary" -> entry.copy(
+                name = "App package",
+                description = "App install files and native libraries.",
+            )
+            "cache" -> entry.copy(
+                name = "Cache",
+                description = "Temporary files and image cache, safe to clean.",
+                cleanupHint = "Will be regenerated during normal usage.",
+            )
+            "conversation_history" -> entry.copy(
+                name = "Conversation history",
+                description = "Chat and tool execution history (estimated).",
+                cleanupHint = "Deletes history records permanently and cannot be undone.",
+            )
+            "database_other" -> entry.copy(
+                name = "Database (other)",
+                description = "Indexes and system table data.",
+            )
+            "workspace_browser" -> entry.copy(
+                name = "Workspace browser artifacts",
+                description = "Screenshots, downloads, and intermediate browser outputs.",
+                cleanupHint = "Deletes intermediate files from browser tools.",
+            )
+            "workspace_offloads" -> entry.copy(
+                name = "Workspace offloads",
+                description = "Offline tool outputs and temporary files.",
+                cleanupHint = "Deletes offline outputs only and keeps core functionality intact.",
+            )
+            "workspace_attachments" -> entry.copy(
+                name = "Workspace attachments",
+                description = "Attachments used by historical tasks.",
+                cleanupHint = "May affect reviewing attachments in past tasks.",
+            )
+            "workspace_shared" -> entry.copy(
+                name = "Workspace shared files",
+                description = "Cross-task shared workspace files.",
+                cleanupHint = "May affect reuse of shared files in future tasks.",
+            )
+            "workspace_memory" -> entry.copy(
+                name = "Workspace memory data",
+                description = "Long/short-term memory and index data.",
+            )
+            "workspace_user_files" -> entry.copy(
+                name = "Workspace user files",
+                description = "Files explicitly saved by user into workspace.",
+            )
+            "local_models_files" -> entry.copy(
+                name = "Local model files",
+                description = "Model files under .mnnmodels and workspace/.omnibot/models.",
+                cleanupHint = "Deletes model files; they need to be downloaded again later.",
+            )
+            "local_models_cache" -> entry.copy(
+                name = "Model inference cache",
+                description = "mmap and local inference temp directories.",
+                cleanupHint = "Will be regenerated during inference.",
+            )
+            "terminal_runtime_local" -> entry.copy(
+                name = "Terminal runtime (local)",
+                description = "Alpine terminal local runtime directory.",
+                cleanupHint = "Deletes terminal local directory and requires re-initialization.",
+            )
+            "terminal_runtime_bootstrap" -> entry.copy(
+                name = "Terminal runtime (bootstrap)",
+                description = "proot/lib/alpine bootstrap files.",
+                cleanupHint = "Deletes terminal bootstrap files and requires re-initialization.",
+            )
+            "shared_drafts" -> entry.copy(
+                name = "Shared drafts",
+                description = "Draft cache imported from external sharing.",
+                cleanupHint = "Deletes unsent draft attachments.",
+            )
+            "mcp_inbox" -> entry.copy(
+                name = "MCP inbox",
+                description = "Incoming directory for MCP file transfers.",
+                cleanupHint = "Deletes files in MCP inbox.",
+            )
+            "legacy_workspace" -> entry.copy(
+                name = "Legacy workspace data",
+                description = "Old workspace directories that may remain after upgrades.",
+                cleanupHint = "Recommended to clean after confirming they are no longer needed.",
+            )
+            "other_user_data" -> entry.copy(
+                name = "Other data",
+                description = "Data not matched by current category rules.",
+            )
+            else -> entry
+        }
+    }
+
+    private fun text(context: Context, zh: String, en: String): String {
+        return if (AppLocaleManager.isEnglish(context)) en else zh
     }
 
     private fun buildSnapshotBundle(
@@ -986,7 +1162,7 @@ class StorageUsageChannel {
             cacheExternalDir = context.externalCacheDir,
             sharedDraftsDir = File(context.filesDir, "shared_open_drafts"),
             mcpInboxDir = File(context.filesDir, "mcp_inbox"),
-            localModelsRoot = File(context.filesDir, ".mnnmodels"),
+            localModelsRoots = resolveLocalModelRoots(context),
             localModelsMmapDir = File(context.filesDir, "tmps"),
             localModelsTempsDir = File(context.filesDir, "local_temps"),
             localModelsBuiltinTempsDir = File(context.filesDir, "builtin_temps"),
@@ -999,8 +1175,47 @@ class StorageUsageChannel {
         )
     }
 
+    private fun resolveLocalModelRoots(context: Context): List<File> {
+        return listOf(
+            File(context.filesDir, ".mnnmodels"),
+            AgentWorkspaceManager.modelsDirectory(context),
+        )
+    }
+
     private fun resolvePrimaryDatabaseFile(context: Context): File {
         return context.getDatabasePath(DATABASE_PRIMARY_NAME)
+    }
+
+    private fun buildTopNativeLibBreakdown(
+        context: Context,
+        topLimit: Int,
+    ): List<CategoryBreakdownEntry> {
+        if (topLimit <= 0) {
+            return emptyList()
+        }
+        val nativeLibRootPath = context.applicationInfo.nativeLibraryDir ?: return emptyList()
+        val nativeLibRoot = File(nativeLibRootPath)
+        if (!nativeLibRoot.exists() || !nativeLibRoot.isDirectory) {
+            return emptyList()
+        }
+
+        return nativeLibRoot.walkTopDown()
+            .maxDepth(8)
+            .filter { file ->
+                file.isFile && file.name.endsWith(".so", ignoreCase = true)
+            }
+            .map { file ->
+                val relative = runCatching {
+                    nativeLibRoot.toPath().relativize(file.toPath()).toString()
+                }.getOrDefault(file.name)
+                CategoryBreakdownEntry(
+                    label = relative.replace('\\', '/'),
+                    bytes = file.length().coerceAtLeast(0L),
+                )
+            }
+            .sortedByDescending { it.bytes }
+            .take(topLimit)
+            .toList()
     }
 
     private fun safeExecSql(database: SQLiteDatabase, sql: String) {
@@ -1169,6 +1384,22 @@ class StorageUsageChannel {
         var merged = CleanupOutcome(success = true)
         outcomes.forEach { outcome ->
             merged = merged.merge(outcome)
+        }
+        return merged
+    }
+
+    private fun clearUniqueDirectories(paths: List<File>): CleanupOutcome {
+        if (paths.isEmpty()) {
+            return CleanupOutcome(success = true)
+        }
+        val visited = hashSetOf<String>()
+        var merged = CleanupOutcome(success = true)
+        paths.forEach { path ->
+            val key = canonicalPath(path)
+            if (!visited.add(key)) {
+                return@forEach
+            }
+            merged = merged.merge(clearDirectoryContents(path))
         }
         return merged
     }

--- a/ui/lib/features/home/pages/settings/storage_usage_page.dart
+++ b/ui/lib/features/home/pages/settings/storage_usage_page.dart
@@ -1,9 +1,10 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:ui/l10n/l10n.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
 import 'package:ui/services/storage_usage_service.dart';
-import 'package:ui/theme/app_colors.dart';
+import 'package:ui/theme/theme_context.dart';
 import 'package:ui/utils/ui.dart';
 import 'package:ui/widgets/common_app_bar.dart';
 
@@ -21,7 +22,7 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   String? _applyingStrategyId;
   StorageUsageSummary? _summary;
 
-  static const List<Color> _palette = [
+  static const List<Color> _segmentPaletteLight = [
     Color(0xFF2C7FEB),
     Color(0xFF00A870),
     Color(0xFFF59E0B),
@@ -34,10 +35,30 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
     Color(0xFF64748B),
   ];
 
+  static const List<Color> _segmentPaletteDark = [
+    Color(0xFF6FA9FF),
+    Color(0xFF66D4A4),
+    Color(0xFFFFC766),
+    Color(0xFFFF8E8E),
+    Color(0xFFB9A1FF),
+    Color(0xFF58D6CB),
+    Color(0xFFFF96CD),
+    Color(0xFF8F9BFF),
+    Color(0xFFB6DD6F),
+    Color(0xFF9AA4B2),
+  ];
+
   @override
   void initState() {
     super.initState();
     _loadSummary();
+  }
+
+  String _t(BuildContext context, String zh, String en) {
+    if (LegacyTextLocalizer.isEnglish) {
+      return en;
+    }
+    return context.trLegacy(zh);
   }
 
   Future<void> _loadSummary({bool silent = false}) async {
@@ -59,15 +80,18 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
       if (!mounted) return;
       setState(() {
         _loading = false;
-        _error = LegacyTextLocalizer.isEnglish
-            ? 'Storage analysis failed, please try again'
-            : '存储分析失败，请重试';
+        _error = _t(
+          context,
+          '存储分析失败，请重试',
+          'Storage analysis failed, please try again',
+        );
       });
     }
   }
 
   Future<void> _onClearCategory(StorageUsageCategory category) async {
     final olderThanDays = await _showClearOptionsDialog(category);
+    if (!mounted) return;
     if (olderThanDays == null) return;
 
     setState(() {
@@ -85,34 +109,35 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
         });
       } else {
         await _loadSummary(silent: true);
+        if (!mounted) return;
       }
 
       if (result.success) {
         showToast(
-          LegacyTextLocalizer.isEnglish
-              ? 'Cleaned ${category.name}, freed ${_formatBytes(result.releasedBytes)}'
-              : '已清理${category.name}，释放 ${_formatBytes(result.releasedBytes)}',
+          _t(
+            context,
+            '已清理 ${category.name}，释放 ${_formatBytes(result.releasedBytes)}',
+            'Cleaned ${category.name}, freed ${_formatBytes(result.releasedBytes)}',
+          ),
           type: ToastType.success,
         );
       } else {
         final hint = (result.manualActionHint ?? '').trim();
         showToast(
           hint.isNotEmpty
-              ? (LegacyTextLocalizer.isEnglish
-                  ? 'Some cleanup failed: $hint'
-                  : '部分清理失败：$hint')
-              : (LegacyTextLocalizer.isEnglish
-                  ? 'Some files failed to clean up, please try again later'
-                  : '部分文件清理失败，请稍后重试'),
+              ? _t(context, '部分清理失败：$hint', 'Some cleanup failed: $hint')
+              : _t(
+                  context,
+                  '部分文件清理失败，请稍后重试',
+                  'Some files failed to clean up, please try again later',
+                ),
           type: ToastType.error,
         );
       }
     } catch (_) {
       if (!mounted) return;
       showToast(
-        LegacyTextLocalizer.isEnglish
-            ? 'Cleanup failed, please try again later'
-            : '清理失败，请稍后重试',
+        _t(context, '清理失败，请稍后重试', 'Cleanup failed, please try again later'),
         type: ToastType.error,
       );
     } finally {
@@ -129,50 +154,63 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
     final canRetention = category.riskLevel != 'dangerous';
     return showDialog<int>(
       context: context,
-      builder: (context) {
+      builder: (dialogContext) {
+        final palette = dialogContext.omniPalette;
         return StatefulBuilder(
-          builder: (context, setDialogState) {
+          builder: (dialogContext, setDialogState) {
             return AlertDialog(
+              backgroundColor: palette.surfacePrimary,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
               title: Text(
-                LegacyTextLocalizer.isEnglish
-                    ? 'Clean ${category.name}'
-                    : '清理${category.name}',
+                _t(
+                  dialogContext,
+                  '清理 ${category.name}',
+                  'Clean ${category.name}',
+                ),
               ),
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(category.cleanupHint ??
-                      (LegacyTextLocalizer.isEnglish
-                          ? 'Confirm cleanup for this category?'
-                          : '确认清理该分类数据吗？')),
+                  Text(
+                    category.cleanupHint ??
+                        _t(
+                          dialogContext,
+                          '确认清理该分类数据吗？',
+                          'Confirm cleanup for this category?',
+                        ),
+                    style: TextStyle(color: palette.textSecondary),
+                  ),
                   if (canRetention) ...[
                     const SizedBox(height: 12),
                     Text(
-                      LegacyTextLocalizer.isEnglish ? 'Cleanup scope' : '清理范围',
+                      _t(dialogContext, '清理范围', 'Cleanup scope'),
+                      style: TextStyle(
+                        color: palette.textPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                     const SizedBox(height: 6),
                     Wrap(
                       spacing: 8,
                       children: [
                         ChoiceChip(
-                          label: Text(
-                            LegacyTextLocalizer.isEnglish ? 'All' : '全部',
-                          ),
+                          label: Text(_t(dialogContext, '全部', 'All')),
                           selected: selected == 0,
                           onSelected: (_) => setDialogState(() => selected = 0),
                         ),
                         ChoiceChip(
-                          label: Text(
-                            LegacyTextLocalizer.isEnglish ? '7 days ago' : '7天前',
-                          ),
+                          label: Text(_t(dialogContext, '7天前', '7 days ago')),
                           selected: selected == 7,
                           onSelected: (_) => setDialogState(() => selected = 7),
                         ),
                         ChoiceChip(
-                          label: const Text('30天前'),
+                          label: Text(_t(dialogContext, '30天前', '30 days ago')),
                           selected: selected == 30,
-                          onSelected: (_) => setDialogState(() => selected = 30),
+                          onSelected: (_) =>
+                              setDialogState(() => selected = 30),
                         ),
                       ],
                     ),
@@ -181,12 +219,12 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
               ),
               actions: [
                 TextButton(
-                  onPressed: () => Navigator.of(context).pop(null),
-                  child: const Text('取消'),
+                  onPressed: () => Navigator.of(dialogContext).pop(null),
+                  child: Text(_t(dialogContext, '取消', 'Cancel')),
                 ),
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(selected),
-                  child: const Text('确认清理'),
+                FilledButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(selected),
+                  child: Text(_t(dialogContext, '确认清理', 'Confirm cleanup')),
                 ),
               ],
             );
@@ -199,23 +237,38 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   Future<void> _applyStrategy(StorageCleanupStrategyPreset preset) async {
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (context) {
+      builder: (dialogContext) {
+        final palette = dialogContext.omniPalette;
         return AlertDialog(
-          title: Text('执行策略：${preset.name}'),
-          content: Text(preset.description),
+          backgroundColor: palette.surfacePrimary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          title: Text(
+            _t(
+              dialogContext,
+              '执行策略：${preset.name}',
+              'Run strategy: ${preset.name}',
+            ),
+          ),
+          content: Text(
+            preset.description,
+            style: TextStyle(color: palette.textSecondary),
+          ),
           actions: [
             TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('取消'),
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(_t(dialogContext, '取消', 'Cancel')),
             ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('开始执行'),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(_t(dialogContext, '开始执行', 'Run')),
             ),
           ],
         );
       },
     );
+    if (!mounted) return;
     if (confirmed != true) return;
 
     setState(() {
@@ -230,23 +283,41 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
         });
       } else {
         await _loadSummary(silent: true);
+        if (!mounted) return;
       }
 
-      final failedCount = result.actionResults.where((item) => !item.success).length;
+      final failedCount = result.actionResults
+          .where((item) => !item.success)
+          .length;
       if (failedCount == 0) {
         showToast(
-          '策略执行完成，释放 ${_formatBytes(result.releasedBytes)}',
+          _t(
+            context,
+            '策略执行完成，释放 ${_formatBytes(result.releasedBytes)}',
+            'Cleanup strategy completed, freed ${_formatBytes(result.releasedBytes)}',
+          ),
           type: ToastType.success,
         );
       } else {
         showToast(
-          '策略完成，释放 ${_formatBytes(result.releasedBytes)}，$failedCount 项未完全成功',
+          _t(
+            context,
+            '策略执行完成，释放 ${_formatBytes(result.releasedBytes)}，$failedCount 项未完全成功',
+            'Cleanup strategy finished, freed ${_formatBytes(result.releasedBytes)}, $failedCount actions were incomplete',
+          ),
           type: ToastType.error,
         );
       }
     } catch (_) {
       if (!mounted) return;
-      showToast('策略执行失败，请稍后重试', type: ToastType.error);
+      showToast(
+        _t(
+          context,
+          '策略执行失败，请稍后重试',
+          'Cleanup strategy failed, please try again later',
+        ),
+        type: ToastType.error,
+      );
     } finally {
       if (mounted) {
         setState(() {
@@ -259,14 +330,25 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   @override
   Widget build(BuildContext context) {
     final summary = _summary;
+    final palette = context.omniPalette;
     return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: const CommonAppBar(title: '存储占用', primary: true),
+      backgroundColor: palette.pageBackground,
+      appBar: CommonAppBar(
+        title: _t(context, '存储占用', 'Storage Usage'),
+        primary: true,
+      ),
       body: _loading
-          ? const Center(child: CircularProgressIndicator())
+          ? Center(
+              child: CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  palette.accentPrimary,
+                ),
+              ),
+            )
           : summary == null
           ? _buildErrorView()
           : RefreshIndicator(
+              color: palette.accentPrimary,
               onRefresh: _loadSummary,
               child: ListView(
                 padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
@@ -287,19 +369,27 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   }
 
   Widget _buildErrorView() {
+    final palette = context.omniPalette;
     return Center(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(_error ?? '加载失败', style: const TextStyle(color: AppColors.text70)),
+          Text(
+            _error ?? _t(context, '加载失败', 'Load failed'),
+            style: TextStyle(color: palette.textSecondary),
+          ),
           const SizedBox(height: 12),
-          ElevatedButton(onPressed: _loadSummary, child: const Text('重新分析')),
+          FilledButton(
+            onPressed: _loadSummary,
+            child: Text(_t(context, '重新分析', 'Analyze again')),
+          ),
         ],
       ),
     );
   }
 
   Widget _buildOverviewCard(StorageUsageSummary summary) {
+    final palette = context.omniPalette;
     final sourceText = _metricsSourceText(summary.metricsSource);
     final hasBothTotals =
         summary.systemTotalBytes > 0 && summary.scanTotalBytes > 0;
@@ -308,37 +398,67 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('总占用', style: TextStyle(fontSize: 12, color: AppColors.text70)),
+          Text(
+            _t(context, '总占用', 'Total usage'),
+            style: TextStyle(fontSize: 12, color: palette.textSecondary),
+          ),
           const SizedBox(height: 4),
           Text(
             _formatBytes(summary.totalBytes),
-            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w700,
+              color: palette.textPrimary,
+            ),
           ),
           const SizedBox(height: 12),
           Row(
             children: [
-              Expanded(child: _buildMetricCell('应用大小', _formatBytes(summary.appBinaryBytes))),
-              Expanded(child: _buildMetricCell('用户数据', _formatBytes(summary.userDataBytes))),
-              Expanded(child: _buildMetricCell('可清理', _formatBytes(summary.cleanableBytes))),
+              Expanded(
+                child: _buildMetricCell(
+                  _t(context, '应用大小', 'App size'),
+                  _formatBytes(summary.appBinaryBytes),
+                ),
+              ),
+              Expanded(
+                child: _buildMetricCell(
+                  _t(context, '用户数据', 'User data'),
+                  _formatBytes(summary.userDataBytes),
+                ),
+              ),
+              Expanded(
+                child: _buildMetricCell(
+                  _t(context, '可清理', 'Cleanable'),
+                  _formatBytes(summary.cleanableBytes),
+                ),
+              ),
             ],
           ),
           const SizedBox(height: 10),
           Text(
-            '统计口径：$sourceText',
-            style: const TextStyle(fontSize: 11, color: AppColors.text70),
+            _t(context, '统计口径：$sourceText', 'Metrics source: $sourceText'),
+            style: TextStyle(fontSize: 11, color: palette.textSecondary),
           ),
           if (summary.packageName.isNotEmpty) ...[
             const SizedBox(height: 2),
             Text(
-              '当前包名：${summary.packageName}',
-              style: const TextStyle(fontSize: 11, color: AppColors.text70),
+              _t(
+                context,
+                '当前包名：${summary.packageName}',
+                'Package: ${summary.packageName}',
+              ),
+              style: TextStyle(fontSize: 11, color: palette.textSecondary),
             ),
           ],
           if (hasBothTotals && diffBytes != 0) ...[
             const SizedBox(height: 2),
             Text(
-              '系统口径与扫描口径差异：${_signedBytes(diffBytes)}',
-              style: const TextStyle(fontSize: 11, color: AppColors.text70),
+              _t(
+                context,
+                '系统口径与扫描口径差异：${_signedBytes(diffBytes)}',
+                'Delta between system and scan totals: ${_signedBytes(diffBytes)}',
+              ),
+              style: TextStyle(fontSize: 11, color: palette.textSecondary),
             ),
           ],
         ],
@@ -347,24 +467,38 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   }
 
   Widget _buildTrendCard(StorageUsageSummary summary) {
+    final palette = context.omniPalette;
     final trend = summary.trend;
     final totalDeltaText = _signedBytes(trend.deltaTotalBytes);
     final cleanableDeltaText = _signedBytes(trend.deltaCleanableBytes);
-    final hasPrev = trend.hasPrevious;
     return _buildCard(
       child: Row(
         children: [
-          const Icon(Icons.trending_up, color: Color(0xFF2C7FEB)),
+          Icon(Icons.trending_up, color: palette.accentPrimary),
           const SizedBox(width: 10),
           Expanded(
-            child: hasPrev
+            child: trend.hasPrevious
                 ? Text(
-                    '较上次分析：总占用 $totalDeltaText，可清理 $cleanableDeltaText',
-                    style: const TextStyle(fontSize: 12, color: AppColors.text70),
+                    _t(
+                      context,
+                      '较上次分析：总占用 $totalDeltaText，可清理 $cleanableDeltaText',
+                      'Since last analysis: total $totalDeltaText, cleanable $cleanableDeltaText',
+                    ),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: palette.textSecondary,
+                    ),
                   )
-                : const Text(
-                    '这是首次分析，后续将展示占用变化趋势',
-                    style: TextStyle(fontSize: 12, color: AppColors.text70),
+                : Text(
+                    _t(
+                      context,
+                      '这是首次分析，后续将展示占用变化趋势',
+                      'This is the first analysis. Trend data will appear next time.',
+                    ),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: palette.textSecondary,
+                    ),
                   ),
           ),
         ],
@@ -373,6 +507,8 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   }
 
   Widget _buildStrategyCard(StorageUsageSummary summary) {
+    final palette = context.omniPalette;
+    final colorScheme = Theme.of(context).colorScheme;
     final presets = summary.strategyPresets;
     if (presets.isEmpty) {
       return const SizedBox.shrink();
@@ -381,9 +517,13 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            '智能清理策略',
-            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+          Text(
+            _t(context, '智能清理策略', 'Cleanup strategies'),
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: palette.textPrimary,
+            ),
           ),
           const SizedBox(height: 8),
           ...presets.map((preset) {
@@ -398,25 +538,44 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
                       children: [
                         Text(
                           preset.name,
-                          style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: palette.textPrimary,
+                          ),
                         ),
                         const SizedBox(height: 2),
                         Text(
                           preset.description,
-                          style: const TextStyle(fontSize: 12, color: AppColors.text70),
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: palette.textSecondary,
+                          ),
                         ),
                       ],
                     ),
                   ),
-                  TextButton(
+                  FilledButton(
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size(72, 34),
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      backgroundColor: palette.accentPrimary,
+                      disabledBackgroundColor: palette.borderStrong,
+                      foregroundColor: colorScheme.onPrimary,
+                    ),
                     onPressed: applying ? null : () => _applyStrategy(preset),
                     child: applying
-                        ? const SizedBox(
+                        ? SizedBox(
                             width: 14,
                             height: 14,
-                            child: CircularProgressIndicator(strokeWidth: 2),
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                colorScheme.onPrimary,
+                              ),
+                            ),
                           )
-                        : const Text('执行'),
+                        : Text(_t(context, '执行', 'Run')),
                   ),
                 ],
               ),
@@ -428,33 +587,65 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   }
 
   Widget _buildPieCard(StorageUsageSummary summary) {
-    final categories = summary.categories.where((item) => item.bytes > 0).toList();
+    final palette = context.omniPalette;
+    final categories = summary.categories
+        .where((item) => item.bytes > 0)
+        .toList();
     final colorMap = _buildCategoryColorMap(summary.categories);
     final segments = _buildChartSegments(categories, colorMap);
     return _buildCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('占用分析', style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600)),
+          Text(
+            _t(context, '占用分析', 'Usage breakdown'),
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: palette.textPrimary,
+            ),
+          ),
           const SizedBox(height: 4),
           Text(
-            '最后分析：${_formatDateTime(summary.generatedAt)}',
-            style: const TextStyle(fontSize: 12, color: AppColors.text70),
+            _t(
+              context,
+              '最后分析：${_formatDateTime(summary.generatedAt)}',
+              'Analyzed at: ${_formatDateTime(summary.generatedAt)}',
+            ),
+            style: TextStyle(fontSize: 12, color: palette.textSecondary),
           ),
           const SizedBox(height: 12),
           Center(
-            child: _StorageUsagePieChart(totalBytes: summary.totalBytes, segments: segments),
+            child: _StorageUsagePieChart(
+              totalBytes: summary.totalBytes,
+              segments: segments,
+              trackColor: palette.segmentTrack,
+              centerTextColor: palette.textPrimary,
+            ),
           ),
           const SizedBox(height: 8),
-          TextButton(onPressed: _loadSummary, child: const Text('重新分析')),
+          TextButton(
+            onPressed: _loadSummary,
+            child: Text(_t(context, '重新分析', 'Analyze again')),
+          ),
         ],
       ),
     );
   }
 
   Widget _buildCategoryListCard(StorageUsageSummary summary) {
-    final categories = summary.categories.where((item) => item.bytes > 0).toList();
+    final palette = context.omniPalette;
+    final colorScheme = Theme.of(context).colorScheme;
+    final categories = summary.categories.toList();
     final colorMap = _buildCategoryColorMap(summary.categories);
+    if (categories.isEmpty) {
+      return _buildCard(
+        child: Text(
+          _t(context, '暂无可展示数据', 'No storage data available'),
+          style: TextStyle(fontSize: 12, color: palette.textSecondary),
+        ),
+      );
+    }
     return _buildCard(
       padding: EdgeInsets.zero,
       child: Column(
@@ -470,22 +661,50 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
                   width: 10,
                   height: 10,
                   decoration: BoxDecoration(
-                    color: colorMap[category.id] ?? const Color(0xFF94A3B8),
+                    color: colorMap[category.id] ?? palette.textTertiary,
                     shape: BoxShape.circle,
                   ),
                 ),
-                title: Text(category.name, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
-                subtitle: Text('${category.description}\n占比 ${percent.toStringAsFixed(1)}%'),
+                title: Text(
+                  category.name,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: palette.textPrimary,
+                  ),
+                ),
+                subtitle: Text(
+                  '${category.description}\n${_t(context, '占比', 'Share')} ${percent.toStringAsFixed(1)}%',
+                  style: TextStyle(
+                    fontSize: 12,
+                    height: 1.45,
+                    color: palette.textSecondary,
+                  ),
+                ),
                 trailing: category.cleanable
-                    ? TextButton(
-                        onPressed: isClearing ? null : () => _onClearCategory(category),
+                    ? FilledButton(
+                        style: FilledButton.styleFrom(
+                          minimumSize: const Size(64, 32),
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                          backgroundColor: palette.accentPrimary,
+                          disabledBackgroundColor: palette.borderStrong,
+                          foregroundColor: colorScheme.onPrimary,
+                        ),
+                        onPressed: isClearing
+                            ? null
+                            : () => _onClearCategory(category),
                         child: isClearing
-                            ? const SizedBox(
+                            ? SizedBox(
                                 width: 14,
                                 height: 14,
-                                child: CircularProgressIndicator(strokeWidth: 2),
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                    colorScheme.onPrimary,
+                                  ),
+                                ),
                               )
-                            : const Text('清理'),
+                            : Text(_t(context, '清理', 'Clean')),
                       )
                     : null,
               ),
@@ -495,15 +714,28 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
                   children: [
                     Text(
                       _formatBytes(category.bytes),
-                      style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: palette.textPrimary,
+                      ),
                     ),
                     const SizedBox(width: 8),
                     _buildRiskTag(category.riskLevel),
                   ],
                 ),
               ),
+              if (category.breakdown.isNotEmpty)
+                _buildCategoryBreakdown(category.breakdown),
               if (category != categories.last)
-                const Divider(height: 1, indent: 16, endIndent: 16),
+                Divider(
+                  height: 1,
+                  indent: 16,
+                  endIndent: 16,
+                  color: palette.borderSubtle.withValues(
+                    alpha: context.isDarkTheme ? 0.56 : 0.8,
+                  ),
+                ),
             ],
           );
         }).toList(),
@@ -512,61 +744,143 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   }
 
   Widget _buildCard({required Widget child, EdgeInsetsGeometry? padding}) {
+    final palette = context.omniPalette;
     return Container(
-      decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16)),
+      decoration: BoxDecoration(
+        color: palette.surfacePrimary,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: palette.borderSubtle.withValues(
+            alpha: context.isDarkTheme ? 0.6 : 0.86,
+          ),
+        ),
+        boxShadow: context.isDarkTheme
+            ? null
+            : [
+                BoxShadow(
+                  color: palette.shadowColor,
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+      ),
       padding: padding ?? const EdgeInsets.all(16),
       child: child,
     );
   }
 
   Widget _buildMetricCell(String title, String value) {
+    final palette = context.omniPalette;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(title, style: const TextStyle(fontSize: 12, color: AppColors.text70)),
+        Text(
+          title,
+          style: TextStyle(fontSize: 12, color: palette.textSecondary),
+        ),
         const SizedBox(height: 2),
-        Text(value, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: palette.textPrimary,
+          ),
+        ),
       ],
     );
   }
 
+  Widget _buildCategoryBreakdown(List<StorageUsageBreakdownEntry> entries) {
+    final palette = context.omniPalette;
+    return Padding(
+      padding: const EdgeInsets.only(left: 50, right: 16, bottom: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _t(context, 'Native 库 Top 明细', 'Top native libs'),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: palette.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          ...entries.map((entry) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Text(
+                '${entry.label} · ${_formatBytes(entry.bytes)}',
+                style: TextStyle(
+                  fontSize: 11,
+                  height: 1.4,
+                  color: palette.textSecondary,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
   Widget _buildRiskTag(String riskLevel) {
+    final isDark = context.isDarkTheme;
     late final String text;
     late final Color bgColor;
     late final Color fgColor;
     switch (riskLevel) {
       case 'safe':
-        text = '低风险';
-        bgColor = const Color(0xFFE6F8F0);
-        fgColor = const Color(0xFF0E9F6E);
+        text = _t(context, '低风险', 'Low risk');
+        bgColor = isDark ? const Color(0xFF1D4C38) : const Color(0xFFE6F8F0);
+        fgColor = isDark ? const Color(0xFF7CE2B4) : const Color(0xFF0E9F6E);
         break;
       case 'caution':
-        text = '谨慎';
-        bgColor = const Color(0xFFFFF4E5);
-        fgColor = const Color(0xFFB76E00);
+        text = _t(context, '谨慎', 'Caution');
+        bgColor = isDark ? const Color(0xFF4E3C1E) : const Color(0xFFFFF4E5);
+        fgColor = isDark ? const Color(0xFFFFD37A) : const Color(0xFFB76E00);
         break;
       case 'dangerous':
-        text = '高风险';
-        bgColor = const Color(0xFFFFECEC);
-        fgColor = const Color(0xFFCC3C3C);
+        text = _t(context, '高风险', 'High risk');
+        bgColor = isDark ? const Color(0xFF4C2225) : const Color(0xFFFFECEC);
+        fgColor = isDark ? const Color(0xFFFF9A9A) : const Color(0xFFCC3C3C);
         break;
       default:
-        text = '只读';
-        bgColor = const Color(0xFFF1F5F9);
-        fgColor = const Color(0xFF475569);
+        text = _t(context, '只读', 'Read-only');
+        bgColor = isDark ? const Color(0xFF2B3138) : const Color(0xFFF1F5F9);
+        fgColor = isDark ? const Color(0xFFB0BCCB) : const Color(0xFF475569);
         break;
     }
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(color: bgColor, borderRadius: BorderRadius.circular(6)),
-      child: Text(text, style: TextStyle(fontSize: 10, color: fgColor)),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: fgColor.withValues(alpha: 0.24)),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 10,
+          color: fgColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
     );
   }
 
-  Map<String, Color> _buildCategoryColorMap(List<StorageUsageCategory> categories) {
+  Map<String, Color> _buildCategoryColorMap(
+    List<StorageUsageCategory> categories,
+  ) {
+    final palette = context.isDarkTheme
+        ? _segmentPaletteDark
+        : _segmentPaletteLight;
     final colorMap = <String, Color>{};
     for (int index = 0; index < categories.length; index++) {
-      colorMap[categories[index].id] = _palette[index % _palette.length];
+      colorMap[categories[index].id] = palette[index % palette.length];
     }
     return colorMap;
   }
@@ -575,17 +889,32 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
     List<StorageUsageCategory> categories,
     Map<String, Color> colorMap,
   ) {
+    final fallbackColor = context.isDarkTheme
+        ? const Color(0xFF9AA4B2)
+        : const Color(0xFF94A3B8);
     final sorted = [...categories]..sort((a, b) => b.bytes.compareTo(a.bytes));
     if (sorted.length <= 7) {
-      return sorted
-          .map((item) => _PieChartSegment(item.name, item.bytes, colorMap[item.id] ?? const Color(0xFF94A3B8)))
-          .toList();
+      return sorted.map((item) {
+        return _PieChartSegment(
+          item.name,
+          item.bytes,
+          colorMap[item.id] ?? fallbackColor,
+        );
+      }).toList();
     }
     final head = sorted.take(6).toList();
-    final tailBytes = sorted.skip(6).fold<int>(0, (sum, item) => sum + item.bytes);
+    final tailBytes = sorted
+        .skip(6)
+        .fold<int>(0, (sum, item) => sum + item.bytes);
     return [
-      ...head.map((item) => _PieChartSegment(item.name, item.bytes, colorMap[item.id] ?? const Color(0xFF94A3B8))),
-      _PieChartSegment('其他', tailBytes, const Color(0xFF94A3B8)),
+      ...head.map(
+        (item) => _PieChartSegment(
+          item.name,
+          item.bytes,
+          colorMap[item.id] ?? fallbackColor,
+        ),
+      ),
+      _PieChartSegment(_t(context, '其他', 'Others'), tailBytes, fallbackColor),
     ];
   }
 
@@ -598,10 +927,14 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
   String _metricsSourceText(String source) {
     switch (source) {
       case 'system_storage_stats':
-        return '系统统计（与系统设置更接近）';
+        return _t(
+          context,
+          '系统统计（与系统设置更接近）',
+          'System stats (closer to Settings)',
+        );
       case 'filesystem_estimate':
       default:
-        return '目录扫描估算';
+        return _t(context, '目录扫描估算', 'Directory scan estimate');
     }
   }
 
@@ -614,7 +947,9 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
       size /= 1024;
       unitIndex++;
     }
-    final fixed = size >= 100 ? size.toStringAsFixed(0) : size.toStringAsFixed(1);
+    final fixed = size >= 100
+        ? size.toStringAsFixed(0)
+        : size.toStringAsFixed(1);
     return '$fixed ${units[unitIndex]}';
   }
 
@@ -634,10 +969,17 @@ class _PieChartSegment {
 }
 
 class _StorageUsagePieChart extends StatelessWidget {
-  const _StorageUsagePieChart({required this.totalBytes, required this.segments});
+  const _StorageUsagePieChart({
+    required this.totalBytes,
+    required this.segments,
+    required this.trackColor,
+    required this.centerTextColor,
+  });
 
   final int totalBytes;
   final List<_PieChartSegment> segments;
+  final Color trackColor;
+  final Color centerTextColor;
 
   @override
   Widget build(BuildContext context) {
@@ -649,11 +991,18 @@ class _StorageUsagePieChart extends StatelessWidget {
         children: [
           CustomPaint(
             size: const Size(210, 210),
-            painter: _StorageUsagePiePainter(segments: segments),
+            painter: _StorageUsagePiePainter(
+              segments: segments,
+              trackColor: trackColor,
+            ),
           ),
           Text(
             _formatBytes(totalBytes),
-            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: centerTextColor,
+            ),
           ),
         ],
       ),
@@ -669,14 +1018,18 @@ class _StorageUsagePieChart extends StatelessWidget {
       size /= 1024;
       unitIndex++;
     }
-    final fixed = size >= 100 ? size.toStringAsFixed(0) : size.toStringAsFixed(1);
+    final fixed = size >= 100
+        ? size.toStringAsFixed(0)
+        : size.toStringAsFixed(1);
     return '$fixed ${units[unitIndex]}';
   }
 }
 
 class _StorageUsagePiePainter extends CustomPainter {
-  _StorageUsagePiePainter({required this.segments});
+  _StorageUsagePiePainter({required this.segments, required this.trackColor});
+
   final List<_PieChartSegment> segments;
+  final Color trackColor;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -685,14 +1038,17 @@ class _StorageUsagePiePainter extends CustomPainter {
     final rect = Rect.fromCircle(center: center, radius: radius);
     final paint = Paint()
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 20;
+      ..strokeWidth = 20
+      ..strokeCap = StrokeCap.butt;
+
+    paint.color = trackColor;
+    canvas.drawArc(rect, -math.pi / 2, math.pi * 2, false, paint);
 
     final total = segments.fold<int>(0, (sum, item) => sum + item.bytes);
     if (total <= 0) {
-      paint.color = const Color(0xFFE2E8F0);
-      canvas.drawArc(rect, -math.pi / 2, math.pi * 2, false, paint);
       return;
     }
+
     double start = -math.pi / 2;
     for (final segment in segments) {
       if (segment.bytes <= 0) continue;
@@ -705,6 +1061,7 @@ class _StorageUsagePiePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _StorageUsagePiePainter oldDelegate) {
+    if (trackColor != oldDelegate.trackColor) return true;
     if (segments.length != oldDelegate.segments.length) return true;
     for (int i = 0; i < segments.length; i++) {
       if (segments[i].bytes != oldDelegate.segments[i].bytes ||

--- a/ui/lib/services/storage_usage_service.dart
+++ b/ui/lib/services/storage_usage_service.dart
@@ -1,5 +1,19 @@
 import 'package:flutter/services.dart';
 
+class StorageUsageBreakdownEntry {
+  const StorageUsageBreakdownEntry({required this.label, required this.bytes});
+
+  final String label;
+  final int bytes;
+
+  factory StorageUsageBreakdownEntry.fromMap(Map<dynamic, dynamic> map) {
+    return StorageUsageBreakdownEntry(
+      label: (map['label'] ?? '').toString(),
+      bytes: StorageUsageCategory._asInt(map['bytes']),
+    );
+  }
+}
+
 class StorageUsageCategory {
   const StorageUsageCategory({
     required this.id,
@@ -9,6 +23,7 @@ class StorageUsageCategory {
     required this.cleanable,
     required this.riskLevel,
     this.cleanupHint,
+    this.breakdown = const [],
     this.order = 0,
   });
 
@@ -19,6 +34,7 @@ class StorageUsageCategory {
   final bool cleanable;
   final String riskLevel;
   final String? cleanupHint;
+  final List<StorageUsageBreakdownEntry> breakdown;
   final int order;
 
   factory StorageUsageCategory.fromMap(Map<dynamic, dynamic> map) {
@@ -30,6 +46,10 @@ class StorageUsageCategory {
       cleanable: map['cleanable'] == true,
       riskLevel: (map['riskLevel'] ?? 'info').toString(),
       cleanupHint: map['cleanupHint']?.toString(),
+      breakdown: (map['breakdown'] as List<dynamic>? ?? const [])
+          .whereType<Map<dynamic, dynamic>>()
+          .map(StorageUsageBreakdownEntry.fromMap)
+          .toList(),
       order: _asInt(map['order']),
     );
   }
@@ -65,8 +85,12 @@ class StorageUsageTrend {
       deltaCleanableBytes: StorageUsageCategory._asInt(
         map['deltaCleanableBytes'],
       ),
-      previousGeneratedAt: StorageUsageCategory._asInt(map['previousGeneratedAt']),
-      previousTotalBytes: StorageUsageCategory._asInt(map['previousTotalBytes']),
+      previousGeneratedAt: StorageUsageCategory._asInt(
+        map['previousGeneratedAt'],
+      ),
+      previousTotalBytes: StorageUsageCategory._asInt(
+        map['previousTotalBytes'],
+      ),
       previousCleanableBytes: StorageUsageCategory._asInt(
         map['previousCleanableBytes'],
       ),
@@ -118,7 +142,9 @@ class StorageCleanupStrategyPreset {
       description: (map['description'] ?? '').toString(),
       riskLevel: (map['riskLevel'] ?? 'info').toString(),
       olderThanDays: StorageUsageCategory._asInt(map['olderThanDays']),
-      targetReleaseBytes: StorageUsageCategory._asInt(map['targetReleaseBytes']),
+      targetReleaseBytes: StorageUsageCategory._asInt(
+        map['targetReleaseBytes'],
+      ),
     );
   }
 }
@@ -157,11 +183,12 @@ class StorageUsageSummary {
   final int systemTotalBytes;
 
   factory StorageUsageSummary.fromMap(Map<dynamic, dynamic> map) {
-    final rawCategories = (map['categories'] as List<dynamic>? ?? const [])
-        .whereType<Map<dynamic, dynamic>>()
-        .map(StorageUsageCategory.fromMap)
-        .toList()
-      ..sort((a, b) => b.bytes.compareTo(a.bytes));
+    final rawCategories =
+        (map['categories'] as List<dynamic>? ?? const [])
+            .whereType<Map<dynamic, dynamic>>()
+            .map(StorageUsageCategory.fromMap)
+            .toList()
+          ..sort((a, b) => b.bytes.compareTo(a.bytes));
     final rawHistory = (map['history'] as List<dynamic>? ?? const [])
         .whereType<Map<dynamic, dynamic>>()
         .map(StorageUsageHistoryPoint.fromMap)
@@ -237,9 +264,7 @@ class StorageUsageCleanupResult {
       retryable: map['retryable'] == true,
       manualActionHint: map['manualActionHint']?.toString(),
       summary: summaryMap is Map
-          ? StorageUsageSummary.fromMap(
-              Map<dynamic, dynamic>.from(summaryMap as Map),
-            )
+          ? StorageUsageSummary.fromMap(Map<dynamic, dynamic>.from(summaryMap))
           : null,
     );
   }
@@ -314,7 +339,9 @@ class StorageUsageService {
   );
 
   static Future<StorageUsageSummary> getStorageUsageSummary() async {
-    final result = await _channel.invokeMethod<dynamic>('getStorageUsageSummary');
+    final result = await _channel.invokeMethod<dynamic>(
+      'getStorageUsageSummary',
+    );
     if (result is! Map) {
       throw PlatformException(
         code: 'INVALID_STORAGE_USAGE_RESULT',
@@ -328,14 +355,12 @@ class StorageUsageService {
     String categoryId, {
     int? olderThanDays,
   }) async {
-    final result = await _channel.invokeMethod<dynamic>(
-      'clearStorageUsageCategory',
-      {
-        'categoryId': categoryId,
-        if (olderThanDays != null && olderThanDays > 0)
-          'olderThanDays': olderThanDays,
-      },
-    );
+    final result = await _channel
+        .invokeMethod<dynamic>('clearStorageUsageCategory', {
+          'categoryId': categoryId,
+          if (olderThanDays != null && olderThanDays > 0)
+            'olderThanDays': olderThanDays,
+        });
     if (result is! Map) {
       throw PlatformException(
         code: 'INVALID_STORAGE_CLEAN_RESULT',
@@ -352,16 +377,14 @@ class StorageUsageService {
     int? olderThanDays,
     int? targetReleaseBytes,
   }) async {
-    final result = await _channel.invokeMethod<dynamic>(
-      'applyStorageCleanupStrategy',
-      {
-        'strategyId': strategyId,
-        if (olderThanDays != null && olderThanDays > 0)
-          'olderThanDays': olderThanDays,
-        if (targetReleaseBytes != null && targetReleaseBytes > 0)
-          'targetReleaseBytes': targetReleaseBytes,
-      },
-    );
+    final result = await _channel
+        .invokeMethod<dynamic>('applyStorageCleanupStrategy', {
+          'strategyId': strategyId,
+          if (olderThanDays != null && olderThanDays > 0)
+            'olderThanDays': olderThanDays,
+          if (targetReleaseBytes != null && targetReleaseBytes > 0)
+            'targetReleaseBytes': targetReleaseBytes,
+        });
     if (result is! Map) {
       throw PlatformException(
         code: 'INVALID_STORAGE_STRATEGY_RESULT',


### PR DESCRIPTION
## 变更摘要

本次改动主要解决了存储占用页的三类问题：主题风格与深色模式不一致、模型目录统计口径不完整(本地模型)、l10n.
## 变更类型

- [ ] Bug 修复
- [ ] 新功能


## 关联 Issue

issue102
## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 存储占用页 UI 对齐主干主题体系,支持深色模式
2. 补充本地模型进入存储占用
3. 兼容 l10n。



## UI 变更（如有）

深色模式
<img width="864" height="1920" alt="支持深色模式" src="https://github.com/user-attachments/assets/13d966b0-bf6b-4dbc-b522-3aae67eda016" />

## 风险与回滚

无
## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
