### PR TITLE
fix: shorten retry message label in quick action menu

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1757,7 +1757,7 @@ class _UserMessageQuickMenuEntryState
                 ),
                 _buildAction(
                   icon: Icons.refresh_rounded,
-                  label: LegacyTextLocalizer.isEnglish ? 'Retry this message' : '重试这条消息',
+                  label: LegacyTextLocalizer.isEnglish ? 'Retry' : '重试这条消息',
                   onTap: () => _select(_UserMessageQuickAction.retry),
                 ),
               ],


### PR DESCRIPTION
## 变更摘要

<!-- 把“Retry this message”改成了“Retry” -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
