### PR TITLE
Fix/issue188 v2

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -7,6 +7,8 @@ import cn.com.omnimind.baselib.llm.LocalModelProviderBridge
 import cn.com.omnimind.baselib.util.OmniLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -38,6 +40,10 @@ class HttpAgentLlmClient(
     }
 ) : AgentLlmClient {
     private val tag = "HttpAgentLlmClient"
+
+    private companion object {
+        const val REASONING_UPDATE_INTERVAL_MS = 300L
+    }
 
     private data class StreamRequestVariant(
         val name: String,
@@ -150,18 +156,69 @@ class HttpAgentLlmClient(
             )
         )
         var lastReasoning = ""
+        var lastReasoningEmitLength = 0
+        var lastReasoningEmitAt = 0L
+        var reasoningEmitJob: Job? = null
+        val reasoningLock = Any()
         var lastContent = ""
         var eventSource: EventSource? = null
 
-        fun emitReasoning() {
-            val reasoning = accumulator.currentReasoning()
-            if (reasoning.isBlank() || reasoning == lastReasoning) return
+        fun dispatchReasoningSnapshot(reasoning: String) {
             lastReasoning = reasoning
             if (onReasoningUpdate != null) {
                 scope.launch {
                     runCatching { onReasoningUpdate.invoke(reasoning) }
                         .onFailure { OmniLog.w(tag, "emit reasoning update failed: ${it.message}") }
                 }
+            }
+        }
+
+        fun collectReasoningSnapshotLocked(): String? {
+            val length = accumulator.currentReasoningLength()
+            if (length <= 0 || length == lastReasoningEmitLength) return null
+            val reasoning = accumulator.currentReasoning()
+            lastReasoningEmitLength = length
+            if (reasoning.isBlank() || reasoning == lastReasoning) return null
+            lastReasoning = reasoning
+            lastReasoningEmitAt = System.currentTimeMillis()
+            return reasoning
+        }
+
+        fun scheduleReasoningSnapshotLocked(delayMs: Long) {
+            reasoningEmitJob = scope.launch {
+                delay(delayMs)
+                val snapshot = synchronized(reasoningLock) {
+                    reasoningEmitJob = null
+                    collectReasoningSnapshotLocked()
+                }
+                if (snapshot != null) {
+                    dispatchReasoningSnapshot(snapshot)
+                }
+            }
+        }
+
+        fun emitReasoning(force: Boolean = false) {
+            var snapshot: String? = null
+            synchronized(reasoningLock) {
+                val length = accumulator.currentReasoningLength()
+                if (length <= 0 || length == lastReasoningEmitLength) return
+                if (force) {
+                    reasoningEmitJob?.cancel()
+                    reasoningEmitJob = null
+                    snapshot = collectReasoningSnapshotLocked()
+                    return@synchronized
+                }
+                if (reasoningEmitJob?.isActive == true) return
+                val elapsed = System.currentTimeMillis() - lastReasoningEmitAt
+                val delayMs = REASONING_UPDATE_INTERVAL_MS - elapsed
+                if (delayMs <= 0L) {
+                    snapshot = collectReasoningSnapshotLocked()
+                } else {
+                    scheduleReasoningSnapshotLocked(delayMs)
+                }
+            }
+            if (snapshot != null) {
+                dispatchReasoningSnapshot(snapshot!!)
             }
         }
 
@@ -181,7 +238,7 @@ class HttpAgentLlmClient(
             if (!completed.compareAndSet(false, true)) return
             runCatching {
                 val turn = accumulator.buildTurn()
-                emitReasoning()
+                emitReasoning(force = true)
                 emitContent()
                 turn
             }.onSuccess { turn ->
@@ -249,6 +306,7 @@ class HttpAgentLlmClient(
             )
             return streamDone.await()
         } finally {
+            reasoningEmitJob?.cancel()
             eventSource?.cancel()
         }
     }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -193,6 +193,8 @@ class AgentLlmStreamAccumulator(
 
     fun currentReasoning(): String = AgentTextSanitizer.sanitizeUtf16(reasoningBuffer.toString())
 
+    fun currentReasoningLength(): Int = reasoningBuffer.length
+
     fun currentContent(): String = AgentTextSanitizer.sanitizeUtf16(contentBuffer.toString())
 
     fun buildTurn(): ChatCompletionTurn {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -125,6 +125,8 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 internal const val CHAT_ONLY_MODE = "chat_only"
+private const val MAX_PERSISTED_THINKING_CHARS = 16 * 1024
+private const val THINKING_TRUNCATION_NOTICE = "[Earlier reasoning omitted]\n"
 
 private val chatTaskPayloadJson = Json {
     ignoreUnknownKeys = true
@@ -3863,10 +3865,25 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     startTime: Long,
                     endTime: Long?
                 ): Map<String, Any?> {
+                    val sanitizedThinking = AgentTextSanitizer.sanitizeUtf16(thinkingContent)
+                    val originalLength = sanitizedThinking.length
+                    val persistedThinking = if (originalLength <= MAX_PERSISTED_THINKING_CHARS) {
+                        sanitizedThinking
+                    } else {
+                        val bodyLimit = (MAX_PERSISTED_THINKING_CHARS - THINKING_TRUNCATION_NOTICE.length)
+                            .coerceAtLeast(0)
+                        AgentTextSanitizer.sanitizeUtf16(
+                            THINKING_TRUNCATION_NOTICE + sanitizedThinking.takeLast(bodyLimit)
+                        )
+                    }
+                    val truncated = persistedThinking.length < originalLength
                     return linkedMapOf(
                         "type" to "deep_thinking",
                         "isLoading" to isLoading,
-                        "thinkingContent" to thinkingContent,
+                        "thinkingContent" to persistedThinking,
+                        "thinkingContentTruncated" to truncated,
+                        "thinkingOriginalLength" to originalLength,
+                        "thinkingTruncateMode" to if (truncated) "head_omitted" else "none",
                         "stage" to stage,
                         "taskID" to taskId,
                         "startTime" to startTime,
@@ -3896,7 +3913,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             conversationMode = resolvedConversationMode,
                             entryId = entryId,
                             cardData = buildDeepThinkingCardData(
-                                thinkingContent = AgentTextSanitizer.sanitizeUtf16(thinkingContent),
+                                thinkingContent = thinkingContent,
                                 isLoading = isLoading,
                                 stage = stage,
                                 startTime = startTime,
@@ -4033,13 +4050,6 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             activeThinkingEntryId = entryId
                             val startTime = System.currentTimeMillis()
                             thinkingCardStartTimes.putIfAbsent(entryId, startTime)
-                            upsertThinkingCard(
-                                entryId = entryId,
-                                thinkingContent = latestThinkingContent,
-                                isLoading = true,
-                                stage = 1,
-                                createdAt = startTime
-                            )
                         } else {
                             pendingThinkingRoundSplit = true
                         }
@@ -4064,13 +4074,6 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             thinkingCardStartTimes[entryId] = startTime
                             latestThinkingContent = normalizedThinking
                             pendingThinkingRoundSplit = false
-                            upsertThinkingCard(
-                                entryId = entryId,
-                                thinkingContent = latestThinkingContent,
-                                isLoading = true,
-                                stage = 1,
-                                createdAt = startTime
-                            )
                         } else {
                             val entryId = activeThinkingEntryId ?: run {
                                 if (thinkingRound <= 0) {
@@ -4085,12 +4088,6 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                                 }
                             }
                             latestThinkingContent = normalizedThinking
-                            upsertThinkingCard(
-                                entryId = entryId,
-                                thinkingContent = latestThinkingContent,
-                                isLoading = true,
-                                stage = 1
-                            )
                         }
                         sendEvent("onAgentThinkingUpdate", mapOf("thinking" to thinking))
                     }

--- a/assists/src/main/java/cn/com/omnimind/assists/task/vlmserver/VLMStreamAccumulator.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/task/vlmserver/VLMStreamAccumulator.kt
@@ -158,6 +158,8 @@ class VLMStreamAccumulator(
 
     fun currentReasoning(): String = reasoningBuffer.toString()
 
+    fun currentReasoningLength(): Int = reasoningBuffer.length
+
     fun buildTurn(): ChatCompletionTurn {
         if (!seenChunk) {
             throw IllegalStateException("chat completion stream ended without chunks")

--- a/assists/src/main/java/cn/com/omnimind/assists/task/vlmserver/VLMStreamClient.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/task/vlmserver/VLMStreamClient.kt
@@ -5,6 +5,8 @@ import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.util.OmniLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -36,6 +38,10 @@ class HttpVLMStreamClient(
     }
 ) : VLMStreamClient {
     private val tag = "HttpVLMStreamClient"
+
+    private companion object {
+        const val REASONING_UPDATE_INTERVAL_MS = 300L
+    }
 
     private data class StreamRequestVariant(
         val name: String,
@@ -88,12 +94,14 @@ class HttpVLMStreamClient(
         val completed = AtomicBoolean(false)
         val accumulator = VLMStreamAccumulator(json)
         var lastReasoning = ""
+        var lastReasoningEmitLength = 0
+        var lastReasoningEmitAt = 0L
+        var reasoningEmitJob: Job? = null
+        val reasoningLock = Any()
         var eventSource: EventSource? = null
         var handle: SceneChatCompletionStreamHandle? = null
 
-        fun emitReasoning() {
-            val reasoning = accumulator.currentReasoning()
-            if (reasoning.isBlank() || reasoning == lastReasoning) return
+        fun dispatchReasoningSnapshot(reasoning: String) {
             lastReasoning = reasoning
             if (onReasoningUpdate != null) {
                 scope.launch {
@@ -103,12 +111,61 @@ class HttpVLMStreamClient(
             }
         }
 
+        fun collectReasoningSnapshotLocked(): String? {
+            val length = accumulator.currentReasoningLength()
+            if (length <= 0 || length == lastReasoningEmitLength) return null
+            val reasoning = accumulator.currentReasoning()
+            lastReasoningEmitLength = length
+            if (reasoning.isBlank() || reasoning == lastReasoning) return null
+            lastReasoning = reasoning
+            lastReasoningEmitAt = System.currentTimeMillis()
+            return reasoning
+        }
+
+        fun scheduleReasoningSnapshotLocked(delayMs: Long) {
+            reasoningEmitJob = scope.launch {
+                delay(delayMs)
+                val snapshot = synchronized(reasoningLock) {
+                    reasoningEmitJob = null
+                    collectReasoningSnapshotLocked()
+                }
+                if (snapshot != null) {
+                    dispatchReasoningSnapshot(snapshot)
+                }
+            }
+        }
+
+        fun emitReasoning(force: Boolean = false) {
+            var snapshot: String? = null
+            synchronized(reasoningLock) {
+                val length = accumulator.currentReasoningLength()
+                if (length <= 0 || length == lastReasoningEmitLength) return
+                if (force) {
+                    reasoningEmitJob?.cancel()
+                    reasoningEmitJob = null
+                    snapshot = collectReasoningSnapshotLocked()
+                    return@synchronized
+                }
+                if (reasoningEmitJob?.isActive == true) return
+                val elapsed = System.currentTimeMillis() - lastReasoningEmitAt
+                val delayMs = REASONING_UPDATE_INTERVAL_MS - elapsed
+                if (delayMs <= 0L) {
+                    snapshot = collectReasoningSnapshotLocked()
+                } else {
+                    scheduleReasoningSnapshotLocked(delayMs)
+                }
+            }
+            if (snapshot != null) {
+                dispatchReasoningSnapshot(snapshot!!)
+            }
+        }
+
         fun completeStream(eventSource: EventSource? = null) {
             if (!completed.compareAndSet(false, true)) return
             runCatching {
                 val resolvedHandle = handle
                     ?: throw IllegalStateException("scene stream handle not initialized")
-                emitReasoning()
+                emitReasoning(force = true)
                 SceneChatCompletionTurn(
                     parser = resolvedHandle.parser,
                     route = resolvedHandle.route,
@@ -171,6 +228,7 @@ class HttpVLMStreamClient(
             eventSource = handle?.eventSource
             return streamDone.await()
         } finally {
+            reasoningEmitJob?.cancel()
             eventSource?.cancel()
         }
     }

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -44,6 +44,7 @@ import 'package:ui/utils/popup_menu_anchor_position.dart';
 import 'package:ui/services/storage_service.dart';
 import 'package:ui/utils/ui.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
+import 'package:ui/features/home/pages/chat/utils/deep_thinking_persistence.dart';
 
 // 导入 Mixins
 import 'mixins/chat_message_handler.dart';

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -13,7 +13,9 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       ConversationHistoryService.upsertConversationUiCard(
         conversationId,
         entryId: message.id,
-        cardData: Map<String, dynamic>.from(cardData!),
+        cardData: buildPersistentDeepThinkingCardData(
+          Map<String, dynamic>.from(cardData!),
+        ),
         createdAtMillis: message.createAt.millisecondsSinceEpoch,
         mode: activeConversationModeValue,
       ),
@@ -159,7 +161,6 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
         ),
       );
     });
-    _persistDeepThinkingCardIfNeeded(_messages.first);
   }
 
   @override
@@ -201,7 +202,6 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       content['cardData'] = cardData;
       _messages[index] = existing.copyWith(content: content);
     });
-    _persistDeepThinkingCardIfNeeded(_messages[index]);
   }
 
   @override

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -4,6 +4,7 @@ import '../../../../../models/conversation_thread_target.dart';
 import '../../../../../models/chat_message_model.dart';
 import '../../../../../services/conversation_service.dart';
 import '../../../../../services/conversation_history_service.dart';
+import '../utils/deep_thinking_persistence.dart';
 
 /// 对话管理 Mixin
 /// 负责对话的创建、加载、保存、切换等功能
@@ -25,7 +26,9 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
       await ConversationHistoryService.upsertConversationUiCard(
         conversationId,
         entryId: message.id,
-        cardData: Map<String, dynamic>.from(cardData),
+        cardData: buildPersistentDeepThinkingCardData(
+          Map<String, dynamic>.from(cardData),
+        ),
         createdAtMillis: message.createAt.millisecondsSinceEpoch,
         mode: mode,
       );

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -6,6 +6,7 @@ import 'package:ui/features/home/pages/authorize/authorize_page_args.dart';
 import 'package:ui/features/home/pages/chat/utils/stream_text_merge.dart';
 import 'package:ui/features/home/pages/command_overlay/constants/messages.dart';
 import 'package:ui/features/home/pages/chat/mixins/agent_stream_handler.dart';
+import 'package:ui/features/home/pages/chat/utils/deep_thinking_persistence.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
 import 'package:ui/models/chat_message_model.dart';
 import 'package:ui/models/conversation_model.dart';
@@ -1766,12 +1767,6 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       if (notifyAfterUpdate) {
         notifyListeners();
       }
-      if (schedulePersistence) {
-        schedulePersistRuntimeConversation(
-          conversationId: binding.conversationId,
-          mode: binding.mode,
-        );
-      }
       return;
     }
 
@@ -1803,12 +1798,6 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     }
     if (notifyAfterUpdate) {
       notifyListeners();
-    }
-    if (schedulePersistence) {
-      schedulePersistRuntimeConversation(
-        conversationId: binding.conversationId,
-        mode: binding.mode,
-      );
     }
   }
 
@@ -2507,11 +2496,6 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         createAt: DateTime.fromMillisecondsSinceEpoch(startTime),
       ),
     );
-    _persistDeepThinkingCardIfNeeded(
-      conversationId: runtime.conversationId,
-      mode: runtime.mode,
-      message: runtime.messages.first,
-    );
   }
 
   String _buildContextCompactionMarkerId({
@@ -2660,11 +2644,6 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
 
     content['cardData'] = cardData;
     runtime.messages[index] = existing.copyWith(content: content);
-    _persistDeepThinkingCardIfNeeded(
-      conversationId: runtime.conversationId,
-      mode: runtime.mode,
-      message: runtime.messages[index],
-    );
   }
 
   void _persistDeepThinkingCardIfNeeded({
@@ -2680,7 +2659,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       ConversationHistoryService.upsertConversationUiCard(
         conversationId,
         entryId: message.id,
-        cardData: Map<String, dynamic>.from(cardData!),
+        cardData: buildPersistentDeepThinkingCardData(
+          Map<String, dynamic>.from(cardData!),
+        ),
         createdAtMillis: message.createAt.millisecondsSinceEpoch,
         mode: _conversationModeFromRuntimeMode(
           mode,

--- a/ui/lib/features/home/pages/chat/utils/deep_thinking_persistence.dart
+++ b/ui/lib/features/home/pages/chat/utils/deep_thinking_persistence.dart
@@ -1,0 +1,32 @@
+const int kMaxPersistedThinkingChars = 16 * 1024;
+const String _thinkingTruncationNotice = '[Earlier reasoning omitted]\n';
+
+Map<String, dynamic> buildPersistentDeepThinkingCardData(
+  Map<String, dynamic> cardData,
+) {
+  final result = Map<String, dynamic>.from(cardData);
+  final thinking = (result['thinkingContent'] ?? '').toString();
+  final originalLength = thinking.length;
+  if (originalLength <= kMaxPersistedThinkingChars) {
+    result['thinkingContentTruncated'] = false;
+    result['thinkingOriginalLength'] = originalLength;
+    result['thinkingTruncateMode'] = 'none';
+    return result;
+  }
+
+  final bodyLimit =
+      kMaxPersistedThinkingChars - _thinkingTruncationNotice.length;
+  final tail = _takeLastRunes(thinking, bodyLimit < 0 ? 0 : bodyLimit);
+  result['thinkingContent'] = '$_thinkingTruncationNotice$tail';
+  result['thinkingContentTruncated'] = true;
+  result['thinkingOriginalLength'] = originalLength;
+  result['thinkingTruncateMode'] = 'head_omitted';
+  return result;
+}
+
+String _takeLastRunes(String value, int maxRunes) {
+  if (maxRunes <= 0 || value.isEmpty) return '';
+  final runes = value.runes.toList(growable: false);
+  if (runes.length <= maxRunes) return value;
+  return String.fromCharCodes(runes.skip(runes.length - maxRunes));
+}

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -12,6 +12,7 @@ import 'package:ui/features/home/pages/command_overlay/services/chat_service.dar
 import 'package:ui/features/home/pages/command_overlay/constants/messages.dart';
 import 'package:ui/features/home/pages/command_overlay/utils/deep_thinking_parser.dart';
 import 'package:ui/features/home/pages/chat/utils/stream_text_merge.dart';
+import 'package:ui/features/home/pages/chat/utils/deep_thinking_persistence.dart';
 import 'package:ui/services/storage_service.dart';
 import 'package:ui/services/voice_playback_coordinator.dart';
 import 'package:ui/services/screen_dialog_service.dart';
@@ -156,10 +157,20 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
       ConversationHistoryService.upsertConversationUiCard(
         conversationId,
         entryId: message.id,
-        cardData: Map<String, dynamic>.from(cardData!),
+        cardData: buildPersistentDeepThinkingCardData(
+          Map<String, dynamic>.from(cardData!),
+        ),
         createdAtMillis: message.createAt.millisecondsSinceEpoch,
       ),
     );
+  }
+
+  void _persistThinkingCardForTask(String taskID, {String? cardId}) {
+    final thinkingCardId = cardId ?? '$taskID-thinking';
+    final index = _messages.indexWhere((msg) => msg.id == thinkingCardId);
+    if (index != -1) {
+      _persistDeepThinkingCardIfNeeded(_messages[index]);
+    }
   }
 
   @override
@@ -753,7 +764,9 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
           await ConversationHistoryService.upsertConversationUiCard(
             _currentConversationId!,
             entryId: message.id,
-            cardData: Map<String, dynamic>.from(cardData),
+            cardData: buildPersistentDeepThinkingCardData(
+              Map<String, dynamic>.from(cardData),
+            ),
             createdAtMillis: message.createAt.millisecondsSinceEpoch,
           );
         }
@@ -1359,7 +1372,6 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
         content['cardData'] = cardData;
         _messages[index] = existing.copyWith(content: content);
       });
-      _persistDeepThinkingCardIfNeeded(_messages[index]);
     }
   }
 
@@ -1372,6 +1384,7 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
     _updateThinkingCard(taskID);
 
     // 调用post-process接口
+    _persistThinkingCardForTask(taskID);
     await _callDispatchPostProcess(taskID, fullContent);
   }
 
@@ -1389,6 +1402,7 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
     _updateThinkingCard(taskID);
 
     // 如果是429限流错误，直接显示限流提示，不再走后续流程
+    _persistThinkingCardForTask(taskID);
     if (isRateLimited) {
       _handleRateLimitError(taskID);
       _resetDispatchState();
@@ -1415,6 +1429,7 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
 
   /// 处理dispatch错误
   void _handleDispatchError(String taskID, String error) {
+    _persistThinkingCardForTask(taskID);
     setState(() {
       _isAiResponding = false;
       // 移除 loading 消息（如果还存在）
@@ -1444,6 +1459,7 @@ class _ChatBotSheetState extends State<ChatBotSheet> with AgentStreamHandler {
     _currentThinkingStage = 4;
     _isDeepThinking = false;
     _updateThinkingCard(taskID);
+    _persistThinkingCardForTask(taskID);
     setState(() {
       _isAiResponding = false;
       _messages.removeWhere((msg) => msg.id == taskID && msg.isLoading);


### PR DESCRIPTION
## 变更摘要

 本次改动针对深度思考场景下 `reasoning` 流式更新导致的 Java 堆内存放大问题，降低高频完整快照、流式阶段高频持久化
  和超长 thinking 持久化带来的 OOM 风险。
  对比旧版与修复版真机实时日志后，旧版可稳定观察到大对象堆积和 `Throwing OutOfMemoryError`，修复版在同类压测下未再出现 issue188 对应的 OOM 特征。
## 变更类型

- [ ] Bug 修复

## 关联 Issue

issue188

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

 1. 对深度思考 `reasoning` 的流式更新做了节流合并，减少高频整段快照带来的内存压力。
  2.  调整 deep thinking 卡片的持久化策略，避免在流式思考过程中反复写库和同步会话。
  3. 对持久化的 thinking 内容增加长度限制和截断标记，降低超长思考内容对历史消息和内存的影响。

## 测试说明

对旧版执行深度思考压测并实时抓取日志：
     - 关键日志：
       - logcat-filtered.txt:2413 -> Throwing OutOfMemoryError / Failed to allocate 32507952 bytes
       - logcat-filtered.txt:2418 -> Throwing OutOfMemoryError / Failed to allocate 94371848 bytes
       Java heap 峰值和平均值都更高。
  3. 对修复版执行同类压测并实时抓取日志：
   无旧版OOM现象出现，java heap峰值和平均值都显著降低。

测试细节：
压测过程中旧版日志OOM
<img width="2692" height="437" alt="旧版日志OOM" src="https://github.com/user-attachments/assets/e06ae5cc-06c2-4395-964d-844b878ba8f2" />
压测过程中旧版日志 java heap 峰值
<img width="618" height="491" alt="旧版压测java heap峰值" src="https://github.com/user-attachments/assets/1f38c6bc-075c-4c29-a612-761316c0af74" />
修复后日志 java heap 峰值
<img width="465" height="451" alt="修复后压测java heap峰值" src="https://github.com/user-attachments/assets/77a8fd44-69d1-403c-96e7-dc4b48b30f16" />



## UI 变更（如有）

无
## 风险与回滚

无