### PR TITLE
Fix/localmodel load

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/omniinfer/OmniInferModelsManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/omniinfer/OmniInferModelsManager.kt
@@ -325,17 +325,24 @@ object OmniInferModelsManager {
         val quants = model["quants"]?.jsonObject ?: return emptyList()
         val sources = model["sources"]?.jsonObject
 
-        return quants.entries.map { (quantName, quantObj) ->
+        val repo = sources?.get(source)?.jsonPrimitive?.contentOrNull.orEmpty()
+
+        return quants.entries.mapNotNull { (quantName, quantObj) ->
             val sizeBytes = quantObj.jsonObject["size_bytes"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: 0L
             val id = "$modelName-$quantName"
             val localFile = findModelFile(id)
             val activeDownload = activeDownloads[id]
+            val hasPausedPart = buildPausedMapFromPartFiles(id) != null
+            // Hide models that have no repo for the current source,
+            // unless already downloaded, actively downloading, or paused.
+            if (repo.isEmpty() && localFile == null && activeDownload == null && !hasPausedPart) {
+                return@mapNotNull null
+            }
             val downloadMap = when {
                 activeDownload != null -> activeDownload.toMap()
                 localFile != null -> completedDownloadMap(localFile.length())
                 else -> buildPausedMapFromPartFiles(id)
             }
-            val repo = sources?.get(source)?.jsonPrimitive?.contentOrNull.orEmpty()
             mapOf(
                 "id" to id,
                 "name" to "$modelName $quantName",

--- a/app/src/main/java/cn/com/omnimind/bot/omniinfer/OmniInferModelsManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/omniinfer/OmniInferModelsManager.kt
@@ -333,7 +333,7 @@ object OmniInferModelsManager {
             val downloadMap = when {
                 activeDownload != null -> activeDownload.toMap()
                 localFile != null -> completedDownloadMap(localFile.length())
-                else -> null
+                else -> buildPausedMapFromPartFiles(id)
             }
             val repo = sources?.get(source)?.jsonPrimitive?.contentOrNull.orEmpty()
             mapOf(
@@ -402,7 +402,15 @@ object OmniInferModelsManager {
     }
 
     fun pauseDownload(modelId: String) {
-        activeDownloads.remove(modelId)?.cancel()
+        val task = activeDownloads.remove(modelId)
+        task?.cancel()
+        val pausedMap = task?.toPausedMap() ?: buildPausedMapFromPartFiles(modelId)
+        if (pausedMap != null) {
+            emitEvent(
+                "download_update",
+                mapOf("modelId" to modelId, "download" to pausedMap),
+            )
+        }
         emitEvent("downloads_changed", mapOf("modelId" to modelId))
     }
 
@@ -551,6 +559,26 @@ object OmniInferModelsManager {
         eventDispatcher?.invoke(mapOf("type" to type) + payload)
     }
 
+    private fun buildPausedMapFromPartFiles(modelId: String): Map<String, Any?>? {
+        val modelSubDir = File(getModelDir(), modelId)
+        if (!modelSubDir.isDirectory) return null
+        val partFile = File(modelSubDir, "$modelId.gguf.part")
+        if (!partFile.exists()) return null
+        val savedSize = partFile.length()
+        return mapOf(
+            "state" to 4,
+            "stateLabel" to "paused",
+            "progress" to 0.0,
+            "savedSize" to savedSize,
+            "totalSize" to 0L,
+            "speedInfo" to "",
+            "errorMessage" to "",
+            "progressStage" to "",
+            "currentFile" to "$modelId.gguf",
+            "hasUpdate" to false,
+        )
+    }
+
     private fun completedDownloadMap(sizeBytes: Long): Map<String, Any?> {
         return mapOf(
             "state" to 0,
@@ -609,6 +637,21 @@ object OmniInferModelsManager {
             return mapOf(
                 "state" to 1,
                 "stateLabel" to "downloading",
+                "progress" to progress,
+                "savedSize" to savedSize,
+                "totalSize" to totalSize,
+                "speedInfo" to "",
+                "errorMessage" to "",
+                "progressStage" to stage,
+                "currentFile" to destFile.name,
+                "hasUpdate" to false,
+            )
+        }
+
+        fun toPausedMap(): Map<String, Any?> {
+            return mapOf(
+                "state" to 4,
+                "stateLabel" to "paused",
                 "progress" to progress,
                 "savedSize" to savedSize,
                 "totalSize" to totalSize,

--- a/app/src/main/java/cn/com/omnimind/bot/omniinfer/OmniInferModelsManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/omniinfer/OmniInferModelsManager.kt
@@ -379,10 +379,13 @@ object OmniInferModelsManager {
 
     fun startDownload(modelId: String) {
         if (activeDownloads.containsKey(modelId)) {
+            Log.d(TAG, "[Download] startDownload skipped, already active: $modelId")
             return
         }
+        Log.d(TAG, "[Download] startDownload: $modelId")
         val source = getDownloadProvider()
         val resolved = findRepoAndQuantForModel(modelId, source) ?: run {
+            Log.e(TAG, "[Download] startDownload failed, no download source: $modelId")
             emitEvent("download_error", mapOf("modelId" to modelId, "error" to "No download source"))
             return
         }
@@ -402,9 +405,11 @@ object OmniInferModelsManager {
     }
 
     fun pauseDownload(modelId: String) {
+        Log.d(TAG, "[Download] pauseDownload: $modelId, hasActiveTask=${activeDownloads.containsKey(modelId)}")
         val task = activeDownloads.remove(modelId)
         task?.cancel()
         val pausedMap = task?.toPausedMap() ?: buildPausedMapFromPartFiles(modelId)
+        Log.d(TAG, "[Download] pauseDownload: $modelId -> paused state=${pausedMap != null}, progress=${pausedMap?.get("progress")}, savedSize=${pausedMap?.get("savedSize")}")
         if (pausedMap != null) {
             emitEvent(
                 "download_update",
@@ -714,7 +719,11 @@ object OmniInferModelsManager {
             OmniInferModelsManager.scope.launch {
                 try {
                     stage = "downloading"
-                    if (!downloadFile(url, destFile)) return@launch
+                    Log.d(TAG, "[Download] task started: $modelId, url=$url")
+                    if (!downloadFile(url, destFile)) {
+                        Log.d(TAG, "[Download] task cancelled during main file: $modelId")
+                        return@launch
+                    }
 
                     // Download mmproj if needed
                     if (mmprojUrl != null && mmprojDest != null && !cancelled.get()) {
@@ -723,12 +732,17 @@ object OmniInferModelsManager {
                             progress = 0.0
                             savedSize = 0L
                             totalSize = 0L
+                            Log.d(TAG, "[Download] downloading mmproj: $modelId")
                             OmniInferModelsManager.emitEvent("downloads_changed", mapOf("modelId" to modelId))
-                            if (!downloadFile(mmprojUrl, mmprojDest)) return@launch
+                            if (!downloadFile(mmprojUrl, mmprojDest)) {
+                                Log.d(TAG, "[Download] task cancelled during mmproj: $modelId")
+                                return@launch
+                            }
                         }
                     }
 
                     if (!cancelled.get()) {
+                        Log.d(TAG, "[Download] task completed: $modelId")
                         OmniInferModelsManager.activeDownloads.remove(modelId)
                         OmniInferModelsManager.emitEvent("downloads_changed", mapOf("modelId" to modelId))
                         OmniInferModelsManager.appContext?.let {
@@ -739,6 +753,7 @@ object OmniInferModelsManager {
                         }
                     }
                 } catch (error: Exception) {
+                    Log.e(TAG, "[Download] task error: $modelId, cancelled=${cancelled.get()}, error=${error.message}")
                     if (!cancelled.get()) {
                         OmniInferModelsManager.activeDownloads.remove(modelId)
                         OmniInferModelsManager.emitEvent(

--- a/ui/lib/features/home/pages/local_models/local_models_page.dart
+++ b/ui/lib/features/home/pages/local_models/local_models_page.dart
@@ -281,6 +281,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
         final download = rawDownload is Map
             ? MnnLocalDownloadInfo.fromMap(rawDownload)
             : null;
+        _showDownloadStateToast(modelId, download);
         _updateMarketDownloadState(modelId, download);
         if (download?.isCompleted == true) {
           _refreshInstalled(silent: true);
@@ -301,6 +302,38 @@ class _LocalModelsPageState extends State<LocalModelsPage>
         }
         break;
       default:
+        break;
+    }
+  }
+
+  void _showDownloadStateToast(String modelId, MnnLocalDownloadInfo? download) {
+    if (download == null || modelId.isEmpty) return;
+    final newState = download.stateLabel;
+    // Look up previous state from the current market model list.
+    final prevModel = _marketModels.where((m) => m.id == modelId).firstOrNull;
+    final prevState = prevModel?.download?.stateLabel ?? 'not_started';
+    if (newState == prevState) return;
+
+    final name = _displayModelName(modelId);
+    final l10n = context.l10n;
+
+    // Toast for terminal/async state transitions only.
+    // User-initiated actions (start/pause) are toasted from button handlers.
+    switch (newState) {
+      case 'completed':
+        showToast(l10n.localModelsDownloadCompletedToast(name), type: ToastType.success);
+        break;
+      case 'failed':
+        final reason = download.errorMessage.trim().isNotEmpty
+            ? download.errorMessage.trim()
+            : l10n.localModelsDownloadErrorUnknown;
+        showToast(l10n.localModelsDownloadFailedToast(name, reason), type: ToastType.error);
+        break;
+      case 'cancelled':
+        final reason = download.errorMessage.trim().isNotEmpty
+            ? download.errorMessage.trim()
+            : l10n.localModelsDownloadErrorUnknown;
+        showToast(l10n.localModelsDownloadCancelledToast(name, reason), type: ToastType.error);
         break;
     }
   }
@@ -1436,6 +1469,12 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                     );
                     try {
                       await MnnLocalModelsService.startDownload(model.id);
+                      if (mounted) {
+                        showToast(
+                          context.l10n.localModelsDownloadStartedToast(model.name),
+                          type: ToastType.success,
+                        );
+                      }
                       _refreshMarket(silent: true);
                     } catch (_) {
                       _refreshMarket(silent: true);
@@ -1470,6 +1509,12 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                     );
                     try {
                       await MnnLocalModelsService.pauseDownload(model.id);
+                      if (mounted) {
+                        showToast(
+                          context.l10n.localModelsDownloadPausedToast(model.name),
+                          type: ToastType.warning,
+                        );
+                      }
                       _refreshMarket(silent: true);
                     } catch (_) {
                       _refreshMarket(silent: true);

--- a/ui/lib/features/home/pages/local_models/local_models_page.dart
+++ b/ui/lib/features/home/pages/local_models/local_models_page.dart
@@ -59,7 +59,6 @@ class _LocalModelsPageState extends State<LocalModelsPage>
   bool _loadingInstalled = true;
   bool _loadingMarket = true;
   bool _loadingConfig = true;
-  bool _togglingApiService = false;
 
   @override
   void initState() {
@@ -394,45 +393,6 @@ class _LocalModelsPageState extends State<LocalModelsPage>
     }
   }
 
-  Future<void> _toggleApiService(bool enable) async {
-    final config = _config;
-    if (config == null || _togglingApiService) {
-      return;
-    }
-    setState(() => _togglingApiService = true);
-    try {
-      final nextConfig = enable
-          ? await MnnLocalModelsService.startApiService(
-              modelId: config.activeModelId.isEmpty
-                  ? null
-                  : config.activeModelId,
-            )
-          : await MnnLocalModelsService.stopApiService();
-      if (!mounted) return;
-      setState(() => _config = nextConfig);
-      _refreshInstalled(silent: true);
-      final apiRunning = nextConfig.apiRunning;
-      if (enable) {
-        showToast(
-          apiRunning ? context.l10n.localModelsServiceStarted : context.l10n.localModelsStartFailed,
-          type: apiRunning ? ToastType.success : ToastType.error,
-        );
-      } else {
-        showToast(
-          apiRunning ? context.l10n.localModelsStopFailed : context.l10n.localModelsServiceStopped,
-          type: apiRunning ? ToastType.error : ToastType.success,
-        );
-      }
-    } catch (_) {
-      if (mounted) {
-        showToast(enable ? context.l10n.localModelsStartFailed : context.l10n.localModelsStopFailed, type: ToastType.error);
-      }
-    } finally {
-      if (mounted) {
-        setState(() => _togglingApiService = false);
-      }
-    }
-  }
 
   void _updateMarketDownloadState(
     String modelId,
@@ -513,11 +473,6 @@ class _LocalModelsPageState extends State<LocalModelsPage>
       default:
         return l10n.localModelsNotDownloaded;
     }
-  }
-
-  bool _shouldEnableStart(MnnLocalConfig config) {
-    return !_togglingApiService &&
-        !(config.activeModelId.isEmpty && _serviceModels.isEmpty);
   }
 
   Color _blend(Color first, Color second, double t) {
@@ -1011,31 +966,6 @@ class _LocalModelsPageState extends State<LocalModelsPage>
     );
   }
 
-  Widget _buildServiceActionButton(MnnLocalConfig config) {
-    final shouldStop = config.apiRunning;
-    final enabled = shouldStop
-        ? !_togglingApiService
-        : _shouldEnableStart(config);
-    final tone = shouldStop ? _AccentTone.danger : _AccentTone.accent;
-    final l10n = context.l10n;
-    final label = _togglingApiService
-        ? (shouldStop ? l10n.localModelsStopping : l10n.localModelsStarting)
-        : (shouldStop ? l10n.localModelsStopService : l10n.localModelsStartService);
-
-    return SizedBox(
-      width: double.infinity,
-      child: FilledButton.icon(
-        onPressed: enabled ? () => _toggleApiService(!shouldStop) : null,
-        style: _filledButtonStyle(tone: tone),
-        icon: Icon(
-          shouldStop ? Icons.stop_circle_outlined : Icons.play_arrow_rounded,
-          size: 18,
-        ),
-        label: Text(label),
-      ),
-    );
-  }
-
   Widget _buildServiceTab() {
     if (_loadingConfig && _config == null) {
       return const Center(child: CircularProgressIndicator());
@@ -1113,8 +1043,6 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                   '${_backendLabel(config.loadedBackend)} / ${_displayModelName(config.loadedModelId)}',
             ),
           ],
-          const SizedBox(height: 12),
-          _buildServiceActionButton(config),
           const SizedBox(height: 24),
           SettingsSectionTitle(
             label: context.l10n.localModelsAutoPreheatSection,

--- a/ui/lib/features/home/pages/local_models/local_models_page.dart
+++ b/ui/lib/features/home/pages/local_models/local_models_page.dart
@@ -274,6 +274,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
 
   void _handleEvent(MnnLocalEvent event) {
     if (!mounted) return;
+    debugPrint('[LocalModels] event: ${event.type}, payload keys: ${event.payload.keys}');
     switch (event.type) {
       case 'download_update':
         final modelId = (event.payload['modelId'] ?? '').toString();
@@ -281,6 +282,15 @@ class _LocalModelsPageState extends State<LocalModelsPage>
         final download = rawDownload is Map
             ? MnnLocalDownloadInfo.fromMap(rawDownload)
             : null;
+        final prevState = _marketModels
+            .where((m) => m.id == modelId)
+            .firstOrNull
+            ?.download
+            ?.stateLabel ?? 'not_started';
+        debugPrint('[LocalModels] download_update: model=$modelId, '
+            'prevState=$prevState -> newState=${download?.stateLabel}, '
+            'progress=${download?.progress.toStringAsFixed(2)}, '
+            'error=${download?.errorMessage}');
         _showDownloadStateToast(modelId, download);
         _updateMarketDownloadState(modelId, download);
         if (download?.isCompleted == true) {
@@ -290,6 +300,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
       case 'download_error':
         final errorModelId = (event.payload['modelId'] ?? '').toString();
         final errorMsg = (event.payload['error'] ?? '').toString();
+        debugPrint('[LocalModels] download_error: model=$errorModelId, error=$errorMsg');
         if (errorModelId.isNotEmpty) {
           final name = _displayModelName(errorModelId);
           final reason = errorMsg.trim().isNotEmpty
@@ -303,6 +314,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
         }
         break;
       case 'downloads_changed':
+        debugPrint('[LocalModels] downloads_changed: ${event.payload}');
         _refreshInstalled(silent: true);
         _refreshMarket(silent: true);
         break;
@@ -331,23 +343,28 @@ class _LocalModelsPageState extends State<LocalModelsPage>
 
     final name = _displayModelName(modelId);
     final l10n = context.l10n;
+    debugPrint('[LocalModels] state transition: model=$modelId ($name), '
+        '$prevState -> $newState');
 
     // Toast for terminal/async state transitions only.
     // User-initiated actions (start/pause) are toasted from button handlers.
     switch (newState) {
       case 'completed':
+        debugPrint('[LocalModels] toast: download completed -> $name');
         showToast(l10n.localModelsDownloadCompletedToast(name), type: ToastType.success);
         break;
       case 'failed':
         final reason = download.errorMessage.trim().isNotEmpty
             ? download.errorMessage.trim()
             : l10n.localModelsDownloadErrorUnknown;
+        debugPrint('[LocalModels] toast: download failed -> $name, reason=$reason');
         showToast(l10n.localModelsDownloadFailedToast(name, reason), type: ToastType.error);
         break;
       case 'cancelled':
         final reason = download.errorMessage.trim().isNotEmpty
             ? download.errorMessage.trim()
             : l10n.localModelsDownloadErrorUnknown;
+        debugPrint('[LocalModels] toast: download cancelled -> $name, reason=$reason');
         showToast(l10n.localModelsDownloadCancelledToast(name, reason), type: ToastType.error);
         break;
     }
@@ -1474,6 +1491,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
               if (!isCompleted && !isDownloading)
                 FilledButton.icon(
                   onPressed: () async {
+                    debugPrint('[LocalModels] button: startDownload model=${model.id} (${model.name}), isPaused=$isPaused, isFailed=$isFailed');
                     _updateMarketDownloadState(
                       model.id,
                       _downloadPlaceholder(
@@ -1484,6 +1502,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                     );
                     try {
                       await MnnLocalModelsService.startDownload(model.id);
+                      debugPrint('[LocalModels] button: startDownload success model=${model.id}');
                       if (mounted) {
                         showToast(
                           context.l10n.localModelsDownloadStartedToast(model.name),
@@ -1491,7 +1510,8 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                         );
                       }
                       _refreshMarket(silent: true);
-                    } catch (_) {
+                    } catch (e) {
+                      debugPrint('[LocalModels] button: startDownload error model=${model.id}, error=$e');
                       _refreshMarket(silent: true);
                       showToast(context.l10n.localModelsDownloadStartFailed, type: ToastType.error);
                     }
@@ -1514,6 +1534,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
               if (isDownloading)
                 OutlinedButton.icon(
                   onPressed: () async {
+                    debugPrint('[LocalModels] button: pauseDownload model=${model.id} (${model.name})');
                     _updateMarketDownloadState(
                       model.id,
                       _downloadPlaceholder(
@@ -1524,6 +1545,7 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                     );
                     try {
                       await MnnLocalModelsService.pauseDownload(model.id);
+                      debugPrint('[LocalModels] button: pauseDownload success model=${model.id}');
                       if (mounted) {
                         showToast(
                           context.l10n.localModelsDownloadPausedToast(model.name),
@@ -1531,7 +1553,8 @@ class _LocalModelsPageState extends State<LocalModelsPage>
                         );
                       }
                       _refreshMarket(silent: true);
-                    } catch (_) {
+                    } catch (e) {
+                      debugPrint('[LocalModels] button: pauseDownload error model=${model.id}, error=$e');
                       _refreshMarket(silent: true);
                       showToast(context.l10n.localModelsDownloadPauseFailed, type: ToastType.error);
                     }

--- a/ui/lib/features/home/pages/local_models/local_models_page.dart
+++ b/ui/lib/features/home/pages/local_models/local_models_page.dart
@@ -287,6 +287,21 @@ class _LocalModelsPageState extends State<LocalModelsPage>
           _refreshInstalled(silent: true);
         }
         break;
+      case 'download_error':
+        final errorModelId = (event.payload['modelId'] ?? '').toString();
+        final errorMsg = (event.payload['error'] ?? '').toString();
+        if (errorModelId.isNotEmpty) {
+          final name = _displayModelName(errorModelId);
+          final reason = errorMsg.trim().isNotEmpty
+              ? errorMsg.trim()
+              : context.l10n.localModelsDownloadErrorUnknown;
+          showToast(
+            context.l10n.localModelsDownloadFailedToast(name, reason),
+            type: ToastType.error,
+          );
+          _refreshMarket(silent: true);
+        }
+        break;
       case 'downloads_changed':
         _refreshInstalled(silent: true);
         _refreshMarket(silent: true);

--- a/ui/lib/l10n/app_en.arb
+++ b/ui/lib/l10n/app_en.arb
@@ -280,6 +280,39 @@
   "localModelsServiceStopped": "Local service stopped",
   "localModelsDownloadStartFailed": "Failed to start download",
   "localModelsDownloadPauseFailed": "Failed to pause download",
+  "localModelsDownloadStartedToast": "Download started: {modelName}",
+  "@localModelsDownloadStartedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" }
+    }
+  },
+  "localModelsDownloadPausedToast": "Download paused: {modelName}",
+  "@localModelsDownloadPausedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" }
+    }
+  },
+  "localModelsDownloadCompletedToast": "Download completed: {modelName}",
+  "@localModelsDownloadCompletedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" }
+    }
+  },
+  "localModelsDownloadFailedToast": "Download failed: {modelName} — {reason}",
+  "@localModelsDownloadFailedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" },
+      "reason": { "type": "String" }
+    }
+  },
+  "localModelsDownloadCancelledToast": "Download cancelled: {modelName} — {reason}",
+  "@localModelsDownloadCancelledToast": {
+    "placeholders": {
+      "modelName": { "type": "String" },
+      "reason": { "type": "String" }
+    }
+  },
+  "localModelsDownloadErrorUnknown": "Unknown error",
   "localModelsFilterAndSource": "Filter & Source",
   "localModelsFilterAndSourceDesc": "Switch inference backend and download source; affects the current market list.",
   "localModelsDownloadSource": "Download Source",

--- a/ui/lib/l10n/app_zh.arb
+++ b/ui/lib/l10n/app_zh.arb
@@ -280,6 +280,39 @@
   "localModelsServiceStopped": "本地服务已停止",
   "localModelsDownloadStartFailed": "启动下载失败",
   "localModelsDownloadPauseFailed": "暂停下载失败",
+  "localModelsDownloadStartedToast": "开始下载：{modelName}",
+  "@localModelsDownloadStartedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" }
+    }
+  },
+  "localModelsDownloadPausedToast": "下载已暂停：{modelName}",
+  "@localModelsDownloadPausedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" }
+    }
+  },
+  "localModelsDownloadCompletedToast": "下载完成：{modelName}",
+  "@localModelsDownloadCompletedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" }
+    }
+  },
+  "localModelsDownloadFailedToast": "下载失败：{modelName} — {reason}",
+  "@localModelsDownloadFailedToast": {
+    "placeholders": {
+      "modelName": { "type": "String" },
+      "reason": { "type": "String" }
+    }
+  },
+  "localModelsDownloadCancelledToast": "下载已取消：{modelName} — {reason}",
+  "@localModelsDownloadCancelledToast": {
+    "placeholders": {
+      "modelName": { "type": "String" },
+      "reason": { "type": "String" }
+    }
+  },
+  "localModelsDownloadErrorUnknown": "未知错误",
   "localModelsFilterAndSource": "筛选与来源",
   "localModelsFilterAndSourceDesc": "切换推理后端和下载源，影响当前市场列表。",
   "localModelsDownloadSource": "下载源",

--- a/ui/lib/l10n/generated/app_localizations.dart
+++ b/ui/lib/l10n/generated/app_localizations.dart
@@ -1736,6 +1736,42 @@ abstract class AppLocalizations {
   /// **'暂停下载失败'**
   String get localModelsDownloadPauseFailed;
 
+  /// No description provided for @localModelsDownloadStartedToast.
+  ///
+  /// In zh, this message translates to:
+  /// **'开始下载：{modelName}'**
+  String localModelsDownloadStartedToast(String modelName);
+
+  /// No description provided for @localModelsDownloadPausedToast.
+  ///
+  /// In zh, this message translates to:
+  /// **'下载已暂停：{modelName}'**
+  String localModelsDownloadPausedToast(String modelName);
+
+  /// No description provided for @localModelsDownloadCompletedToast.
+  ///
+  /// In zh, this message translates to:
+  /// **'下载完成：{modelName}'**
+  String localModelsDownloadCompletedToast(String modelName);
+
+  /// No description provided for @localModelsDownloadFailedToast.
+  ///
+  /// In zh, this message translates to:
+  /// **'下载失败：{modelName} — {reason}'**
+  String localModelsDownloadFailedToast(String modelName, String reason);
+
+  /// No description provided for @localModelsDownloadCancelledToast.
+  ///
+  /// In zh, this message translates to:
+  /// **'下载已取消：{modelName} — {reason}'**
+  String localModelsDownloadCancelledToast(String modelName, String reason);
+
+  /// No description provided for @localModelsDownloadErrorUnknown.
+  ///
+  /// In zh, this message translates to:
+  /// **'未知错误'**
+  String get localModelsDownloadErrorUnknown;
+
   /// No description provided for @localModelsFilterAndSource.
   ///
   /// In zh, this message translates to:

--- a/ui/lib/l10n/generated/app_localizations_en.dart
+++ b/ui/lib/l10n/generated/app_localizations_en.dart
@@ -921,6 +921,34 @@ class AppLocalizationsEn extends AppLocalizations {
   String get localModelsDownloadPauseFailed => 'Failed to pause download';
 
   @override
+  String localModelsDownloadStartedToast(String modelName) {
+    return 'Download started: $modelName';
+  }
+
+  @override
+  String localModelsDownloadPausedToast(String modelName) {
+    return 'Download paused: $modelName';
+  }
+
+  @override
+  String localModelsDownloadCompletedToast(String modelName) {
+    return 'Download completed: $modelName';
+  }
+
+  @override
+  String localModelsDownloadFailedToast(String modelName, String reason) {
+    return 'Download failed: $modelName — $reason';
+  }
+
+  @override
+  String localModelsDownloadCancelledToast(String modelName, String reason) {
+    return 'Download cancelled: $modelName — $reason';
+  }
+
+  @override
+  String get localModelsDownloadErrorUnknown => 'Unknown error';
+
+  @override
   String get localModelsFilterAndSource => 'Filter & Source';
 
   @override

--- a/ui/lib/l10n/generated/app_localizations_zh.dart
+++ b/ui/lib/l10n/generated/app_localizations_zh.dart
@@ -866,6 +866,34 @@ class AppLocalizationsZh extends AppLocalizations {
   String get localModelsDownloadPauseFailed => '暂停下载失败';
 
   @override
+  String localModelsDownloadStartedToast(String modelName) {
+    return '开始下载：$modelName';
+  }
+
+  @override
+  String localModelsDownloadPausedToast(String modelName) {
+    return '下载已暂停：$modelName';
+  }
+
+  @override
+  String localModelsDownloadCompletedToast(String modelName) {
+    return '下载完成：$modelName';
+  }
+
+  @override
+  String localModelsDownloadFailedToast(String modelName, String reason) {
+    return '下载失败：$modelName — $reason';
+  }
+
+  @override
+  String localModelsDownloadCancelledToast(String modelName, String reason) {
+    return '下载已取消：$modelName — $reason';
+  }
+
+  @override
+  String get localModelsDownloadErrorUnknown => '未知错误';
+
+  @override
   String get localModelsFilterAndSource => '筛选与来源';
 
   @override


### PR DESCRIPTION
## 变更摘要

修复本地模型load 的逻辑，不需要再在local models页面启动模型，因为作为一个服务商，不应该指定模型load，用户可以直接在聊天页面选择模型，然后聊天的时候启动即可
修复本地模型下载市场没有按照下载源筛选模型的问题

## 变更类型

- [ ] Bug 修复

