### PR TITLE
feat: Implement beta opt-in feature for app updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release APK (Draft)
+name: Release APK
 
 on:
   push:
@@ -24,6 +24,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+
+      - name: Determine release mode
+        id: release_mode
+        shell: bash
+        run: |
+          NORMALIZED_REF="${GITHUB_REF_NAME#v}"
+          if [[ "$NORMALIZED_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "track=beta" >> "$GITHUB_OUTPUT"
+            echo "draft=false" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$NORMALIZED_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "track=stable" >> "$GITHUB_OUTPUT"
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "track=custom" >> "$GITHUB_OUTPUT"
+            echo "draft=true" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Initialize required OmniInfer submodules
         run: |
@@ -130,10 +149,11 @@ jobs:
             app/build/outputs/apk/production/release/${{ env.RELEASE_APK_NAME }}
             app/build/outputs/apk/production/release/${{ env.RELEASE_APK_NAME }}.sha256
 
-      - name: Create Draft GitHub Release
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: ${{ steps.release_mode.outputs.draft == 'true' }}
+          prerelease: ${{ steps.release_mode.outputs.prerelease == 'true' }}
           generate_release_notes: true
           files: |
             app/build/outputs/apk/production/release/${{ env.RELEASE_APK_NAME }}

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AppUpdateChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AppUpdateChannel.kt
@@ -35,6 +35,15 @@ class AppUpdateChannel {
         }
 
         when (call.method) {
+            "getBetaOptIn" -> {
+                result.success(AppUpdateManager.isBetaOptIn(safeContext))
+            }
+
+            "setBetaOptIn" -> {
+                val enabled = call.argument<Boolean>("enabled") == true
+                result.success(AppUpdateManager.setBetaOptIn(safeContext, enabled))
+            }
+
             "getCachedStatus" -> {
                 result.success(AppUpdateManager.getCachedStatus(safeContext).toMap())
             }

--- a/app/src/main/java/cn/com/omnimind/bot/update/AppUpdateManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/update/AppUpdateManager.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
-import org.json.JSONObject
 import java.io.IOException
 import java.time.Instant
 import java.util.Locale
@@ -54,9 +53,27 @@ internal data class ReleaseAsset(
     val downloadUrl: String
 )
 
+@VisibleForTesting
+internal enum class ReleaseTrack {
+    STABLE,
+    BETA,
+    UNSUPPORTED
+}
+
+@VisibleForTesting
+internal data class ReleaseCandidate(
+    val version: String,
+    val track: ReleaseTrack,
+    val publishedAt: Long,
+    val releaseUrl: String,
+    val releaseNotes: String,
+    val assets: List<ReleaseAsset>
+)
+
 object AppUpdateManager {
     private const val TAG = "AppUpdateManager"
     private const val PREFS_NAME = "app_update_state"
+    private const val KEY_BETA_OPT_IN = "beta_opt_in"
     private const val KEY_LATEST_VERSION = "latest_version"
     private const val KEY_HAS_UPDATE = "has_update"
     private const val KEY_CHECKED_AT = "checked_at"
@@ -66,8 +83,8 @@ object AppUpdateManager {
     private const val KEY_APK_NAME = "apk_name"
     private const val KEY_APK_DOWNLOAD_URL = "apk_download_url"
 
-    private const val LATEST_RELEASE_URL =
-        "https://api.github.com/repos/omnimind-ai/OpenOmniBot/releases/latest"
+    private const val RELEASES_URL =
+        "https://api.github.com/repos/omnimind-ai/OpenOmniBot/releases?per_page=30"
     private const val WORK_NAME = "app_update_periodic_check"
     private const val PERIODIC_CHECK_HOURS = 12L
     private const val SILENT_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000L
@@ -113,19 +130,43 @@ object AppUpdateManager {
     }
 
     fun getCachedStatus(context: Context): AppUpdateState {
-        return readState(context.applicationContext, currentVersion(context.applicationContext))
+        val appContext = context.applicationContext
+        return readState(
+            context = appContext,
+            currentVersion = currentVersion(appContext),
+            includeBeta = isBetaOptIn(appContext)
+        )
+    }
+
+    fun isBetaOptIn(context: Context): Boolean {
+        return context.applicationContext
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_BETA_OPT_IN, false)
+    }
+
+    fun setBetaOptIn(context: Context, enabled: Boolean): Boolean {
+        val prefs = context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val changed = prefs.getBoolean(KEY_BETA_OPT_IN, false) != enabled
+        prefs.edit().apply {
+            putBoolean(KEY_BETA_OPT_IN, enabled)
+            if (changed) {
+                putLong(KEY_CHECKED_AT, 0L)
+            }
+        }.apply()
+        return enabled
     }
 
     suspend fun checkNow(context: Context, force: Boolean): AppUpdateState {
         val appContext = context.applicationContext
         val now = System.currentTimeMillis()
         val currentVersion = currentVersion(appContext)
-        val cached = readState(appContext, currentVersion)
+        val includeBeta = isBetaOptIn(appContext)
+        val cached = readState(appContext, currentVersion, includeBeta)
         if (!force && now - cached.checkedAt < SILENT_CHECK_INTERVAL_MS) {
             return cached
         }
 
-        val fetched = fetchLatestReleaseState(currentVersion)
+        val fetched = fetchLatestReleaseState(currentVersion, includeBeta)
             .copy(checkedAt = now)
         saveState(appContext, fetched)
         return fetched
@@ -169,9 +210,9 @@ object AppUpdateManager {
         val right = normalizeVersion(rightRaw)
         if (left == right) return 0
 
-        val leftParts = left.split('.').mapNotNull { it.toIntOrNull() }
-        val rightParts = right.split('.').mapNotNull { it.toIntOrNull() }
-        if (leftParts.isNotEmpty() && rightParts.isNotEmpty()) {
+        val leftParts = parseNumericVersionParts(left)
+        val rightParts = parseNumericVersionParts(right)
+        if (leftParts != null && rightParts != null) {
             val maxLength = maxOf(leftParts.size, rightParts.size)
             for (index in 0 until maxLength) {
                 val leftValue = leftParts.getOrElse(index) { 0 }
@@ -184,6 +225,52 @@ object AppUpdateManager {
         }
 
         return left.compareTo(right)
+    }
+
+    @VisibleForTesting
+    internal fun versionSegmentCount(raw: String?): Int {
+        val normalized = normalizeVersion(raw)
+        if (normalized.isBlank()) return 0
+        val parts = normalized.split('.')
+        if (parts.any { part -> part.isBlank() || part.any { !it.isDigit() } }) {
+            return 0
+        }
+        return parts.size
+    }
+
+    @VisibleForTesting
+    internal fun classifyReleaseTrack(rawVersion: String?, prerelease: Boolean = false): ReleaseTrack {
+        if (prerelease) {
+            return ReleaseTrack.BETA
+        }
+        return when (versionSegmentCount(rawVersion)) {
+            3 -> ReleaseTrack.STABLE
+            4 -> ReleaseTrack.BETA
+            else -> ReleaseTrack.UNSUPPORTED
+        }
+    }
+
+    @VisibleForTesting
+    internal fun selectLatestRelease(
+        candidates: List<ReleaseCandidate>,
+        includeBeta: Boolean
+    ): ReleaseCandidate? {
+        var selected: ReleaseCandidate? = null
+        for (candidate in candidates) {
+            if (!shouldIncludeTrack(candidate.track, includeBeta)) continue
+            val currentSelected = selected
+            if (
+                currentSelected == null ||
+                compareVersions(candidate.version, currentSelected.version) > 0 ||
+                (
+                    compareVersions(candidate.version, currentSelected.version) == 0 &&
+                        candidate.publishedAt > currentSelected.publishedAt
+                    )
+            ) {
+                selected = candidate
+            }
+        }
+        return selected
     }
 
     @VisibleForTesting
@@ -205,23 +292,27 @@ object AppUpdateManager {
         return checkNow(context, force = true)
     }
 
-    private fun readState(context: Context, currentVersion: String): AppUpdateState {
+    private fun readState(context: Context, currentVersion: String, includeBeta: Boolean): AppUpdateState {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        val latestVersion = prefs.getString(KEY_LATEST_VERSION, currentVersion).orEmpty().ifBlank {
-            currentVersion
-        }
-        val hasUpdate = prefs.getBoolean(KEY_HAS_UPDATE, false) &&
-            compareVersions(latestVersion, currentVersion) > 0
-        return AppUpdateState(
+        val storedState = AppUpdateState(
             currentVersion = currentVersion,
-            latestVersion = latestVersion,
-            hasUpdate = hasUpdate,
+            latestVersion = prefs.getString(KEY_LATEST_VERSION, currentVersion).orEmpty().ifBlank {
+                currentVersion
+            },
+            hasUpdate = prefs.getBoolean(KEY_HAS_UPDATE, false),
             checkedAt = prefs.getLong(KEY_CHECKED_AT, 0L),
             publishedAt = prefs.getLong(KEY_PUBLISHED_AT, 0L),
             releaseUrl = prefs.getString(KEY_RELEASE_URL, "").orEmpty(),
             releaseNotes = prefs.getString(KEY_RELEASE_NOTES, "").orEmpty(),
             apkName = prefs.getString(KEY_APK_NAME, "").orEmpty(),
             apkDownloadUrl = prefs.getString(KEY_APK_DOWNLOAD_URL, "").orEmpty()
+        )
+        if (!shouldIncludeTrack(classifyReleaseTrack(storedState.latestVersion), includeBeta)) {
+            return emptyState(currentVersion = currentVersion, checkedAt = storedState.checkedAt)
+        }
+        return storedState.copy(
+            hasUpdate = storedState.hasUpdate &&
+                compareVersions(storedState.latestVersion, currentVersion) > 0
         )
     }
 
@@ -246,9 +337,9 @@ object AppUpdateManager {
             ?: "0.0.0"
     }
 
-    private fun fetchLatestReleaseState(currentVersion: String): AppUpdateState {
+    private fun fetchLatestReleaseState(currentVersion: String, includeBeta: Boolean): AppUpdateState {
         val request = Request.Builder()
-            .url(LATEST_RELEASE_URL)
+            .url(RELEASES_URL)
             .addHeader("Accept", "application/vnd.github+json")
             .addHeader("X-GitHub-Api-Version", "2022-11-28")
             .addHeader("User-Agent", USER_AGENT)
@@ -265,40 +356,45 @@ object AppUpdateManager {
                 throw IOException("GitHub release response body is empty")
             }
 
-            val release = JSONObject(body)
-            if (release.optBoolean("draft") || release.optBoolean("prerelease")) {
-                return AppUpdateState(
-                    currentVersion = currentVersion,
-                    latestVersion = currentVersion,
-                    hasUpdate = false,
-                    checkedAt = System.currentTimeMillis(),
-                    publishedAt = 0L,
-                    releaseUrl = "",
-                    releaseNotes = "",
-                    apkName = "",
-                    apkDownloadUrl = ""
-                )
-            }
-            val latestVersion = normalizeVersion(release.optString("tag_name"))
-                .ifBlank { currentVersion }
-            val releaseUrl = release.optString("html_url")
-            val releaseNotes = release.optString("body")
-            val publishedAt = parseGithubTimeToMillis(release.optString("published_at"))
-            val assets = parseAssets(release.optJSONArray("assets"))
-            val preferredAsset = selectPreferredApkAsset(assets)
+            val selectedRelease = selectLatestRelease(
+                candidates = parseReleaseCandidates(JSONArray(body)),
+                includeBeta = includeBeta
+            ) ?: return emptyState(currentVersion, checkedAt = System.currentTimeMillis())
+            val preferredAsset = selectPreferredApkAsset(selectedRelease.assets)
 
             return AppUpdateState(
                 currentVersion = currentVersion,
-                latestVersion = latestVersion,
-                hasUpdate = compareVersions(latestVersion, currentVersion) > 0,
+                latestVersion = selectedRelease.version,
+                hasUpdate = compareVersions(selectedRelease.version, currentVersion) > 0,
                 checkedAt = System.currentTimeMillis(),
-                publishedAt = publishedAt,
-                releaseUrl = releaseUrl,
-                releaseNotes = releaseNotes,
+                publishedAt = selectedRelease.publishedAt,
+                releaseUrl = selectedRelease.releaseUrl,
+                releaseNotes = selectedRelease.releaseNotes,
                 apkName = preferredAsset?.name.orEmpty(),
                 apkDownloadUrl = preferredAsset?.downloadUrl.orEmpty()
             )
         }
+    }
+
+    private fun parseReleaseCandidates(array: JSONArray?): List<ReleaseCandidate> {
+        if (array == null) return emptyList()
+        val candidates = mutableListOf<ReleaseCandidate>()
+        for (index in 0 until array.length()) {
+            val raw = array.optJSONObject(index) ?: continue
+            if (raw.optBoolean("draft")) continue
+            val version = normalizeVersion(raw.optString("tag_name"))
+            val track = classifyReleaseTrack(version, prerelease = raw.optBoolean("prerelease"))
+            if (track == ReleaseTrack.UNSUPPORTED || version.isBlank()) continue
+            candidates += ReleaseCandidate(
+                version = version,
+                track = track,
+                publishedAt = parseGithubTimeToMillis(raw.optString("published_at")),
+                releaseUrl = raw.optString("html_url"),
+                releaseNotes = raw.optString("body"),
+                assets = parseAssets(raw.optJSONArray("assets"))
+            )
+        }
+        return candidates
     }
 
     private fun parseAssets(array: JSONArray?): List<ReleaseAsset> {
@@ -318,6 +414,37 @@ object AppUpdateManager {
     private fun parseGithubTimeToMillis(raw: String?): Long {
         if (raw.isNullOrBlank()) return 0L
         return runCatching { Instant.parse(raw).toEpochMilli() }.getOrDefault(0L)
+    }
+
+    private fun emptyState(currentVersion: String, checkedAt: Long = 0L): AppUpdateState {
+        return AppUpdateState(
+            currentVersion = currentVersion,
+            latestVersion = currentVersion,
+            hasUpdate = false,
+            checkedAt = checkedAt,
+            publishedAt = 0L,
+            releaseUrl = "",
+            releaseNotes = "",
+            apkName = "",
+            apkDownloadUrl = ""
+        )
+    }
+
+    private fun parseNumericVersionParts(raw: String): List<Int>? {
+        if (raw.isBlank()) return null
+        val parts = raw.split('.')
+        if (parts.any { part -> part.isBlank() || part.any { !it.isDigit() } }) {
+            return null
+        }
+        return parts.map { it.toInt() }
+    }
+
+    private fun shouldIncludeTrack(track: ReleaseTrack, includeBeta: Boolean): Boolean {
+        return when (track) {
+            ReleaseTrack.STABLE -> true
+            ReleaseTrack.BETA -> includeBeta
+            ReleaseTrack.UNSUPPORTED -> false
+        }
     }
 }
 

--- a/app/src/test/java/cn/com/omnimind/bot/update/AppUpdateManagerTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/update/AppUpdateManagerTest.kt
@@ -16,6 +16,46 @@ class AppUpdateManagerTest {
         assertEquals(1, AppUpdateManager.compareVersions("0.0.2", "0.0.1"))
         assertEquals(0, AppUpdateManager.compareVersions("v1.2.0", "1.2"))
         assertEquals(-1, AppUpdateManager.compareVersions("1.9.9", "2.0.0"))
+        assertEquals(1, AppUpdateManager.compareVersions("1.6.1.2", "1.6.1"))
+    }
+
+    @Test
+    fun classifyReleaseTrackTreatsFourSegmentsAsBeta() {
+        assertEquals(ReleaseTrack.STABLE, AppUpdateManager.classifyReleaseTrack("1.6.1"))
+        assertEquals(ReleaseTrack.BETA, AppUpdateManager.classifyReleaseTrack("1.6.1.2"))
+        assertEquals(
+            ReleaseTrack.BETA,
+            AppUpdateManager.classifyReleaseTrack("1.6.1", prerelease = true)
+        )
+    }
+
+    @Test
+    fun selectLatestReleaseHonorsBetaOptIn() {
+        val stable = ReleaseCandidate(
+            version = "1.6.2",
+            track = ReleaseTrack.STABLE,
+            publishedAt = 1L,
+            releaseUrl = "https://example.com/stable",
+            releaseNotes = "",
+            assets = emptyList()
+        )
+        val beta = ReleaseCandidate(
+            version = "1.6.2.3",
+            track = ReleaseTrack.BETA,
+            publishedAt = 2L,
+            releaseUrl = "https://example.com/beta",
+            releaseNotes = "",
+            assets = emptyList()
+        )
+
+        assertEquals(
+            "1.6.2",
+            AppUpdateManager.selectLatestRelease(listOf(stable, beta), includeBeta = false)?.version
+        )
+        assertEquals(
+            "1.6.2.3",
+            AppUpdateManager.selectLatestRelease(listOf(stable, beta), includeBeta = true)?.version
+        )
     }
 
     @Test

--- a/ui/lib/features/my/pages/about/about_page.dart
+++ b/ui/lib/features/my/pages/about/about_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_switch/flutter_switch.dart';
 import 'package:ui/l10n/l10n.dart';
 import 'package:ui/core/router/go_router_manager.dart';
 import 'package:ui/services/app_update_service.dart';
@@ -21,12 +22,15 @@ class AboutPage extends StatefulWidget {
 class _AboutPageState extends State<AboutPage> {
   String _version = '';
   AppUpdateStatus? _updateStatus;
+  bool _betaOptIn = false;
   bool _isCheckingUpdate = false;
+  bool _isUpdatingBetaOptIn = false;
 
   @override
   void initState() {
     super.initState();
     AppUpdateService.statusNotifier.addListener(_handleUpdateStatusChanged);
+    AppUpdateService.betaOptInNotifier.addListener(_handleBetaOptInChanged);
     _loadVersion();
     _loadUpdateStatus();
   }
@@ -34,6 +38,7 @@ class _AboutPageState extends State<AboutPage> {
   @override
   void dispose() {
     AppUpdateService.statusNotifier.removeListener(_handleUpdateStatusChanged);
+    AppUpdateService.betaOptInNotifier.removeListener(_handleBetaOptInChanged);
     super.dispose();
   }
 
@@ -64,7 +69,15 @@ class _AboutPageState extends State<AboutPage> {
     await AppUpdateService.initialize();
     if (!mounted) return;
     setState(() {
+      _betaOptIn = AppUpdateService.betaOptInNotifier.value;
       _updateStatus = AppUpdateService.statusNotifier.value;
+    });
+  }
+
+  void _handleBetaOptInChanged() {
+    if (!mounted) return;
+    setState(() {
+      _betaOptIn = AppUpdateService.betaOptInNotifier.value;
     });
   }
 
@@ -73,6 +86,34 @@ class _AboutPageState extends State<AboutPage> {
     setState(() {
       _updateStatus = AppUpdateService.statusNotifier.value;
     });
+  }
+
+  Future<void> _handleToggleBetaOptIn(bool enabled) async {
+    if (_isUpdatingBetaOptIn) return;
+    setState(() {
+      _isUpdatingBetaOptIn = true;
+    });
+
+    try {
+      final updated = await AppUpdateService.setBetaOptIn(enabled);
+      if (!mounted) return;
+      setState(() {
+        _betaOptIn = updated;
+        _updateStatus = AppUpdateService.statusNotifier.value;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      showToast(
+        context.l10n.aboutBetaProgramToggleFailed,
+        type: ToastType.error,
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUpdatingBetaOptIn = false;
+        });
+      }
+    }
   }
 
   Future<void> _handleCheckUpdate() async {
@@ -128,6 +169,88 @@ class _AboutPageState extends State<AboutPage> {
     return context.trLegacy('检查 GitHub Release 获取最新版本');
   }
 
+  Widget _buildBetaOptInCard() {
+    final palette = context.omniPalette;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _isUpdatingBetaOptIn
+            ? null
+            : () => _handleToggleBetaOptIn(!_betaOptIn),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 180),
+          opacity: _isUpdatingBetaOptIn ? 0.72 : 1,
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            decoration: BoxDecoration(
+              color: context.isDarkTheme
+                  ? palette.surfaceSecondary
+                  : const Color(0xFFF5F9FF),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(
+                color: context.isDarkTheme
+                    ? palette.borderStrong
+                    : const Color(0xFFD9E6FB),
+              ),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        context.l10n.aboutBetaProgramTitle,
+                        style: TextStyle(
+                          fontFamily: AppTextStyles.fontFamily,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          color: context.isDarkTheme
+                              ? palette.textPrimary
+                              : AppColors.text,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        context.l10n.aboutBetaProgramDescription,
+                        style: TextStyle(
+                          fontFamily: AppTextStyles.fontFamily,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w400,
+                          height: 1.5,
+                          color: context.isDarkTheme
+                              ? palette.textSecondary
+                              : AppColors.text70,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IgnorePointer(
+                  child: FlutterSwitch(
+                    width: 44.8,
+                    height: 25.0,
+                    toggleSize: 15.3,
+                    padding: 4.8,
+                    activeColor: palette.accentPrimary,
+                    inactiveColor: palette.borderStrong,
+                    value: _betaOptIn,
+                    borderRadius: 28.75,
+                    onToggle: (_) {},
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final palette = context.omniPalette;
@@ -154,147 +277,157 @@ class _AboutPageState extends State<AboutPage> {
       backgroundColor: context.isDarkTheme
           ? palette.pageBackground
           : Colors.white,
-      appBar: CommonAppBar(title: context.l10n.settingsAboutTitle, primary: true),
+      appBar: CommonAppBar(
+        title: context.l10n.settingsAboutTitle,
+        primary: true,
+      ),
       body: SafeArea(
         top: false,
-        child: SizedBox(
-          width: double.infinity,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const SizedBox(height: 80),
-              // Logo
-              SizedBox(
-                width: 167,
-                height: 120,
-                child: Center(
-                  child: Image.asset(
-                    'assets/my/about_icon.png',
-                    width: 167,
-                    height: 120,
-                    fit: BoxFit.contain,
-                    errorBuilder: (context, error, stackTrace) {
-                      return const Icon(
-                        Icons.image,
-                        size: 96,
-                        color: AppColors.primaryBlue,
-                      );
-                    },
-                  ),
-                ),
-              ),
-
-              const SizedBox(height: 24),
-
-              // 描述文字
-              Text(
-                context.l10n.aboutDescription,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontFamily: AppTextStyles.fontFamily,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w400,
-                  color: context.isDarkTheme
-                      ? palette.textSecondary
-                      : AppColors.text70,
-                  letterSpacing: 0.39,
-                  height: 1.5,
-                ),
-              ),
-
-              const Spacer(),
-
-              // 版本号
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    _version,
-                    textAlign: TextAlign.center,
-                    style:
-                        const TextStyle(
-                          fontFamily: AppTextStyles.fontFamily,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w400,
-                          letterSpacing: 0.33,
-                          height: 1.5,
-                        ).copyWith(
-                          color: context.isDarkTheme
-                              ? palette.textSecondary
-                              : AppColors.text70,
-                        ),
-                  ),
-                ],
-              ),
-
-              const SizedBox(height: 10),
-              Text(
-                _buildUpdateHint(),
-                textAlign: TextAlign.center,
-                style:
-                    const TextStyle(
-                      fontFamily: AppTextStyles.fontFamily,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w500,
-                      letterSpacing: 0.3,
-                      height: 1.5,
-                    ).copyWith(
-                      color: context.isDarkTheme
-                          ? palette.textTertiary
-                          : AppColors.text50,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.only(bottom: 32),
+          child: SizedBox(
+            width: double.infinity,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const SizedBox(height: 80),
+                // Logo
+                SizedBox(
+                  width: 167,
+                  height: 120,
+                  child: Center(
+                    child: Image.asset(
+                      'assets/my/about_icon.png',
+                      width: 167,
+                      height: 120,
+                      fit: BoxFit.contain,
+                      errorBuilder: (context, error, stackTrace) {
+                        return const Icon(
+                          Icons.image,
+                          size: 96,
+                          color: AppColors.primaryBlue,
+                        );
+                      },
                     ),
-              ),
-              const SizedBox(height: 16),
-              GradientButton(
-                text: _isCheckingUpdate
-                    ? context.trLegacy('检查中...')
-                    : (_updateStatus?.hasUpdate == true ? context.trLegacy('查看新版本') : context.trLegacy('检查更新')),
-                width: 180,
-                height: 44,
-                gradientColors: updateButtonGradient,
-                textStyle: TextStyle(
-                  color: updateButtonTextColor,
-                  fontSize: 16,
-                  fontFamily: AppTextStyles.fontFamily,
-                  fontWeight: FontWeight.w500,
-                  height: 1.5,
-                  letterSpacing: 0.5,
+                  ),
                 ),
-                enabled: !_isCheckingUpdate,
-                onTap: () {
-                  _handlePrimaryAction();
-                },
-              ),
-              const SizedBox(height: 12),
-              OutlinedButton.icon(
-                onPressed: () {
-                  GoRouterManager.push('/my/about/request-logs');
-                },
-                icon: const Icon(Icons.receipt_long_outlined, size: 18),
-                label: Text(context.trLegacy('请求日志')),
-                style: OutlinedButton.styleFrom(
-                  minimumSize: const Size(180, 44),
-                  foregroundColor: context.isDarkTheme
-                      ? palette.textPrimary
-                      : AppColors.text,
-                  side: BorderSide(
-                    color: context.isDarkTheme
-                        ? const Color(0xFF2B3444)
-                        : const Color(0xFFD6E0EE),
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(14),
-                  ),
-                  textStyle: const TextStyle(
+
+                const SizedBox(height: 24),
+
+                // 描述文字
+                Text(
+                  context.l10n.aboutDescription,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
                     fontFamily: AppTextStyles.fontFamily,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w500,
-                    height: 1.4,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w400,
+                    color: context.isDarkTheme
+                        ? palette.textSecondary
+                        : AppColors.text70,
+                    letterSpacing: 0.39,
+                    height: 1.5,
                   ),
                 ),
-              ),
-              const SizedBox(height: 154),
-            ],
+                const SizedBox(height: 24),
+                _buildBetaOptInCard(),
+
+                const SizedBox(height: 72),
+
+                // 版本号
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _version,
+                      textAlign: TextAlign.center,
+                      style:
+                          const TextStyle(
+                            fontFamily: AppTextStyles.fontFamily,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w400,
+                            letterSpacing: 0.33,
+                            height: 1.5,
+                          ).copyWith(
+                            color: context.isDarkTheme
+                                ? palette.textSecondary
+                                : AppColors.text70,
+                          ),
+                    ),
+                  ],
+                ),
+
+                const SizedBox(height: 10),
+                Text(
+                  _buildUpdateHint(),
+                  textAlign: TextAlign.center,
+                  style:
+                      const TextStyle(
+                        fontFamily: AppTextStyles.fontFamily,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                        letterSpacing: 0.3,
+                        height: 1.5,
+                      ).copyWith(
+                        color: context.isDarkTheme
+                            ? palette.textTertiary
+                            : AppColors.text50,
+                      ),
+                ),
+                const SizedBox(height: 16),
+                GradientButton(
+                  text: _isCheckingUpdate
+                      ? context.trLegacy('检查中...')
+                      : (_updateStatus?.hasUpdate == true
+                            ? context.trLegacy('查看新版本')
+                            : context.trLegacy('检查更新')),
+                  width: 180,
+                  height: 44,
+                  gradientColors: updateButtonGradient,
+                  textStyle: TextStyle(
+                    color: updateButtonTextColor,
+                    fontSize: 16,
+                    fontFamily: AppTextStyles.fontFamily,
+                    fontWeight: FontWeight.w500,
+                    height: 1.5,
+                    letterSpacing: 0.5,
+                  ),
+                  enabled: !_isCheckingUpdate,
+                  onTap: () {
+                    _handlePrimaryAction();
+                  },
+                ),
+                const SizedBox(height: 12),
+                OutlinedButton.icon(
+                  onPressed: () {
+                    GoRouterManager.push('/my/about/request-logs');
+                  },
+                  icon: const Icon(Icons.receipt_long_outlined, size: 18),
+                  label: Text(context.trLegacy('请求日志')),
+                  style: OutlinedButton.styleFrom(
+                    minimumSize: const Size(180, 44),
+                    foregroundColor: context.isDarkTheme
+                        ? palette.textPrimary
+                        : AppColors.text,
+                    side: BorderSide(
+                      color: context.isDarkTheme
+                          ? const Color(0xFF2B3444)
+                          : const Color(0xFFD6E0EE),
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    textStyle: const TextStyle(
+                      fontFamily: AppTextStyles.fontFamily,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 154),
+              ],
+            ),
           ),
         ),
       ),

--- a/ui/lib/l10n/app_en.arb
+++ b/ui/lib/l10n/app_en.arb
@@ -477,6 +477,9 @@
   "storageLastAnalyzed": "Last analyzed: {time}",
 
   "aboutDescription": "Omnibot is an AI assistant app centered on\nintelligent conversation, using semantic understanding\nand continuous learning to help with information\nprocessing, decision support, and daily management.",
+  "aboutBetaProgramTitle": "Join beta testing",
+  "aboutBetaProgramDescription": "Beta builds use four-segment version numbers, update faster, and get new features earlier.",
+  "aboutBetaProgramToggleFailed": "Failed to update beta testing preference",
 
   "workspaceMemoryLoadFailed": "Failed to load workspace memory config",
   "workspaceSoulSaved": "SOUL.md saved",

--- a/ui/lib/l10n/app_zh.arb
+++ b/ui/lib/l10n/app_zh.arb
@@ -477,6 +477,9 @@
   "storageLastAnalyzed": "上次分析时间：{time}",
 
   "aboutDescription": "小万，是一款以智能对话为核心的手机AI助\n手，通过语义理解与持续学习能力，协助用户\n完成信息处理、决策辅助和日常管理。",
+  "aboutBetaProgramTitle": "加入 beta 测试",
+  "aboutBetaProgramDescription": "beta 版本为 4 位数版本号，迭代更快，优先获取最新的功能支持。",
+  "aboutBetaProgramToggleFailed": "beta 测试设置更新失败",
 
   "workspaceMemoryLoadFailed": "加载 workspace 记忆配置失败",
   "workspaceSoulSaved": "SOUL.md 已保存",

--- a/ui/lib/l10n/generated/app_localizations.dart
+++ b/ui/lib/l10n/generated/app_localizations.dart
@@ -2714,6 +2714,24 @@ abstract class AppLocalizations {
   /// **'小万，是一款以智能对话为核心的手机AI助\n手，通过语义理解与持续学习能力，协助用户\n完成信息处理、决策辅助和日常管理。'**
   String get aboutDescription;
 
+  /// No description provided for @aboutBetaProgramTitle.
+  ///
+  /// In zh, this message translates to:
+  /// **'加入 beta 测试'**
+  String get aboutBetaProgramTitle;
+
+  /// No description provided for @aboutBetaProgramDescription.
+  ///
+  /// In zh, this message translates to:
+  /// **'beta 版本为 4 位数版本号，迭代更快，优先获取最新的功能支持。'**
+  String get aboutBetaProgramDescription;
+
+  /// No description provided for @aboutBetaProgramToggleFailed.
+  ///
+  /// In zh, this message translates to:
+  /// **'beta 测试设置更新失败'**
+  String get aboutBetaProgramToggleFailed;
+
   /// No description provided for @workspaceMemoryLoadFailed.
   ///
   /// In zh, this message translates to:

--- a/ui/lib/l10n/generated/app_localizations_en.dart
+++ b/ui/lib/l10n/generated/app_localizations_en.dart
@@ -1490,6 +1490,17 @@ class AppLocalizationsEn extends AppLocalizations {
       'Omnibot is an AI assistant app centered on\nintelligent conversation, using semantic understanding\nand continuous learning to help with information\nprocessing, decision support, and daily management.';
 
   @override
+  String get aboutBetaProgramTitle => 'Join beta testing';
+
+  @override
+  String get aboutBetaProgramDescription =>
+      'Beta builds use four-segment version numbers, update faster, and get new features earlier.';
+
+  @override
+  String get aboutBetaProgramToggleFailed =>
+      'Failed to update beta testing preference';
+
+  @override
   String get workspaceMemoryLoadFailed =>
       'Failed to load workspace memory config';
 

--- a/ui/lib/l10n/generated/app_localizations_zh.dart
+++ b/ui/lib/l10n/generated/app_localizations_zh.dart
@@ -1386,6 +1386,16 @@ class AppLocalizationsZh extends AppLocalizations {
       '小万，是一款以智能对话为核心的手机AI助\n手，通过语义理解与持续学习能力，协助用户\n完成信息处理、决策辅助和日常管理。';
 
   @override
+  String get aboutBetaProgramTitle => '加入 beta 测试';
+
+  @override
+  String get aboutBetaProgramDescription =>
+      'beta 版本为 4 位数版本号，迭代更快，优先获取最新的功能支持。';
+
+  @override
+  String get aboutBetaProgramToggleFailed => 'beta 测试设置更新失败';
+
+  @override
   String get workspaceMemoryLoadFailed => '加载 workspace 记忆配置失败';
 
   @override

--- a/ui/lib/services/app_update_service.dart
+++ b/ui/lib/services/app_update_service.dart
@@ -87,14 +87,28 @@ class AppUpdateService {
   static const String _dismissedBannerVersionKey =
       'dismissed_app_update_banner_version';
 
+  static final ValueNotifier<bool> betaOptInNotifier = ValueNotifier<bool>(
+    false,
+  );
   static final ValueNotifier<AppUpdateStatus?> statusNotifier =
       ValueNotifier<AppUpdateStatus?>(null);
 
   static Future<void> initialize() => _initialize();
 
   static Future<void> _initialize() async {
-    await refreshCachedStatus();
+    await Future.wait<void>([refreshBetaOptIn(), refreshCachedStatus()]);
     unawaited(_safeRefreshIfNeeded());
+  }
+
+  static Future<bool> refreshBetaOptIn() async {
+    try {
+      final enabled =
+          await _channel.invokeMethod<bool>('getBetaOptIn') ?? false;
+      betaOptInNotifier.value = enabled;
+      return enabled;
+    } catch (_) {
+      return betaOptInNotifier.value;
+    }
   }
 
   static Future<AppUpdateStatus?> refreshCachedStatus() async {
@@ -102,8 +116,7 @@ class AppUpdateService {
       final result = await _channel.invokeMethod<Map<dynamic, dynamic>>(
         'getCachedStatus',
       );
-      final status =
-          result == null ? null : AppUpdateStatus.fromMap(result);
+      final status = result == null ? null : AppUpdateStatus.fromMap(result);
       statusNotifier.value = status;
       return status;
     } catch (_) {
@@ -117,6 +130,21 @@ class AppUpdateService {
 
   static Future<AppUpdateStatus?> checkNow() {
     return _check(force: true);
+  }
+
+  static Future<bool> setBetaOptIn(bool enabled) async {
+    final updated =
+        await _channel.invokeMethod<bool>('setBetaOptIn', {
+          'enabled': enabled,
+        }) ??
+        enabled;
+    betaOptInNotifier.value = updated;
+    try {
+      await _check(force: true);
+    } catch (_) {
+      await refreshCachedStatus();
+    }
+    return updated;
   }
 
   static Future<AppUpdateInstallResult> installLatestApk() async {

--- a/ui/lib/widgets/gradient_button.dart
+++ b/ui/lib/widgets/gradient_button.dart
@@ -4,37 +4,37 @@ import 'package:flutter/material.dart';
 class GradientButton extends StatelessWidget {
   /// 按钮文字
   final String text;
-  
+
   /// 按钮宽度
   final double width;
-  
+
   /// 按钮高度
   final double height;
-  
+
   /// 点击事件回调
   final VoidCallback? onTap;
-  
+
   /// 文字样式，如果不提供则使用默认样式
   final TextStyle? textStyle;
-  
+
   /// 渐变色列表
   final List<Color> gradientColors;
-  
+
   /// 渐变开始位置
   final Alignment gradientBegin;
-  
+
   /// 渐变结束位置
   final Alignment gradientEnd;
-  
+
   /// 圆角半径
   final double borderRadius;
-  
+
   /// 是否启用（禁用时会显示灰色）
   final bool enabled;
-  
+
   /// 文字后的图标（可选）
   final Widget? trailingIcon;
-  
+
   /// 文字和图标之间的间距
   final double iconSpacing;
 
@@ -82,24 +82,29 @@ class GradientButton extends StatelessWidget {
             width: width,
             height: height,
             child: Row(
-              mainAxisSize: MainAxisSize.min,
+              mainAxisSize: MainAxisSize.max,
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Text(
-                  text,
-                  textAlign: TextAlign.center,
-                  style: textStyle ??
-                      const TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontFamily: 'PingFang SC',
-                        fontWeight: FontWeight.w500,
-                        height: 1.5,
-                        letterSpacing: 0.5,
-                      ),
+                Flexible(
+                  child: Text(
+                    text,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style:
+                        textStyle ??
+                        const TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontFamily: 'PingFang SC',
+                          fontWeight: FontWeight.w500,
+                          height: 1.5,
+                          letterSpacing: 0.5,
+                        ),
+                  ),
                 ),
-                if (trailingIcon != null) ... [
+                if (trailingIcon != null) ...[
                   SizedBox(width: iconSpacing),
                   trailingIcon!,
                 ],

--- a/ui/test/features/my/pages/about/about_page_test.dart
+++ b/ui/test/features/my/pages/about/about_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ui/features/my/pages/about/about_page.dart';
+import 'package:ui/l10n/generated/app_localizations.dart';
 import 'package:ui/services/app_update_service.dart';
 
 void main() {
@@ -11,6 +12,7 @@ void main() {
   const updateChannel = MethodChannel('cn.com.omnimind.bot/app_update');
 
   tearDown(() async {
+    AppUpdateService.betaOptInNotifier.value = false;
     AppUpdateService.statusNotifier.value = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(deviceChannel, null);
@@ -28,6 +30,9 @@ void main() {
         });
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(updateChannel, (call) async {
+          if (call.method == 'getBetaOptIn') {
+            return false;
+          }
           if (call.method == 'getCachedStatus') {
             return <String, dynamic>{
               'currentVersion': '0.0.1',
@@ -59,12 +64,16 @@ void main() {
 
     await tester.pumpWidget(
       const MaterialApp(
+        locale: Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: AboutPage(),
       ),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('Version 0.0.1'), findsOneWidget);
+    expect(find.text('加入 beta 测试'), findsOneWidget);
     expect(find.textContaining('发现新版本'), findsOneWidget);
     expect(find.text('查看新版本'), findsOneWidget);
   });

--- a/ui/test/services/app_update_service_test.dart
+++ b/ui/test/services/app_update_service_test.dart
@@ -1,8 +1,8 @@
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ui/services/app_update_service.dart';
 import 'package:ui/services/storage_service.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -10,6 +10,7 @@ void main() {
   const channel = MethodChannel('cn.com.omnimind.bot/app_update');
 
   tearDown(() async {
+    AppUpdateService.betaOptInNotifier.value = false;
     AppUpdateService.statusNotifier.value = null;
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);
@@ -39,6 +40,35 @@ void main() {
     expect(status, isNotNull);
     expect(status!.hasUpdate, isTrue);
     expect(AppUpdateService.statusNotifier.value?.latestVersion, '0.0.2');
+  });
+
+  test('setBetaOptIn updates notifier and refreshes status', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          if (call.method == 'setBetaOptIn') {
+            return call.arguments['enabled'] == true;
+          }
+          if (call.method == 'checkNow') {
+            return <String, dynamic>{
+              'currentVersion': '1.6.1',
+              'latestVersion': '1.6.1.2',
+              'hasUpdate': true,
+              'checkedAt': 3,
+              'publishedAt': 4,
+              'releaseUrl': 'https://example.com/release',
+              'releaseNotes': 'beta notes',
+              'apkName': 'OpenOmniBot-v1.6.1.2.apk',
+              'apkDownloadUrl': 'https://example.com/app.apk',
+            };
+          }
+          return null;
+        });
+
+    final enabled = await AppUpdateService.setBetaOptIn(true);
+
+    expect(enabled, isTrue);
+    expect(AppUpdateService.betaOptInNotifier.value, isTrue);
+    expect(AppUpdateService.statusNotifier.value?.latestVersion, '1.6.1.2');
   });
 
   test('dismissBanner hides the banner for the same version only', () async {


### PR DESCRIPTION
- Updated GitHub Actions workflow to determine release mode and adjust draft and prerelease settings based on versioning.
- Added methods in AppUpdateChannel for getting and setting beta opt-in status.
- Enhanced AppUpdateManager to manage beta opt-in preferences and update checks accordingly.
- Introduced UI elements in AboutPage to toggle beta opt-in with corresponding state management.
- Updated localization files to include new strings for beta program.
- Added tests for beta opt-in functionality in AppUpdateService and AboutPage.

## 变更摘要

<!-- 用 1-3 句话描述本次改动解决了什么问题 -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
