### PR TITLE
 fix: 修复 Xiaomi/HyperOS 下陪伴模式后台权限误判

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
@@ -57,6 +57,16 @@ class SpecialPermissionManager(private val context: Context) {
         }
     }
 
+    fun isBackgroundRunAllowed(result: MethodChannel.Result) {
+        try {
+            val value = AssistsUtil.Setting.isBackgroundRunAllowed(context)
+            result.success(value)
+        } catch (e: Exception) {
+            OmniLog.e(TAG, "Error checking background run permission", e)
+            result.error("CHECK_FAILED", "Failed to check background run permission.", e.message)
+        }
+    }
+
     fun openBatteryOptimizationSettings(result: MethodChannel.Result) {
         try {
             AssistsUtil.Setting.openBatteryOptimizationSettings(context)

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/SpecialPermissionChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/SpecialPermissionChannel.kt
@@ -64,6 +64,10 @@ class SpecialPermissionChannel {
                         result
                     )
 
+                    "isBackgroundRunAllowed" -> specialPermissionManager!!.isBackgroundRunAllowed(
+                        result
+                    )
+
                     "openBatteryOptimizationSettings" -> specialPermissionManager!!.openBatteryOptimizationSettings(
                         result
                     )

--- a/app/src/main/java/cn/com/omnimind/bot/util/AssistsUtil.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/util/AssistsUtil.kt
@@ -1,12 +1,14 @@
 package cn.com.omnimind.bot.util
 
 import cn.com.omnimind.accessibility.action.ScreenCaptureManager
+import android.app.AppOpsManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Process
 import android.os.PowerManager
 import android.provider.Settings
 import android.util.Log
@@ -17,6 +19,7 @@ import cn.com.omnimind.assists.api.interfaces.OnMessagePushListener
 import cn.com.omnimind.assists.task.scheduled.worker.ScheduledParams
 import cn.com.omnimind.assists.task.scheduled.worker.ScheduledStates
 import cn.com.omnimind.baselib.util.APPPackageUtil
+import cn.com.omnimind.baselib.util.MobileManufacturerUtil
 import cn.com.omnimind.baselib.util.exception.PermissionException
 import cn.com.omnimind.bot.App
 import cn.com.omnimind.bot.manager.OmniForegroundService
@@ -392,11 +395,76 @@ class AssistsUtil {
 
         }
 
+        fun isBackgroundRunAllowed(context: Context): Boolean {
+            if (isIgnoringBatteryOptimizations(context)) {
+                return true
+            }
+            if (!MobileManufacturerUtil.isXiaomiSeries()) {
+                return false
+            }
+            val compatibilityAllowed = isXiaomiBackgroundRunAllowed(context)
+            Log.d(TAG, "Xiaomi background run compatibility result=$compatibilityAllowed")
+            return compatibilityAllowed
+        }
+
+        private fun isXiaomiBackgroundRunAllowed(context: Context): Boolean {
+            val appOpsManager =
+                context.getSystemService(Context.APP_OPS_SERVICE) as? AppOpsManager
+                    ?: return false
+            val uid = context.applicationInfo.uid.takeIf { it > 0 } ?: Process.myUid()
+            val packageName = context.packageName
+            val runAnyMode = readAppOpMode(
+                appOpsManager = appOpsManager,
+                operation = OPSTR_RUN_ANY_IN_BACKGROUND,
+                uid = uid,
+                packageName = packageName
+            )
+            val runMode = readAppOpMode(
+                appOpsManager = appOpsManager,
+                operation = OPSTR_RUN_IN_BACKGROUND,
+                uid = uid,
+                packageName = packageName
+            )
+            Log.d(TAG, "Xiaomi background run app ops: runAny=$runAnyMode, run=$runMode")
+            val knownModes = listOf(runAnyMode, runMode).filterNotNull()
+            if (knownModes.isEmpty()) {
+                return false
+            }
+            val explicitlyBlocked = knownModes.any { mode ->
+                mode == AppOpsManager.MODE_IGNORED ||
+                        mode == AppOpsManager.MODE_ERRORED ||
+                        mode == AppOpsManager.MODE_FOREGROUND
+            }
+            if (explicitlyBlocked) {
+                return false
+            }
+            return knownModes.all { mode ->
+                mode == AppOpsManager.MODE_ALLOWED || mode == AppOpsManager.MODE_DEFAULT
+            }
+        }
+
+        private fun readAppOpMode(
+            appOpsManager: AppOpsManager,
+            operation: String,
+            uid: Int,
+            packageName: String
+        ): Int? {
+            return runCatching {
+                appOpsManager.unsafeCheckOpNoThrow(operation, uid, packageName)
+            }.getOrElse { error ->
+                Log.d(TAG, "readAppOpMode failed for $operation: ${error.message}")
+                null
+            }
+        }
+
         /**
          * 打开电池优化设置页面
          * @param context 上下文
          * @param result 方法调用结果
          */
+        private const val OPSTR_RUN_ANY_IN_BACKGROUND = "android:run_any_in_background"
+        private const val OPSTR_RUN_IN_BACKGROUND = "android:run_in_background"
+
         fun openBatteryOptimizationSettings(context: Context) {
             val intent =
                 Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {

--- a/ui/lib/features/home/pages/authorize_setting/authorize_setting_page.dart
+++ b/ui/lib/features/home/pages/authorize_setting/authorize_setting_page.dart
@@ -218,9 +218,7 @@ class _AuthorizeSettingPageState extends State<AuthorizeSettingPage>
 
   Future<void> _checkPermissions() async {
     try {
-      final backgroundRunning =
-          await spePermission.invokeMethod('isIgnoringBatteryOptimizations') ??
-          false;
+      final backgroundRunning = await isBackgroundRunAllowed();
       final overlayPermission =
           await spePermission.invokeMethod('isOverlayPermission') ?? false;
       final installedAppsPermission =

--- a/ui/lib/services/permission_registry.dart
+++ b/ui/lib/services/permission_registry.dart
@@ -117,7 +117,7 @@ class PermissionRegistry {
             ? 'Keep running in background'
             : '后台持续运行，切出APP不中断服务',
         openMethod: 'openBatteryOptimizationSettings',
-        checkMethod: 'isIgnoringBatteryOptimizations',
+        checkMethod: 'isBackgroundRunAllowed',
       ),
       PermissionSpec(
         id: 'installed_apps',

--- a/ui/lib/services/special_permission.dart
+++ b/ui/lib/services/special_permission.dart
@@ -947,3 +947,13 @@ Future<Map<String, dynamic>> downloadAndInstallTermuxApk(
   );
   return Map<String, dynamic>.from(result ?? const {});
 }
+
+Future<bool> isBackgroundRunAllowed() async {
+  try {
+    return await spePermission.invokeMethod<bool>('isBackgroundRunAllowed') ??
+        false;
+  } catch (e) {
+    debugPrint('检查后台运行权限失败: $e');
+    return false;
+  }
+}


### PR DESCRIPTION
## 变更摘要

 修复了 Xiaomi / HyperOS 设备上“省电策略”已设置为“无限制”时，App 仍误判“允许后台运行”未授权，导致“开启陪伴”按钮被错误禁用的问题。
  本次改动将后台运行权限判断从单一的 Android 标准电池优化状态，升级为“标准判断 + Xiaomi 兼容判断”的统一判定链路。
## 变更类型

- [ ] Bug 修复


## 关联 Issue

#183
## 主要改动

<!-- 请列出关键改动点，便于 Review -->

  1. 在 native 侧新增统一后台运行权限判定 `isBackgroundRunAllowed`，保留标准 `isIgnoringBatteryOptimizations` 检查，并为
  Xiaomi / HyperOS 增加基于 `AppOps` 的兼容判断。
  2. 新增 `MethodChannel` 接口，将 Flutter 侧“允许后台运行”权限检查统一切换到 `isBackgroundRunAllowed`，避免授权页、权限弹窗、陪伴入口之间判定不一致。

## 测试说明


- [ ] 已本地编译通过
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

复现原始陪伴模式Bug：
<img width="864" height="1920" alt="陪伴模式bug复现" src="https://github.com/user-attachments/assets/e376ac9f-034b-4adb-98df-a200996e36ce" />

修复后结果(可以有后台权限，正常使用陪伴模式)：
<img width="864" height="1920" alt="陪伴模式修复后结果" src="https://github.com/user-attachments/assets/fe9a8446-7094-4dd7-90eb-28d4eff12e0e" />


## UI 变更（如有）

无

## 风险与回滚

无
## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
