### PR TITLE
fix: 修复由于不同配置读取导致的DeepSeek官网 reasoning_content 返回报错400问题。

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -77,6 +77,7 @@ class AgentConversationHistoryRepository(
         text: String,
         isError: Boolean = false,
         attachments: List<Map<String, Any?>> = emptyList(),
+        reasoningContent: String? = null,
         streamMeta: Map<String, Any?>? = null,
         createdAt: Long = System.currentTimeMillis()
     ) {
@@ -85,6 +86,7 @@ class AgentConversationHistoryRepository(
             user = 2,
             text = text,
             attachments = attachments,
+            reasoningContent = reasoningContent,
             isError = isError,
             streamMeta = streamMeta,
             createdAt = createdAt

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -69,11 +69,14 @@ internal object AgentConversationHistorySupport {
         user: Int,
         text: String,
         attachments: List<Map<String, Any?>> = emptyList(),
+        reasoningContent: String? = null,
         isError: Boolean,
         streamMeta: Map<String, Any?>?,
         createdAt: Long
     ): Map<String, Any?> {
         val safeText = AgentTextSanitizer.sanitizeUtf16(text)
+        val safeReasoning = AgentTextSanitizer.sanitizeUtf16(reasoningContent.orEmpty())
+            .takeIf { it.isNotBlank() }
         val historyAttachments = AgentImageAttachmentSupport
             .prepareAttachments(attachments)
             .historyAttachments
@@ -94,6 +97,7 @@ internal object AgentConversationHistorySupport {
             "isError" to isError,
             "isSummarizing" to false,
             "streamMeta" to streamMeta,
+            "reasoning_content" to safeReasoning,
             "createAt" to Instant.ofEpochMilli(createdAt).toString()
         ).filterValues { it != null }
     }
@@ -528,10 +532,16 @@ internal object AgentConversationHistorySupport {
         val payload = readMap(entry.payloadJson)
         val content = buildPromptContentFromMessagePayload(payload) ?: return emptyList()
         if (content.isBlankJsonPrimitive()) return emptyList()
+        val reasoningContent = AgentTextSanitizer.sanitizeUtf16(
+            payload["reasoning_content"]?.toString()
+                ?: payload["reasoningContent"]?.toString()
+                ?: ""
+        ).takeIf { it.isNotBlank() }
         return listOf(
             ChatCompletionMessage(
                 role = "assistant",
-                content = content
+                content = content,
+                reasoningContent = reasoningContent
             )
         )
     }
@@ -1379,6 +1389,18 @@ internal object AgentConversationHistorySupport {
             content["text"]?.toString().orEmpty().ifBlank { entry.summary },
             MAX_STORAGE_MESSAGE_TEXT_CHARS
         )
+        val safeReasoningContent = if (
+            entry.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE
+        ) {
+            trimText(
+                payload["reasoning_content"]?.toString()
+                    ?: payload["reasoningContent"]?.toString()
+                    ?: "",
+                MAX_STORAGE_MESSAGE_TEXT_CHARS
+            ).takeIf { it.isNotBlank() }
+        } else {
+            null
+        }
         val safeStreamMeta = compactDisplayStreamMeta(payload["streamMeta"])
         val safeAttachments = compactDisplayList(content["attachments"])
         fun buildPayload(attachments: List<Map<String, Any?>>): Map<String, Any?> {
@@ -1391,6 +1413,7 @@ internal object AgentConversationHistorySupport {
                 },
                 text = safeText,
                 attachments = attachments,
+                reasoningContent = safeReasoningContent,
                 isError = parseBoolean(
                     payload["isError"],
                     default = entry.status == AgentConversationHistoryRepository.STATUS_ERROR

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -3,9 +3,7 @@ package cn.com.omnimind.bot.agent
 import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionTurn
-import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.llm.LocalModelProviderBridge
-import cn.com.omnimind.baselib.llm.ModelProviderConfigStore
 import cn.com.omnimind.baselib.llm.ReasoningStreamUpdatePolicy
 import cn.com.omnimind.baselib.util.OmniLog
 import kotlinx.coroutines.CompletableDeferred
@@ -153,13 +151,20 @@ class HttpAgentLlmClient(
     ): ChatCompletionTurn {
         val streamDone = CompletableDeferred<ChatCompletionTurn>()
         val completed = AtomicBoolean(false)
+        val routeInfo = HttpController.resolveChatCompletionRouteInfo(
+            modelOrScene = model,
+            explicitApiBase = modelOverride?.apiBase,
+            explicitApiKey = modelOverride?.apiKey,
+            explicitModel = modelOverride?.modelId,
+            explicitProtocolType = modelOverride?.protocolType
+        )
         val accumulator = AgentLlmStreamAccumulator(
             json = json,
             preferInlineThinkTags = LocalModelProviderBridge.isBuiltinLocalProvider(
                 modelOverride?.providerProfileId,
                 modelOverride?.apiBase
             ),
-            includeReasoningInAssistantMessage = isOfficialDeepSeekTarget()
+            includeReasoningInAssistantMessage = routeInfo?.requiresReasoningEcho == true
         )
         var lastReasoning = ""
         var lastReasoningEmitLength = 0
@@ -265,6 +270,7 @@ class HttpAgentLlmClient(
             if (!completed.compareAndSet(false, true)) return
             runCatching {
                 val turn = accumulator.buildTurn()
+                enforceReasoningEchoIfRequired(turn, routeInfo)
                 emitReasoning(force = true)
                 emitContent()
                 turn
@@ -340,6 +346,25 @@ class HttpAgentLlmClient(
         }
     }
 
+    private fun enforceReasoningEchoIfRequired(
+        turn: ChatCompletionTurn,
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ) {
+        if (!routeInfo.requiresReasoningEcho) {
+            return
+        }
+        if (turn.reasoning.isBlank()) {
+            return
+        }
+        if (!turn.message.reasoningContent.isNullOrBlank()) {
+            return
+        }
+        throw IllegalStateException(
+            "assistant turn is missing reasoning_content for route=${routeInfo.resolvedModel} " +
+                "protocol=${routeInfo.protocolType} despite non-empty reasoning output"
+        )
+    }
+
     private fun buildRequestVariants(request: ChatCompletionRequest): List<StreamRequestVariant> {
         val variants = mutableListOf<StreamRequestVariant>()
         val seenPayloads = LinkedHashSet<String>()
@@ -379,21 +404,6 @@ class HttpAgentLlmClient(
             )
         }
         return variants
-    }
-
-    private fun isOfficialDeepSeekTarget(): Boolean {
-        if (modelOverride != null) {
-            return DeepSeekProvider.shouldUseOfficialAdapter(
-                protocolType = modelOverride.protocolType,
-                apiBase = modelOverride.apiBase
-            )
-        }
-        val profile = runCatching { ModelProviderConfigStore.getEditingProfile() }
-            .getOrNull()
-        return DeepSeekProvider.shouldUseOfficialAdapter(
-            protocolType = profile?.protocolType,
-            apiBase = profile?.baseUrl
-        )
     }
 
     private fun toLegacyFunctionCall(toolChoice: JsonElement?): JsonElement? {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -4104,6 +4104,9 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             entryId = entryId,
                             text = normalizedText,
                             isError = isError,
+                            reasoningContent = latestThinkingContent
+                                .takeIf { it.isNotBlank() }
+                                ?.let(AgentTextSanitizer::sanitizeUtf16),
                             streamMeta = streamMeta(
                                 entryId = entryId,
                                 roundIndex = roundIndex,

--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -59,6 +59,20 @@ object HttpController {
     private const val ANTHROPIC_EPHEMERAL_CACHE_TYPE = "ephemeral"
     private const val ANTHROPIC_MAX_CACHE_BREAKPOINTS = 4
 
+    data class ChatCompletionRouteInfo(
+        val requestedModel: String,
+        val resolvedModel: String,
+        val apiBase: String?,
+        val providerProfileId: String?,
+        val providerProfileName: String?,
+        val routeTag: String?,
+        val bindingApplied: Boolean,
+        val bindingProfileMissing: Boolean,
+        val overrideApplied: Boolean,
+        val protocolType: String = "openai_compatible",
+        val requiresReasoningEcho: Boolean = false
+    )
+
     private data class ResolvedSceneRequest(
         val requestedModel: String,
         val resolvedModel: String,
@@ -93,6 +107,22 @@ object HttpController {
         val code: Int? = null,
         val message: String
     )
+
+    fun resolveChatCompletionRouteInfo(
+        modelOrScene: String,
+        explicitApiBase: String? = null,
+        explicitApiKey: String? = null,
+        explicitModel: String? = null,
+        explicitProtocolType: String? = null
+    ): ChatCompletionRouteInfo {
+        return resolveSceneRequest(
+            modelOrScene = modelOrScene,
+            explicitApiBase = explicitApiBase,
+            explicitApiKey = explicitApiKey,
+            explicitModel = explicitModel,
+            explicitProtocolType = explicitProtocolType
+        ).toRouteInfo()
+    }
 
     private val openClawStreamClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
@@ -394,6 +424,25 @@ object HttpController {
         OmniLog.i(
             TAG,
             "scene_profile scene=${profile.sceneId} model=${resolved.resolvedModel} transport=${resolved.effectiveTransport.wireValue} parser=${resolved.responseParser.wireValue} source=${profile.modelSource.wireValue} config_source=${profile.configSource.wireValue} override_group=${profile.overrideGroup.orEmpty()} custom_api_base=${resolved.customApiBaseApplied} binding_applied=${resolved.bindingApplied} binding_profile=${resolved.providerProfileId.orEmpty()} binding_profile_missing=${resolved.bindingProfileMissing} override_applied=${resolved.overrideApplied} override_model=${resolved.overrideModel.orEmpty()}"
+        )
+    }
+
+    private fun ResolvedSceneRequest.toRouteInfo(): ChatCompletionRouteInfo {
+        return ChatCompletionRouteInfo(
+            requestedModel = requestedModel,
+            resolvedModel = resolvedModel,
+            apiBase = apiBase,
+            providerProfileId = providerProfileId,
+            providerProfileName = providerProfileName,
+            routeTag = routeTag,
+            bindingApplied = bindingApplied,
+            bindingProfileMissing = bindingProfileMissing,
+            overrideApplied = overrideApplied,
+            protocolType = protocolType,
+            requiresReasoningEcho = DeepSeekProvider.shouldUseOfficialAdapter(
+                protocolType = protocolType,
+                apiBase = apiBase
+            )
         )
     }
 


### PR DESCRIPTION
## 变更摘要

本次改动修复了 `scene.dispatch.model` 经场景绑定路由到 DeepSeek 官方 thinking mode 后，首轮返回 `reasoning_content` 但第二轮工具续轮未按协议回传，导致服务端返回 400 实际出现断流表象的问题。修复后，`reasoning_content` 的保留与续传改为基于真实路由结果判断，并补齐了 assistant 历史消息中的 `reasoning_content` 存储与重建链路。
## 变更类型

- [ ] Bug 修复

## 关联 Issue

issue283 issue271
## 主要改动

<!-- 请列出关键改动点，便于 Review -->

  1. 在 `HttpController` 中抽出可复用的 chat completion 路由信息，基于真实 resolved route 判断当前目标是否要求
  `reasoning_content` 在后续轮次回传。
  2. 在 `AgentLlmClient` 中移除基于全局 profile / override 的旧判断逻辑，改为按真实 route capability 决定是否把
  `reasoning_content` 写回 assistant message，并在本地增加缺失时的 fail-fast 校验。
  3. 在 `AgentConversationHistorySupport`、`AgentConversationHistoryRepository` 和 `AssistsCoreManager` 中补齐 assistant
  消息 `reasoning_content` 的持久化与历史重建，避免恢复会话或历史回放时再次丢失。

## 测试说明

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

![image.png](attachment:a94d7c9c-61da-4c33-bd88-33466a3698a9:image.png)

![image.png](attachment:77a98f70-43a9-4f50-aa62-12056925b3f5:image.png)

## UI 变更（如有）

无
## 风险与回滚

无
## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块

修复前与修复后抓包日志比较
[logcat-raw.txt](https://github.com/user-attachments/files/27620170/logcat-raw.txt)

[logcat-raw.txt](https://github.com/user-attachments/files/27620159/logcat-raw.txt)
