### PR TITLE
fix: 修复兼容其他导致 reasoning_content 返回报错400问题，针对中转站503 空 turn 误报已复现修复为真实错误

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -75,6 +75,7 @@ class AgentConversationHistoryRepository(
         conversationMode: String,
         entryId: String,
         text: String,
+        reasoningContent: String? = null,
         isError: Boolean = false,
         attachments: List<Map<String, Any?>> = emptyList(),
         streamMeta: Map<String, Any?>? = null,
@@ -85,6 +86,7 @@ class AgentConversationHistoryRepository(
             user = 2,
             text = text,
             attachments = attachments,
+            reasoningContent = reasoningContent,
             isError = isError,
             streamMeta = streamMeta,
             createdAt = createdAt

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -69,11 +69,13 @@ internal object AgentConversationHistorySupport {
         user: Int,
         text: String,
         attachments: List<Map<String, Any?>> = emptyList(),
+        reasoningContent: String? = null,
         isError: Boolean,
         streamMeta: Map<String, Any?>?,
         createdAt: Long
     ): Map<String, Any?> {
         val safeText = AgentTextSanitizer.sanitizeUtf16(text)
+        val safeReasoning = AgentTextSanitizer.sanitizeUtf16(reasoningContent.orEmpty()).trim()
         val historyAttachments = AgentImageAttachmentSupport
             .prepareAttachments(attachments)
             .historyAttachments
@@ -95,7 +97,11 @@ internal object AgentConversationHistorySupport {
             "isSummarizing" to false,
             "streamMeta" to streamMeta,
             "createAt" to Instant.ofEpochMilli(createdAt).toString()
-        ).filterValues { it != null }
+        ).apply {
+            if (user == 2 && safeReasoning.isNotEmpty()) {
+                put("reasoning_content", safeReasoning)
+            }
+        }.filterValues { it != null }
     }
 
     fun buildCardMessagePayload(
@@ -477,6 +483,13 @@ internal object AgentConversationHistorySupport {
         } else {
             chooseText("terminalOutput")
         }
+        val reasoningContent = text(incoming, "reasoning_content").ifEmpty {
+            text(incoming, "reasoningContent").ifEmpty {
+                text(existing, "reasoning_content").ifEmpty {
+                    text(existing, "reasoningContent")
+                }
+            }
+        }
 
         return linkedMapOf<String, Any?>(
             "taskId" to chooseAny("taskId"),
@@ -494,6 +507,7 @@ internal object AgentConversationHistorySupport {
             "argsJson" to chooseText("argsJson"),
             "resultPreviewJson" to chooseText("resultPreviewJson"),
             "rawResultJson" to chooseText("rawResultJson"),
+            "reasoning_content" to reasoningContent,
             "terminalOutput" to terminalOutput,
             "terminalOutputDelta" to terminalOutputDelta,
             "terminalSessionId" to chooseAny("terminalSessionId"),
@@ -528,10 +542,14 @@ internal object AgentConversationHistorySupport {
         val payload = readMap(entry.payloadJson)
         val content = buildPromptContentFromMessagePayload(payload) ?: return emptyList()
         if (content.isBlankJsonPrimitive()) return emptyList()
+        val reasoningContent = payload["reasoning_content"]?.toString()?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: payload["reasoningContent"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
         return listOf(
             ChatCompletionMessage(
                 role = "assistant",
-                content = content
+                content = content,
+                reasoningContent = reasoningContent
             )
         )
     }
@@ -567,6 +585,9 @@ internal object AgentConversationHistorySupport {
 
         val toolCallId = "restored_${entry.entryId}"
         val argsJson = payload["argsJson"]?.toString()?.trim()?.ifEmpty { null } ?: "{}"
+        val reasoningContent = payload["reasoning_content"]?.toString()?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: payload["reasoningContent"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
         val assistantMessage = ChatCompletionMessage(
             role = "assistant",
             toolCalls = listOf(
@@ -577,7 +598,8 @@ internal object AgentConversationHistorySupport {
                         arguments = argsJson
                     )
                 )
-            )
+            ),
+            reasoningContent = reasoningContent
         )
         val toolMessage = ChatCompletionMessage(
             role = "tool",
@@ -1379,6 +1401,9 @@ internal object AgentConversationHistorySupport {
             content["text"]?.toString().orEmpty().ifBlank { entry.summary },
             MAX_STORAGE_MESSAGE_TEXT_CHARS
         )
+        val reasoningContent = payload["reasoning_content"]?.toString()?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: payload["reasoningContent"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
         val safeStreamMeta = compactDisplayStreamMeta(payload["streamMeta"])
         val safeAttachments = compactDisplayList(content["attachments"])
         fun buildPayload(attachments: List<Map<String, Any?>>): Map<String, Any?> {
@@ -1391,6 +1416,7 @@ internal object AgentConversationHistorySupport {
                 },
                 text = safeText,
                 attachments = attachments,
+                reasoningContent = reasoningContent,
                 isError = parseBoolean(
                     payload["isError"],
                     default = entry.status == AgentConversationHistoryRepository.STATUS_ERROR
@@ -1442,6 +1468,7 @@ internal object AgentConversationHistorySupport {
             },
             text = safeText,
             attachments = emptyList(),
+            reasoningContent = null,
             isError = entry.status == AgentConversationHistoryRepository.STATUS_ERROR,
             streamMeta = mapOf(
                 "payloadCompacted" to true,

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -2,6 +2,7 @@ package cn.com.omnimind.bot.agent
 
 import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
+import cn.com.omnimind.baselib.llm.ChatCompletionMessage
 import cn.com.omnimind.baselib.llm.ChatCompletionTurn
 import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.llm.LocalModelProviderBridge
@@ -71,7 +72,9 @@ class HttpAgentLlmClient(
         onContentUpdate: (suspend (String) -> Unit)?
     ): ChatCompletionTurn {
         val modelCandidates = buildModelCandidates(request.model)
-        val variants = buildRequestVariants(request)
+        val variants = buildRequestVariants(
+            sanitizeRequestForTarget(request)
+        )
         var lastFailure: StreamRequestFailure? = null
 
         for (modelIndex in modelCandidates.indices) {
@@ -381,6 +384,52 @@ class HttpAgentLlmClient(
         return variants
     }
 
+    private fun sanitizeRequestForTarget(request: ChatCompletionRequest): ChatCompletionRequest {
+        if (shouldPreserveAllAssistantReasoning()) {
+            return request
+        }
+        val sanitizedMessages = request.messages.mapIndexed { index, message ->
+            if (
+                message.role != "assistant" ||
+                message.reasoningContent.isNullOrBlank() ||
+                shouldRetainAssistantReasoning(index, request.messages)
+            ) {
+                message
+            } else {
+                message.copy(reasoningContent = null)
+            }
+        }
+        return if (sanitizedMessages == request.messages) {
+            request
+        } else {
+            request.copy(messages = sanitizedMessages)
+        }
+    }
+
+    private fun shouldPreserveAllAssistantReasoning(): Boolean {
+        if (isOfficialDeepSeekTarget()) {
+            return true
+        }
+        return resolvedProtocolType() == DeepSeekProvider.PROTOCOL_TYPE
+    }
+
+    private fun shouldRetainAssistantReasoning(
+        assistantIndex: Int,
+        messages: List<ChatCompletionMessage>
+    ): Boolean {
+        val message = messages.getOrNull(assistantIndex) ?: return false
+        if (message.toolCalls?.isNotEmpty() == true) {
+            return true
+        }
+        for (index in assistantIndex + 1 until messages.size) {
+            when (messages[index].role) {
+                "tool" -> return true
+                "user" -> return false
+            }
+        }
+        return false
+    }
+
     private fun isOfficialDeepSeekTarget(): Boolean {
         if (modelOverride != null) {
             return DeepSeekProvider.shouldUseOfficialAdapter(
@@ -394,6 +443,15 @@ class HttpAgentLlmClient(
             protocolType = profile?.protocolType,
             apiBase = profile?.baseUrl
         )
+    }
+
+    private fun resolvedProtocolType(): String {
+        modelOverride?.protocolType
+            ?.let(DeepSeekProvider::normalizeProtocolType)
+            ?.let { return it }
+        return runCatching { ModelProviderConfigStore.getEditingProfile().protocolType }
+            .map(DeepSeekProvider::normalizeProtocolType)
+            .getOrDefault(DeepSeekProvider.normalizeProtocolType(null))
     }
 
     private fun toLegacyFunctionCall(toolChoice: JsonElement?): JsonElement? {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -33,10 +33,12 @@ class AgentLlmStreamAccumulator(
     private val reasoningBuffer = StringBuilder()
     private val inlineTextBuffer = StringBuilder()
     private val toolCallBuilders: SortedMap<Int, MutableToolCallBuilder> = TreeMap()
+    private var providerError: StreamProviderError? = null
     private var finishReason: String? = null
     private var usage: ChatCompletionUsage? = null
     private var decodeTokensPerSecond: Double? = null
     private var seenChunk = false
+    private var seenDoneSignal = false
     private var lastChunkPreview: String = ""
     private var thinkSectionOpen = false
     private var inlineThinkTagObserved = false
@@ -59,7 +61,10 @@ class AgentLlmStreamAccumulator(
     }
 
     private fun consumeSingleChunk(trimmed: String): Boolean {
-        if (trimmed == "[DONE]") return true
+        if (trimmed == "[DONE]") {
+            seenDoneSignal = true
+            return true
+        }
         val root = parseJsonObject(trimmed)
         if (root == null) {
             seenChunk = true
@@ -75,6 +80,9 @@ class AgentLlmStreamAccumulator(
         val prevReasoningLen = reasoningBuffer.length
         val prevToolCallCount = toolCallBuilders.size
 
+        extractProviderError(root)?.let { error ->
+            providerError = error
+        }
         usage = decodeUsage(root["usage"]) ?: usage
         decodeTokensPerSecond = decodeTimings(root["timings"]) ?: decodeTokensPerSecond
 
@@ -198,6 +206,24 @@ class AgentLlmStreamAccumulator(
 
     fun currentContent(): String = AgentTextSanitizer.sanitizeUtf16(contentBuffer.toString())
 
+    fun hasDoneSignal(): Boolean = seenDoneSignal
+
+    fun currentFinishReason(): String? = finishReason
+
+    fun hasUsagePayload(): Boolean = usage != null
+
+    fun hasAssistantPayload(): Boolean {
+        return contentBuffer.isNotEmpty() ||
+            reasoningBuffer.isNotEmpty() ||
+            toolCallBuilders.isNotEmpty()
+    }
+
+    fun canFinalizeOnClosed(): Boolean {
+        return hasDoneSignal() ||
+            !finishReason.isNullOrBlank() ||
+            (hasUsagePayload() && hasAssistantPayload())
+    }
+
     fun buildTurn(): ChatCompletionTurn {
         if (!seenChunk) {
             throw IllegalStateException("chat completion stream ended without chunks")
@@ -226,6 +252,9 @@ class AgentLlmStreamAccumulator(
             )
         }
         if (content.isBlank() && toolCalls.isEmpty()) {
+            providerError?.let { error ->
+                throw IllegalStateException(buildProviderErrorMessage(error))
+            }
             throw IllegalStateException(
                 "assistant turn has neither content nor tool_calls; finish_reason=${finishReason.orEmpty()}, last_chunk=$lastChunkPreview"
             )
@@ -237,7 +266,11 @@ class AgentLlmStreamAccumulator(
                 content = content.ifBlank { null }?.let(::JsonPrimitive),
                 toolCalls = toolCalls.ifEmpty { null },
                 reasoningContent = reasoning.takeIf {
-                    includeReasoningInAssistantMessage && it.isNotBlank()
+                    it.isNotBlank() && (
+                        includeReasoningInAssistantMessage ||
+                            toolCalls.isNotEmpty() ||
+                            finishReasonIndicatesToolCall(finishReason)
+                        )
                 }
             ),
             reasoning = reasoning,
@@ -249,7 +282,7 @@ class AgentLlmStreamAccumulator(
             TAG,
             "[stream done] chunks=$chunkIndex, content_len=${content.length}, " +
                 "reasoning_len=${reasoningBuffer.length}, tool_calls=${toolCalls.size}, " +
-                "finish=$finishReason" +
+                "finish=$finishReason, done=$seenDoneSignal" +
                 (turn.usage?.let { u ->
                     ", usage(prompt=${u.promptTokens}, completion=${u.completionTokens}, total=${u.totalTokens}" +
                         (u.decodeTokensPerSecond?.let { ", decode=${it}tok/s" }.orEmpty()) + ")"
@@ -264,6 +297,13 @@ class AgentLlmStreamAccumulator(
         var type: String? = null,
         var name: String? = null,
         val arguments: StringBuilder = StringBuilder()
+    )
+
+    private data class StreamProviderError(
+        val statusCode: Int? = null,
+        val code: String? = null,
+        val type: String? = null,
+        val message: String
     )
 
     private fun consumeChoice(choice: JsonObject): Boolean {
@@ -424,6 +464,35 @@ class AgentLlmStreamAccumulator(
     private fun decodeTimings(element: JsonElement?): Double? {
         val obj = element as? JsonObject ?: return null
         return obj["predicted_per_second"]?.jsonPrimitive?.contentOrNull?.toDoubleOrNull()
+    }
+
+    private fun extractProviderError(root: JsonObject): StreamProviderError? {
+        val errorObj = root["error"] as? JsonObject ?: return null
+        val message = extractText(errorObj["message"])
+            ?: extractText(errorObj["detail"])
+            ?: extractText(root["message"])
+            ?: return null
+        val statusCode = root["status_code"]?.jsonPrimitive?.intOrNull
+            ?: errorObj["status_code"]?.jsonPrimitive?.intOrNull
+        return StreamProviderError(
+            statusCode = statusCode,
+            code = extractText(errorObj["code"]),
+            type = extractText(errorObj["type"]),
+            message = message
+        )
+    }
+
+    private fun buildProviderErrorMessage(error: StreamProviderError): String {
+        val suffix = buildList {
+            error.statusCode?.let { add("status=$it") }
+            error.code?.takeIf { it.isNotBlank() }?.let { add("code=$it") }
+            error.type?.takeIf { it.isNotBlank() }?.let { add("type=$it") }
+        }.joinToString(", ")
+        return if (suffix.isBlank()) {
+            "provider stream returned error: ${error.message}"
+        } else {
+            "provider stream returned error ($suffix): ${error.message}"
+        }
     }
 
     private fun appendReasoningPayload(element: JsonElement?) {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -4409,6 +4409,9 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         val payload = buildToolStartPayload(toolName, argsJson).toMutableMap().apply {
                             put("cardId", entryId)
                         }
+                        latestThinkingContent.takeIf { it.isNotBlank() }?.let { reasoning ->
+                            payload["reasoning_content"] = reasoning
+                        }
                         upsertToolEvent(
                             entryId = entryId,
                             roundIndex = roundIndex,
@@ -4487,6 +4490,9 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             .toMutableMap().apply {
                                 put("cardId", entryId)
                             }
+                        latestThinkingContent.takeIf { it.isNotBlank() }?.let { reasoning ->
+                            payload["reasoning_content"] = reasoning
+                        }
                         val success = payload["success"] != false
                         upsertToolEvent(
                             entryId = entryId,

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
@@ -219,6 +219,100 @@ class AgentConversationHistorySupportTest {
     }
 
     @Test
+    fun `buildPromptRelevantMessages preserves assistant reasoning content when present in payload`() {
+        val payload = AgentConversationHistorySupport.buildTextMessagePayload(
+            messageId = "a-reasoning",
+            user = 2,
+            text = "先调用工具",
+            reasoningContent = "需要先定位文件",
+            isError = false,
+            streamMeta = null,
+            createdAt = 1L
+        )
+        val entry = AgentConversationEntry(
+            id = 10,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "a-reasoning",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE,
+            status = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            summary = "先调用工具",
+            payloadJson = gson.toJson(payload),
+            createdAt = 1,
+            updatedAt = 1
+        )
+
+        val messages = AgentConversationHistorySupport.buildPromptRelevantMessages(listOf(entry))
+
+        assertEquals(1, messages.size)
+        assertEquals("assistant", messages.single().role)
+        assertEquals("需要先定位文件", messages.single().reasoningContent)
+    }
+
+    @Test
+    fun `prepareEntryForStorage keeps assistant reasoning content`() {
+        val payload = AgentConversationHistorySupport.buildTextMessagePayload(
+            messageId = "a-storage",
+            user = 2,
+            text = "完成首轮",
+            reasoningContent = "上一轮思考内容",
+            isError = false,
+            streamMeta = null,
+            createdAt = 1L
+        )
+        val entry = AgentConversationEntry(
+            id = 11,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "a-storage",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE,
+            status = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            summary = "完成首轮",
+            payloadJson = gson.toJson(payload),
+            createdAt = 1,
+            updatedAt = 1
+        )
+
+        val stored = AgentConversationHistorySupport.prepareEntryForStorage(entry)
+        val storedPayload = AgentConversationHistorySupport.readMap(stored.payloadJson)
+
+        assertEquals("上一轮思考内容", storedPayload["reasoning_content"])
+    }
+
+    @Test
+    fun `buildPromptRelevantMessages replays tool turn reasoning content from tool payload`() {
+        val entry = AgentConversationEntry(
+            id = 12,
+            conversationId = 7,
+            conversationMode = "normal",
+            entryId = "task-1-tool-1",
+            entryType = AgentConversationHistoryRepository.ENTRY_TYPE_TOOL_EVENT,
+            status = AgentConversationHistoryRepository.STATUS_SUCCESS,
+            summary = "抓取成功",
+            payloadJson = gson.toJson(
+                mapOf(
+                    "toolName" to "browser_use",
+                    "displayName" to "浏览器自动化",
+                    "toolType" to "builtin",
+                    "argsJson" to """{"url":"https://example.com"}""",
+                    "reasoning_content" to "需要先打开页面确认结构",
+                    "summary" to "抓取成功",
+                    "success" to true
+                )
+            ),
+            createdAt = 1,
+            updatedAt = 1
+        )
+
+        val messages = AgentConversationHistorySupport.buildPromptRelevantMessages(listOf(entry))
+
+        assertEquals(2, messages.size)
+        assertEquals("assistant", messages[0].role)
+        assertEquals("需要先打开页面确认结构", messages[0].reasoningContent)
+        assertEquals("browser_use", messages[0].toolCalls?.single()?.function?.name)
+    }
+
+    @Test
     fun `restoreToolPayloadFromUiMessage keeps agent tool cards restorable as tool events`() {
         val message = mapOf<String, Any?>(
             "id" to "task-1-tool-1",

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
@@ -3,6 +3,7 @@ package cn.com.omnimind.bot.agent
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AgentLlmStreamAccumulatorTest {
@@ -109,6 +110,40 @@ class AgentLlmStreamAccumulatorTest {
 
         assertEquals("需要查工具", turn.reasoning)
         assertEquals("需要查工具", turn.message.reasoningContent)
+    }
+
+    @Test
+    fun `tool rounds retain reasoning content even without full deepseek adapter mode`() {
+        val accumulator = AgentLlmStreamAccumulator(json = json)
+
+        accumulator.consume(
+            """{"choices":[{"delta":{"reasoning_content":"继续调用工具前要回传思考","content":"","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_time","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"""
+        )
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("继续调用工具前要回传思考", turn.reasoning)
+        assertEquals("继续调用工具前要回传思考", turn.message.reasoningContent)
+    }
+
+    @Test
+    fun `surfaces top level provider error instead of empty assistant turn`() {
+        val accumulator = AgentLlmStreamAccumulator(json = json)
+
+        accumulator.consume(
+            """{"error":{"code":"upstream_unavailable","message":"Upstream service is unavailable and returned no output.","param":null,"type":"service_unavailable_error"},"status_code":503}"""
+        )
+        accumulator.consume(
+            """{"id":"","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":0,"total_tokens":10}}"""
+        )
+        accumulator.consume("[DONE]")
+
+        val error = runCatching { accumulator.buildTurn() }.exceptionOrNull()
+
+        requireNotNull(error)
+        assertTrue(error.message.orEmpty().contains("provider stream returned error"))
+        assertTrue(error.message.orEmpty().contains("status=503"))
+        assertTrue(error.message.orEmpty().contains("upstream_unavailable"))
     }
 
     @Test


### PR DESCRIPTION
## 变更摘要

兼容 DeepSeek thinking / `reasoning_content` 协议的 provider 在 tool continuation 场景下因未回传前一轮 assistant reasoning 导致的 `400`；
对于newapi格式中转站返回上游 `503` 时被本地误报为 `assistant turn has neither content nor tool_calls` 的问题。将上游流式错
  误正确透传出来。

## 变更类型

- [ ] Bug 修复

## 关联 Issue

#issue291

## 主要改动

1. 修复 `reasoning_content` continuation 链路：对带 `tool_calls` 的 assistant 回合保留 reasoning，并在 tool event 落库、
  历史重建、上下文压缩后仍可恢复，兼容所有遵循 DeepSeek thinking continuation 语义的 provider，而不只限于官方 DeepSeek 路由。
  2. 在请求发送前增加 assistant reasoning 出站过滤策略：官方 DeepSeek / `protocolType=deepseek` 保留全部 reasoning，其他
  route 默认仅保留与 tool continuation 直接相关的 assistant reasoning，兼顾 thinking 协议兼容性与中转站兼容性。
  3. 修复流式错误分类：当 SSE 返回 top-level `error`（如 `503 upstream_unavailable`）且没有 assistant `content/tool_calls`
  时，优先透传真实 provider 错误，不再误报为空 assistant turn。

## 测试说明

已手动抓包修复，与真机测试验证。

测试细节：
对于中转站，上游错误就是503，与小万本身无关，已修复成透传错误。
<img width="3510" height="154" alt="image" src="https://github.com/user-attachments/assets/1fbf4d75-f0dc-40a3-b6f9-35599bc5311f" />

## UI 变更（如有）

无
## 风险与回滚
无

