### PR TITLE
fix: 修复 reasoning_content 在历史回放和重试链路中的丢失问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -1463,7 +1463,8 @@ internal object AgentConversationHistorySupport {
         if (encoded.length > MAX_STORAGE_ENTRY_PAYLOAD_CHARS) {
             return buildRecoveredTextEntry(
                 entry = entry.copy(summary = safeText),
-                originalPayloadLength = entry.payloadJson.length
+                originalPayloadLength = entry.payloadJson.length,
+                reasoningContent = safeReasoningContent
             )
         }
         return entry.copy(
@@ -1474,7 +1475,8 @@ internal object AgentConversationHistorySupport {
 
     private fun buildRecoveredTextEntry(
         entry: AgentConversationEntry,
-        originalPayloadLength: Int
+        originalPayloadLength: Int,
+        reasoningContent: String? = null
     ): AgentConversationEntry {
         val summary = normalizeStoredSummary(
             entry.summary.ifBlank { "历史消息内容过大，已压缩保存。" },
@@ -1488,6 +1490,22 @@ internal object AgentConversationHistorySupport {
             },
             MAX_STORAGE_MESSAGE_TEXT_CHARS
         )
+        val safeReasoningContent = if (
+            entry.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE
+        ) {
+            fitReasoningContentToRecoveredTextPayload(
+                messageId = entry.entryId,
+                text = safeText,
+                isError = entry.status == AgentConversationHistoryRepository.STATUS_ERROR,
+                createdAt = entry.createdAt,
+                reasoningContent = trimText(
+                    reasoningContent.orEmpty(),
+                    MAX_STORAGE_MESSAGE_TEXT_CHARS
+                ).trim().takeIf { it.isNotBlank() }
+            )
+        } else {
+            null
+        }
         val payload = buildTextMessagePayload(
             messageId = entry.entryId,
             user = if (entry.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_USER_MESSAGE) {
@@ -1497,6 +1515,7 @@ internal object AgentConversationHistorySupport {
             },
             text = safeText,
             attachments = emptyList(),
+            reasoningContent = safeReasoningContent,
             isError = entry.status == AgentConversationHistoryRepository.STATUS_ERROR,
             streamMeta = mapOf(
                 "payloadCompacted" to true,
@@ -1508,6 +1527,53 @@ internal object AgentConversationHistorySupport {
             summary = summary.ifBlank { safeText },
             payloadJson = gson.toJson(payload)
         )
+    }
+
+    private fun fitReasoningContentToRecoveredTextPayload(
+        messageId: String,
+        text: String,
+        isError: Boolean,
+        createdAt: Long,
+        reasoningContent: String?
+    ): String? {
+        val normalizedReasoning = reasoningContent?.trim()?.takeIf { it.isNotBlank() } ?: return null
+
+        fun encodedLength(candidate: String?): Int {
+            return gson.toJson(
+                buildTextMessagePayload(
+                    messageId = messageId,
+                    user = 2,
+                    text = text,
+                    attachments = emptyList(),
+                    reasoningContent = candidate,
+                    isError = isError,
+                    streamMeta = mapOf(
+                        "payloadCompacted" to true,
+                        "originalPayloadLength" to MAX_STORAGE_ENTRY_PAYLOAD_CHARS + 1
+                    ),
+                    createdAt = createdAt
+                )
+            ).length
+        }
+
+        if (encodedLength(normalizedReasoning) <= MAX_STORAGE_ENTRY_PAYLOAD_CHARS) {
+            return normalizedReasoning
+        }
+
+        var low = 0
+        var high = normalizedReasoning.length
+        var best: String? = null
+        while (low <= high) {
+            val mid = (low + high) ushr 1
+            val candidate = normalizedReasoning.take(mid).trimEnd().takeIf { it.isNotBlank() }
+            if (encodedLength(candidate) <= MAX_STORAGE_ENTRY_PAYLOAD_CHARS) {
+                best = candidate
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+        return best
     }
 
     private fun normalizeStoredSummary(summary: String, entryType: String): String {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -4260,6 +4260,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     missing: List<String>? = null,
                     extras: Map<String, Any?> = emptyMap()
                 ) {
+                    val effectiveThinking = thinking
+                        ?.takeIf { it.isNotBlank() }
+                        ?: latestThinkingContent.takeIf {
+                            kind == "text_snapshot" &&
+                                it.isNotBlank()
+                        }
                     val basePayload = AgentStreamEvent(
                         taskId = taskId,
                         seq = nextEventSeq(),
@@ -4269,7 +4275,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         roundIndex = roundIndex,
                         isFinal = isFinal,
                         text = text,
-                        thinking = thinking,
+                        thinking = effectiveThinking,
                         stage = stage,
                         prefillTokensPerSecond = prefillTokensPerSecond,
                         decodeTokensPerSecond = decodeTokensPerSecond,

--- a/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
+++ b/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
@@ -234,6 +234,9 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     final messageId = (event.entryId ?? '').trim();
     final text = event.text.trim();
     if (messageId.isEmpty || text.isEmpty) return;
+    final reasoningContent =
+        _normalizeReasoningContent(event.thinking) ??
+        _normalizeReasoningContent(deepThinkingContent);
     final streamMeta = ensureAgentStreamMessageMeta(
       _streamMetaFromEvent(event),
       entryId: messageId,
@@ -259,6 +262,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
                 'decodeTokensPerSecond': event.decodeTokensPerSecond,
             },
             streamMeta: streamMeta,
+            reasoningContent: reasoningContent,
           ),
         );
       } else {
@@ -274,6 +278,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         messages[index] = existing.copyWith(
           content: content,
           streamMeta: streamMeta,
+          reasoningContent: reasoningContent ?? existing.reasoningContent,
         );
       }
       isAiResponding = true;
@@ -317,6 +322,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         progress: toolEvent.progress,
         resultPreviewJson: toolEvent.resultPreviewJson,
         rawResultJson: toolEvent.rawResultJson,
+        reasoningContent: event.thinking,
         streamMeta: _streamMetaFromEvent(event),
       );
     });
@@ -331,6 +337,9 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         ? event.question.trim()
         : event.text.trim();
     final messageId = (event.entryId ?? '').trim();
+    final reasoningContent =
+        _normalizeReasoningContent(event.thinking) ??
+        _normalizeReasoningContent(deepThinkingContent);
     final streamMeta = ensureAgentStreamMessageMeta(
       _streamMetaFromEvent(event),
       entryId: messageId,
@@ -351,12 +360,15 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
               user: 2,
               content: {'text': text, 'id': messageId},
               streamMeta: streamMeta,
+              reasoningContent: reasoningContent,
             ),
           );
         } else {
           messages[index] = messages[index].copyWith(
             content: {'text': text, 'id': messageId},
             streamMeta: streamMeta,
+            reasoningContent:
+                reasoningContent ?? messages[index].reasoningContent,
           );
         }
       }
@@ -412,6 +424,9 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     final taskId = event.taskId;
     final messageId = (event.entryId ?? '').trim();
     final text = event.text.trim();
+    final reasoningContent =
+        _normalizeReasoningContent(event.thinking) ??
+        _normalizeReasoningContent(deepThinkingContent);
     final permissionCardId =
         (event.raw['permissionCardId'] ?? '$taskId-permission').toString();
     final executionPermissionIds = _resolveExecutionPermissionIds(
@@ -442,12 +457,15 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
               user: 2,
               content: {'text': text, 'id': messageId},
               streamMeta: replyStreamMeta,
+              reasoningContent: reasoningContent,
             ),
           );
         } else {
           messages[index] = messages[index].copyWith(
             content: {'text': text, 'id': messageId},
             streamMeta: replyStreamMeta,
+            reasoningContent:
+                reasoningContent ?? messages[index].reasoningContent,
           );
         }
       }
@@ -744,6 +762,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     required String progress,
     required String resultPreviewJson,
     required String rawResultJson,
+    String? reasoningContent,
     Map<String, dynamic>? streamMeta,
   }) {
     setState(() {
@@ -771,6 +790,9 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         'toolType': event.toolType,
         'serverName': event.serverName,
         'status': status,
+        'reasoning_content':
+            _normalizeReasoningContent(reasoningContent) ??
+            (existingCardData['reasoning_content'] ?? '').toString(),
         'summary': summary.isNotEmpty
             ? summary
             : (existingCardData['summary'] ?? '').toString(),
@@ -880,5 +902,10 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         : candidate;
     final remaining = _maxTerminalOutputChars - notice.length;
     return '$notice${body.substring(body.length > remaining ? body.length - remaining : 0)}';
+  }
+
+  String? _normalizeReasoningContent(String? value) {
+    final normalized = value?.trim() ?? '';
+    return normalized.isEmpty ? null : normalized;
   }
 }

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -990,6 +990,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
 
     _removeLatestLoadingIfExists(runtime);
     _removeOpenClawWaitingCard(runtime, taskId);
+    final reasoningContent =
+        _normalizeReasoningContent(runtime.currentThinkingMessages[taskId]) ??
+        _normalizeReasoningContent(runtime.deepThinkingContent);
     _updateOrAddAiMessage(
       runtime,
       taskId,
@@ -1001,6 +1004,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       attachments: attachments,
       prefillTokensPerSecond: prefillTokensPerSecond,
       decodeTokensPerSecond: decodeTokensPerSecond,
+      reasoningContent: reasoningContent,
     );
     if (emitVoiceUpdate &&
         !isError &&
@@ -1061,6 +1065,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     Map<String, dynamic>? streamMeta,
     double? prefillTokensPerSecond,
     double? decodeTokensPerSecond,
+    String? reasoningContent,
   }) {
     final resolvedStreamMeta = ensureAgentStreamMessageMeta(
       streamMeta,
@@ -1092,6 +1097,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
           content: content,
           isError: isError,
           streamMeta: resolvedStreamMeta,
+          reasoningContent: _normalizeReasoningContent(reasoningContent),
         ),
       );
       return;
@@ -1121,6 +1127,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         entryId: messageId,
         isFinal: isFinal,
       ),
+      reasoningContent:
+          _normalizeReasoningContent(reasoningContent) ??
+          existing.reasoningContent,
     );
   }
 
@@ -1164,6 +1173,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         isFinal: isFinal,
         prefillTokensPerSecond: prefillTokensPerSecond,
         decodeTokensPerSecond: decodeTokensPerSecond,
+        reasoningContent: runtime.currentThinkingMessages[taskId],
       );
     }
     if (batch != null && (hasPendingFlush || isFinal)) {
@@ -1647,6 +1657,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       streamMeta: _streamMetaFromEvent(event),
       prefillTokensPerSecond: event.prefillTokensPerSecond,
       decodeTokensPerSecond: event.decodeTokensPerSecond,
+      reasoningContent: event.thinking,
     );
     if (event.isFinal) {
       _syncMessageLinkPreviews(runtime, messageId);
@@ -1698,6 +1709,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       progress: toolEvent.progress,
       resultPreviewJson: toolEvent.resultPreviewJson,
       rawResultJson: toolEvent.rawResultJson,
+      reasoningContent: event.thinking,
       streamMeta: _streamMetaFromEvent(event),
     );
     if (event.kind == AgentStreamEventKind.toolCompleted) {
@@ -1731,6 +1743,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         renderMarkdown: true,
         isFinal: true,
         streamMeta: _streamMetaFromEvent(event),
+        reasoningContent: event.thinking,
       );
     }
     _finalizeThinkingCard(
@@ -1854,6 +1867,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         renderMarkdown: true,
         isFinal: true,
         streamMeta: _streamMetaFromEvent(event),
+        reasoningContent: event.thinking,
       );
     }
     _finalizeThinkingCard(
@@ -2255,6 +2269,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     List<Map<String, dynamic>> attachments = const [],
     double? prefillTokensPerSecond,
     double? decodeTokensPerSecond,
+    String? reasoningContent,
   }) {
     final index = runtime.messages.indexWhere((msg) => msg.id == taskId);
     if (index == -1) {
@@ -2287,6 +2302,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
           isLoading: false,
           isError: isError,
           isSummarizing: isSummarizing,
+          reasoningContent: _normalizeReasoningContent(reasoningContent),
         ),
       );
       return;
@@ -2320,6 +2336,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       isLoading: false,
       isError: isError,
       isSummarizing: isSummarizing,
+      reasoningContent:
+          _normalizeReasoningContent(reasoningContent) ??
+          existing.reasoningContent,
     );
   }
 
@@ -2933,6 +2952,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     required String progress,
     required String resultPreviewJson,
     required String rawResultJson,
+    String? reasoningContent,
     Map<String, dynamic>? streamMeta,
   }) {
     final index = runtime.messages.indexWhere((msg) => msg.id == cardId);
@@ -2960,6 +2980,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       'toolType': event.toolType,
       'serverName': event.serverName,
       'status': status,
+      'reasoning_content':
+          _normalizeReasoningContent(reasoningContent) ??
+          (existingCardData['reasoning_content'] ?? '').toString(),
       'summary': summary.isNotEmpty
           ? summary
           : (existingCardData['summary'] ?? '').toString(),
@@ -3124,6 +3147,11 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         : candidate;
     final remaining = _maxTerminalOutputChars - notice.length;
     return '$notice${body.substring(body.length > remaining ? body.length - remaining : 0)}';
+  }
+
+  String? _normalizeReasoningContent(String? value) {
+    final normalized = value?.trim() ?? '';
+    return normalized.isEmpty ? null : normalized;
   }
 
   void _removeOpenClawWaitingCard(

--- a/ui/lib/models/agent_stream_event.dart
+++ b/ui/lib/models/agent_stream_event.dart
@@ -127,7 +127,8 @@ class AgentStreamEvent {
       roundIndex: _asInt(raw['roundIndex']) ?? 0,
       isFinal: raw['isFinal'] == true,
       text: (raw['text'] ?? raw['message'] ?? '').toString(),
-      thinking: (raw['thinking'] ?? '').toString(),
+      thinking:
+          (raw['thinking'] ?? raw['reasoning_content'] ?? '').toString(),
       stage: _asInt(raw['stage']) ?? 1,
       prefillTokensPerSecond: _asDouble(raw['prefillTokensPerSecond']),
       decodeTokensPerSecond: _asDouble(raw['decodeTokensPerSecond']),

--- a/ui/lib/models/chat_message_model.dart
+++ b/ui/lib/models/chat_message_model.dart
@@ -34,6 +34,7 @@ class ChatMessageModel {
 
   /// 原生流式排序元数据
   final Map<String, dynamic>? streamMeta;
+  final String? reasoningContent;
 
   /// 创建时间
   final DateTime createAt;
@@ -48,6 +49,7 @@ class ChatMessageModel {
     this.isError = false,
     this.isSummarizing = false,
     this.streamMeta,
+    this.reasoningContent,
     DateTime? createAt,
   }) : createAt = createAt ?? DateTime.now();
 
@@ -114,6 +116,9 @@ class ChatMessageModel {
       streamMeta: _normalizeDynamic(json['streamMeta']) is Map<String, dynamic>
           ? _normalizeDynamic(json['streamMeta']) as Map<String, dynamic>
           : null,
+      reasoningContent: _normalizeOptionalString(
+        json['reasoning_content'] ?? json['reasoningContent'],
+      ),
       createAt: _parseCreateAt(json['createAt']),
     );
   }
@@ -130,6 +135,7 @@ class ChatMessageModel {
       'isError': isError,
       'isSummarizing': isSummarizing,
       if (streamMeta != null) 'streamMeta': streamMeta,
+      if (reasoningContent != null) 'reasoning_content': reasoningContent,
       'createAt': createAt.toIso8601String(),
     };
   }
@@ -150,6 +156,7 @@ class ChatMessageModel {
     String text, {
     String? id,
     bool isLoading = false,
+    String? reasoningContent,
   }) {
     final messageId = id ?? DateTime.now().millisecondsSinceEpoch.toString();
     return ChatMessageModel(
@@ -158,6 +165,7 @@ class ChatMessageModel {
       user: 2, // AI
       content: {'text': text, 'id': messageId},
       isLoading: isLoading,
+      reasoningContent: _normalizeOptionalString(reasoningContent),
     );
   }
 
@@ -188,6 +196,7 @@ class ChatMessageModel {
     bool? isError,
     bool? isSummarizing,
     Map<String, dynamic>? streamMeta,
+    String? reasoningContent,
     DateTime? createAt,
   }) {
     return ChatMessageModel(
@@ -200,6 +209,7 @@ class ChatMessageModel {
       isError: isError ?? this.isError,
       isSummarizing: isSummarizing ?? this.isSummarizing,
       streamMeta: streamMeta ?? this.streamMeta,
+      reasoningContent: reasoningContent ?? this.reasoningContent,
       createAt: createAt ?? this.createAt,
     );
   }
@@ -227,6 +237,11 @@ class ChatMessageModel {
       }
     }
     return null;
+  }
+
+  static String? _normalizeOptionalString(dynamic raw) {
+    final value = raw?.toString().trim() ?? '';
+    return value.isEmpty ? null : value;
   }
 
   static DateTime _parseCreateAt(dynamic raw) {


### PR DESCRIPTION
## 变更摘要

修复多轮会话和“消息完成后重试”场景下 reasoning_content 在历史回放、UI 快照回写和 tool card 恢复链路中丢失的问题，避免thinking 模型在后续请求中返回 400。
  本次改动同时覆盖原生会话历史重建、Flutter 消息模型持久化、实时流消息同步和重试快照恢复路径，确保 reasoning_content 能完整传回 API。
## 变更类型

- [ ] Bug 修复


## 关联 Issue

#issue291 271
## 主要改动

<!-- 请列出关键改动点，便于 Review -->

  1. 在原生会话历史链路中补齐 reasoning_content 保留与恢复，包括 tool event merge/storage/replay，以及超长 assistant 文本
     回收压缩时的恢复逻辑。
  2. 在 Flutter 侧补齐 assistant 消息、stream event 和 tool card 的 reasoning_content 持久化，避免
     replaceConversationMessages 重试回写时把 reasoning 丢掉。

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

抓包复现证据：
  1. 前一轮会话本身是正常结束的 随后触发了重试回写
  2. 回写后立刻重新发起新的 round=1 请求
  3. 首发即被小米 thinking continuity 校验拒绝(含 reasoning content 的模型均是同一链路)
<img width="3427" height="505" alt="image" src="https://github.com/user-attachments/assets/f10bce3e-5cbe-4788-93ab-40a46a5a603d" />

修复后验证证据：
同一实验环境、过程，没有再在首发阶段 400，而是正常结束。
<img width="2317" height="995" alt="image" src="https://github.com/user-attachments/assets/da034171-c7a5-431d-920f-a9bde98ea27f" />



## UI 变更（如有）

无
## 风险与回滚

无

