### PR TITLE
fix: 修复 DeepSeek/OpenAI 兼容链路 cache_control 400 问题

### DIFF
--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -1545,11 +1545,12 @@ object HttpController {
             requestBodyJson = baseBody,
             apiBase = apiBase
         )
-        return if (DeepSeekProvider.shouldUseOfficialAdapter(protocolType, apiBase)) {
+        val protocolReadyBody = if (DeepSeekProvider.shouldUseOfficialAdapter(protocolType, apiBase)) {
             applyOfficialDeepSeekThinkingMode(localReadyBody)
         } else {
             localReadyBody
         }
+        return stripAnthropicOnlyFieldsForOpenAiCompatible(protocolReadyBody)
     }
 
     private fun applyLocalBackendMaxCompletionTokens(
@@ -1616,6 +1617,25 @@ object HttpController {
             updated.remove("reasoning_effort")
         }
         return KxJsonObject(updated).toString()
+    }
+
+    private fun stripAnthropicOnlyFieldsForOpenAiCompatible(requestBodyJson: String): String {
+        val payload = runCatching {
+            completionJson.parseToJsonElement(requestBodyJson)
+        }.getOrNull() ?: return requestBodyJson
+        return stripAnthropicOnlyFields(payload).toString()
+    }
+
+    private fun stripAnthropicOnlyFields(payload: JsonElement): JsonElement {
+        return when (payload) {
+            is KxJsonObject -> KxJsonObject(
+                payload
+                    .filterKeys { it != "cache_control" }
+                    .mapValues { (_, value) -> stripAnthropicOnlyFields(value) }
+            )
+            is KxJsonArray -> KxJsonArray(payload.map(::stripAnthropicOnlyFields))
+            else -> payload
+        }
     }
 
     private suspend fun postOpenAIStreamRequestAsFlow(


### PR DESCRIPTION
## 变更摘要

修复了 OpenAI-compatible 请求链路中的协议字段污染问题：内部为 Anthropic 缓存保留的 cache_control 字段会被错误带到非Anthropic 请求中，导致部分服务端返回 400。改动后仅在 OpenAI-compatible 最终出站前递归清理 Anthropic 私有字段，不影响 Anthropic 路径本身的缓存能力。
## 变更类型

- [ ] Bug 修复


## 关联 Issue

#issue301
## 主要改动

<!-- 请列出关键改动点，便于 Review -->

在 HttpController.buildOpenAICompatibleRequestBody() 最终返回前新增净化步骤，统一清理 Anthropic 私有字段。

## 测试说明

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

复现错误：

从旧的历史请求日志里仍有 cache control 字段：

<img width="2681" height="186" alt="4299520a-0c74-4549-8e76-67aaa755b1c9" src="https://github.com/user-attachments/assets/c2c90d63-1c83-4e7c-b592-79425c58f31d" />
修复结果：

修复后请求里已不再有 cache control 字段：
<img width="1913" height="197" alt="14f62dd4-0ac8-47c0-ba69-8e09909cb751" src="https://github.com/user-attachments/assets/c1a70180-2727-4865-8239-04b11e895b8c" />

<img width="2663" height="501" alt="image" src="https://github.com/user-attachments/assets/7e47d038-665a-4f4f-ad87-ec322d9dfc11" />


## UI 变更（如有）

无
## 风险与回滚

无

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
