### PR TITLE
fix: 修复 anthropic 格式下 thinking 字段在工具调用后丢失问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -76,6 +76,8 @@ class AgentConversationHistoryRepository(
         entryId: String,
         text: String,
         reasoningContent: String? = null,
+        thinkingContent: String? = null,
+        thinkingSignature: String? = null,
         isError: Boolean = false,
         attachments: List<Map<String, Any?>> = emptyList(),
         streamMeta: Map<String, Any?>? = null,
@@ -87,6 +89,8 @@ class AgentConversationHistoryRepository(
             text = text,
             attachments = attachments,
             reasoningContent = reasoningContent,
+            thinkingContent = thinkingContent,
+            thinkingSignature = thinkingSignature,
             isError = isError,
             streamMeta = streamMeta,
             createdAt = createdAt

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -5,6 +5,7 @@ import cn.com.omnimind.baselib.database.AgentConversationEntryRecord
 import cn.com.omnimind.baselib.llm.AssistantToolCall
 import cn.com.omnimind.baselib.llm.AssistantToolCallFunction
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import cn.com.omnimind.baselib.llm.ChatCompletionThinkingContentBlock
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.serialization.json.JsonArray
@@ -70,12 +71,21 @@ internal object AgentConversationHistorySupport {
         text: String,
         attachments: List<Map<String, Any?>> = emptyList(),
         reasoningContent: String? = null,
+        thinkingContent: String? = null,
+        thinkingSignature: String? = null,
         isError: Boolean,
         streamMeta: Map<String, Any?>?,
         createdAt: Long
     ): Map<String, Any?> {
         val safeText = AgentTextSanitizer.sanitizeUtf16(text)
         val safeReasoning = AgentTextSanitizer.sanitizeUtf16(reasoningContent.orEmpty())
+            .trim()
+            .takeIf { it.isNotBlank() }
+        val safeThinking = AgentTextSanitizer.sanitizeUtf16(thinkingContent.orEmpty())
+            .trim()
+            .takeIf { it.isNotBlank() }
+            ?: safeReasoning
+        val safeThinkingSignature = AgentTextSanitizer.sanitizeUtf16(thinkingSignature.orEmpty())
             .trim()
             .takeIf { it.isNotBlank() }
         val historyAttachments = AgentImageAttachmentSupport
@@ -102,6 +112,18 @@ internal object AgentConversationHistorySupport {
         ).apply {
             if (user == 2 && safeReasoning != null) {
                 put("reasoning_content", safeReasoning)
+            }
+            if (user == 2 && safeThinking != null) {
+                put(
+                    "thinking",
+                    linkedMapOf<String, Any?>(
+                        "thinking" to safeThinking,
+                        "signature" to safeThinkingSignature
+                    ).filterValues { it != null }
+                )
+            }
+            if (user == 2 && safeThinkingSignature != null) {
+                put("thinking_signature", safeThinkingSignature)
             }
         }.filterValues { it != null }
     }
@@ -136,6 +158,32 @@ internal object AgentConversationHistorySupport {
                 ?: payload["reasoningContent"]?.toString()
                 ?: ""
         ).trim().takeIf { it.isNotBlank() }
+    }
+
+    private fun readThinkingSignature(payload: Map<String, Any?>): String? {
+        val thinkingMap = payload["thinking"] as? Map<*, *>
+        val signature = thinkingMap?.get("signature")
+            ?: payload["thinking_signature"]
+            ?: payload["thinkingSignature"]
+            ?: ""
+        return AgentTextSanitizer.sanitizeUtf16(signature.toString())
+            .trim()
+            .takeIf { it.isNotBlank() }
+    }
+
+    private fun readThinkingBlock(payload: Map<String, Any?>): ChatCompletionThinkingContentBlock? {
+        val thinkingMap = payload["thinking"] as? Map<*, *>
+        val thinkingText = AgentTextSanitizer.sanitizeUtf16(
+            (thinkingMap?.get("thinking")
+                ?: payload["thinking"]
+                ?: payload["reasoning_content"]
+                ?: payload["reasoningContent"]
+                ?: "").toString()
+        ).trim().takeIf { it.isNotBlank() } ?: return null
+        return ChatCompletionThinkingContentBlock(
+            thinking = thinkingText,
+            signature = readThinkingSignature(payload)
+        )
     }
 
     fun materializeRecord(record: AgentConversationEntryRecord): MaterializedEntry {
@@ -550,7 +598,9 @@ internal object AgentConversationHistorySupport {
             ChatCompletionMessage(
                 role = "assistant",
                 content = content,
-                reasoningContent = readReasoningContent(payload)
+                reasoningContent = readReasoningContent(payload),
+                thinking = readThinkingBlock(payload),
+                thinkingSignature = readThinkingSignature(payload)
             )
         )
     }
@@ -589,6 +639,8 @@ internal object AgentConversationHistorySupport {
         val assistantMessage = ChatCompletionMessage(
             role = "assistant",
             reasoningContent = readReasoningContent(payload),
+            thinking = readThinkingBlock(payload),
+            thinkingSignature = readThinkingSignature(payload),
             toolCalls = listOf(
                 AssistantToolCall(
                     id = toolCallId,
@@ -1433,6 +1485,16 @@ internal object AgentConversationHistorySupport {
         } else {
             null
         }
+        val safeThinkingSignature = if (
+            entry.entryType == AgentConversationHistoryRepository.ENTRY_TYPE_ASSISTANT_MESSAGE
+        ) {
+            trimText(
+                readThinkingSignature(payload).orEmpty(),
+                MAX_STORAGE_MESSAGE_TEXT_CHARS
+            ).trim().takeIf { it.isNotBlank() }
+        } else {
+            null
+        }
         val safeStreamMeta = compactDisplayStreamMeta(payload["streamMeta"])
         val safeAttachments = compactDisplayList(content["attachments"])
         fun buildPayload(attachments: List<Map<String, Any?>>): Map<String, Any?> {
@@ -1446,6 +1508,8 @@ internal object AgentConversationHistorySupport {
                 text = safeText,
                 attachments = attachments,
                 reasoningContent = safeReasoningContent,
+                thinkingContent = safeReasoningContent,
+                thinkingSignature = safeThinkingSignature,
                 isError = parseBoolean(
                     payload["isError"],
                     default = entry.status == AgentConversationHistoryRepository.STATUS_ERROR
@@ -1464,7 +1528,8 @@ internal object AgentConversationHistorySupport {
             return buildRecoveredTextEntry(
                 entry = entry.copy(summary = safeText),
                 originalPayloadLength = entry.payloadJson.length,
-                reasoningContent = safeReasoningContent
+                reasoningContent = safeReasoningContent,
+                thinkingSignature = safeThinkingSignature
             )
         }
         return entry.copy(
@@ -1476,7 +1541,8 @@ internal object AgentConversationHistorySupport {
     private fun buildRecoveredTextEntry(
         entry: AgentConversationEntry,
         originalPayloadLength: Int,
-        reasoningContent: String? = null
+        reasoningContent: String? = null,
+        thinkingSignature: String? = null
     ): AgentConversationEntry {
         val summary = normalizeStoredSummary(
             entry.summary.ifBlank { "历史消息内容过大，已压缩保存。" },
@@ -1516,6 +1582,8 @@ internal object AgentConversationHistorySupport {
             text = safeText,
             attachments = emptyList(),
             reasoningContent = safeReasoningContent,
+            thinkingContent = safeReasoningContent,
+            thinkingSignature = thinkingSignature,
             isError = entry.status == AgentConversationHistoryRepository.STATUS_ERROR,
             streamMeta = mapOf(
                 "payloadCompacted" to true,
@@ -1546,6 +1614,7 @@ internal object AgentConversationHistorySupport {
                     text = text,
                     attachments = emptyList(),
                     reasoningContent = candidate,
+                    thinkingContent = candidate,
                     isError = isError,
                     streamMeta = mapOf(
                         "payloadCompacted" to true,

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -71,9 +71,19 @@ class HttpAgentLlmClient(
         onReasoningUpdate: (suspend (String) -> Unit)?,
         onContentUpdate: (suspend (String) -> Unit)?
     ): ChatCompletionTurn {
+        val requestRouteInfo = HttpController.resolveChatCompletionRouteInfo(
+            modelOrScene = request.model,
+            explicitApiBase = modelOverride?.apiBase,
+            explicitApiKey = modelOverride?.apiKey,
+            explicitModel = modelOverride?.modelId,
+            explicitProtocolType = modelOverride?.protocolType
+        )
         val modelCandidates = buildModelCandidates(request.model)
         val variants = buildRequestVariants(
-            sanitizeRequestForTarget(request)
+            sanitizeRequestForTarget(
+                request = request,
+                keepAssistantThinking = requestRouteInfo.protocolType == "anthropic"
+            )
         )
         var lastFailure: StreamRequestFailure? = null
 
@@ -411,19 +421,40 @@ class HttpAgentLlmClient(
         return variants
     }
 
-    private fun sanitizeRequestForTarget(request: ChatCompletionRequest): ChatCompletionRequest {
-        if (shouldPreserveAllAssistantReasoning()) {
-            return request
-        }
+    private fun sanitizeRequestForTarget(
+        request: ChatCompletionRequest,
+        keepAssistantThinking: Boolean
+    ): ChatCompletionRequest {
+        val preserveReasoning = shouldPreserveAllAssistantReasoning()
         val sanitizedMessages = request.messages.mapIndexed { index, message ->
-            if (
-                message.role != "assistant" ||
-                message.reasoningContent.isNullOrBlank() ||
+            if (message.role != "assistant") {
+                return@mapIndexed message
+            }
+            val hasAssistantReasoningPayload = !message.reasoningContent.isNullOrBlank() ||
+                message.thinking != null ||
+                !message.thinkingSignature.isNullOrBlank()
+            if (!hasAssistantReasoningPayload) {
+                return@mapIndexed message
+            }
+            val retainReasoning = preserveReasoning ||
                 shouldRetainAssistantReasoning(index, request.messages)
+            if (
+                !retainReasoning
             ) {
-                message
+                message.copy(
+                    reasoningContent = null,
+                    thinking = null,
+                    thinkingSignature = null
+                )
+            } else if (!keepAssistantThinking &&
+                (message.thinking != null || !message.thinkingSignature.isNullOrBlank())
+            ) {
+                message.copy(
+                    thinking = null,
+                    thinkingSignature = null
+                )
             } else {
-                message.copy(reasoningContent = null)
+                message
             }
         }
         return if (sanitizedMessages == request.messages) {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -31,6 +31,8 @@ class AgentLlmStreamAccumulator(
 
     private val contentBuffer = StringBuilder()
     private val reasoningBuffer = StringBuilder()
+    private val thinkingSignatureBuffer = StringBuilder()
+    private var sawStructuredThinkingPayload = false
     private val inlineTextBuffer = StringBuilder()
     private val toolCallBuilders: SortedMap<Int, MutableToolCallBuilder> = TreeMap()
     private var providerError: StreamProviderError? = null
@@ -99,16 +101,23 @@ class AgentLlmStreamAccumulator(
             chunkHasPayload = appendTextPayload(root["text"]) || chunkHasPayload
             chunkHasPayload = appendTextPayload(root["message"]) || chunkHasPayload
             chunkHasPayload = appendTextPayload(root["output_text"]) || chunkHasPayload
-            appendReasoningPayload(root["reasoning_content"])
+            val hasThinkingPayload = appendThinkingPayload(root["thinking"])
+            if (!hasThinkingPayload) {
+                appendReasoningPayload(root["reasoning_content"])
+            }
             appendReasoningPayload(root["reasoning"])
-            appendReasoningPayload(root["thinking"])
+            appendThinkingSignaturePayload(root["thinking_signature"])
 
             val outputObj = root["output"] as? JsonObject
             if (outputObj != null) {
                 chunkHasPayload = appendTextPayload(outputObj["text"]) || chunkHasPayload
                 chunkHasPayload = appendTextPayload(outputObj["content"]) || chunkHasPayload
-                appendReasoningPayload(outputObj["reasoning_content"])
+                val outputHasThinkingPayload = appendThinkingPayload(outputObj["thinking"])
+                if (!outputHasThinkingPayload) {
+                    appendReasoningPayload(outputObj["reasoning_content"])
+                }
                 appendReasoningPayload(outputObj["reasoning"])
+                appendThinkingSignaturePayload(outputObj["thinking_signature"])
             }
         }
 
@@ -246,6 +255,9 @@ class AgentLlmStreamAccumulator(
 
         val content = AgentTextSanitizer.sanitizeUtf16(contentBuffer.toString())
         val reasoning = AgentTextSanitizer.sanitizeUtf16(reasoningBuffer.toString())
+        val thinkingSignature = AgentTextSanitizer.sanitizeUtf16(thinkingSignatureBuffer.toString())
+            .trim()
+            .takeIf { it.isNotBlank() }
         if (finishReasonIndicatesToolCall(finishReason) && toolCalls.isEmpty()) {
             throw IllegalStateException(
                 "finish_reason indicates tool call but no tool_calls parsed; finish_reason=${finishReason.orEmpty()}, last_chunk=$lastChunkPreview"
@@ -270,8 +282,15 @@ class AgentLlmStreamAccumulator(
                         includeReasoningInAssistantMessage ||
                             toolCalls.isNotEmpty() ||
                             finishReasonIndicatesToolCall(finishReason)
-                        )
-                }
+                    )
+                },
+                thinking = reasoning.takeIf { it.isNotBlank() }?.let { thinkingText ->
+                    ChatCompletionThinkingContentBlock(
+                        thinking = thinkingText,
+                        signature = thinkingSignature
+                    )
+                }?.takeIf { sawStructuredThinkingPayload },
+                thinkingSignature = thinkingSignature.takeIf { sawStructuredThinkingPayload }
             ),
             reasoning = reasoning,
             finishReason = finishReason,
@@ -346,9 +365,12 @@ class AgentLlmStreamAccumulator(
     private fun consumeMessageLike(message: JsonObject, isDelta: Boolean): Boolean {
         var hasPayload = false
         hasPayload = appendTextPayload(message["content"]) || hasPayload
-        appendReasoningPayload(message["reasoning_content"])
+        val hasThinkingPayload = appendThinkingPayload(message["thinking"])
+        if (!hasThinkingPayload) {
+            appendReasoningPayload(message["reasoning_content"])
+        }
         appendReasoningPayload(message["reasoning"])
-        appendReasoningPayload(message["thinking"])
+        appendThinkingSignaturePayload(message["thinking_signature"])
 
         val toolCalls = message["tool_calls"] as? JsonArray
         if (toolCalls != null) {
@@ -499,6 +521,26 @@ class AgentLlmStreamAccumulator(
         extractText(element)?.let { appendReasoningText(it) }
     }
 
+    private fun appendThinkingPayload(element: JsonElement?): Boolean {
+        var appended = false
+        extractThinkingText(element)?.let {
+            appendReasoningText(it)
+            appended = true
+        }
+        if (appended) {
+            sawStructuredThinkingPayload = true
+        }
+        extractThinkingSignature(element)?.let { appendThinkingSignatureText(it) }
+        return appended
+    }
+
+    private fun appendThinkingSignaturePayload(element: JsonElement?) {
+        extractText(element)?.let {
+            sawStructuredThinkingPayload = true
+            appendThinkingSignatureText(it)
+        }
+    }
+
     private fun appendTextPayload(element: JsonElement?): Boolean {
         val text = extractText(element) ?: return false
         appendTextChunk(text)
@@ -619,6 +661,23 @@ class AgentLlmStreamAccumulator(
             return
         }
         reasoningBuffer.append(text)
+    }
+
+    private fun appendThinkingSignatureText(text: String) {
+        if (text.isEmpty()) {
+            return
+        }
+        thinkingSignatureBuffer.append(text)
+    }
+
+    private fun extractThinkingText(element: JsonElement?): String? {
+        val obj = element as? JsonObject ?: return extractText(element)
+        return extractText(obj["thinking"]) ?: extractText(obj["text"]) ?: extractText(obj["content"])
+    }
+
+    private fun extractThinkingSignature(element: JsonElement?): String? {
+        val obj = element as? JsonObject ?: return null
+        return extractText(obj["signature"])
     }
 
     private fun extractText(element: JsonElement?): String? {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/ChatCompletionModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/ChatCompletionModels.kt
@@ -5,6 +5,7 @@ import cn.com.omnimind.baselib.llm.contentText as sharedContentText
 typealias ChatCompletionRequest = cn.com.omnimind.baselib.llm.ChatCompletionRequest
 typealias ChatCompletionStreamOptions = cn.com.omnimind.baselib.llm.ChatCompletionStreamOptions
 typealias ChatCompletionMessage = cn.com.omnimind.baselib.llm.ChatCompletionMessage
+typealias ChatCompletionThinkingContentBlock = cn.com.omnimind.baselib.llm.ChatCompletionThinkingContentBlock
 typealias ChatCompletionTool = cn.com.omnimind.baselib.llm.ChatCompletionTool
 typealias ChatCompletionFunction = cn.com.omnimind.baselib.llm.ChatCompletionFunction
 typealias AssistantToolCall = cn.com.omnimind.baselib.llm.AssistantToolCall

--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -11,6 +11,7 @@ import cn.com.omnimind.baselib.llm.AiRequestLogStore
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionStreamOptions
+import cn.com.omnimind.baselib.llm.ChatCompletionThinkingContentBlock
 import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.database.DatabaseHelper
 import cn.com.omnimind.baselib.database.TokenUsageRecord
@@ -730,8 +731,12 @@ object HttpController {
             when (msg.role) {
                 "assistant" -> {
                     val toolCalls = msg.toolCalls
+                    val replayThinking = buildAnthropicThinkingBlock(msg)
                     if (!toolCalls.isNullOrEmpty()) {
                         val content = JSONArray()
+                        if (replayThinking != null) {
+                            content.put(replayThinking)
+                        }
                         // optional text part
                         val textPart = msg.content?.let {
                             if (it is kotlinx.serialization.json.JsonPrimitive) it.content.trim() else null
@@ -752,8 +757,17 @@ object HttpController {
                         messages.put(JSONObject().put("role", "assistant").put("content", content))
                     } else {
                         val content = convertContentToAnthropicFormat(msg.content)
-                        if (content != null) {
-                            messages.put(JSONObject().put("role", "assistant").put("content", content))
+                        if (replayThinking != null || content != null) {
+                            val mergedContent = JSONArray()
+                            if (replayThinking != null) {
+                                mergedContent.put(replayThinking)
+                            }
+                            appendAnthropicContentBlocks(mergedContent, content)
+                            messages.put(
+                                JSONObject()
+                                    .put("role", "assistant")
+                                    .put("content", mergedContent)
+                            )
                         }
                     }
                 }
@@ -1044,6 +1058,30 @@ object HttpController {
                         val index = json.optInt("index", 0)
                         val block = json.optJSONObject("content_block") ?: return
                         when (block.optString("type")) {
+                            "thinking" -> {
+                                val initialThinking = block.optString("thinking", "")
+                                if (initialThinking.isNotEmpty()) {
+                                    val chunk = buildOpenAIChunk(
+                                        deltaJson = JSONObject()
+                                            .put("reasoning_content", initialThinking)
+                                            .put(
+                                                "thinking",
+                                                JSONObject().put("thinking", initialThinking)
+                                            ),
+                                        finishReason = null
+                                    )
+                                    outer.onEvent(eventSource, id, type, chunk)
+                                }
+                                val initialSignature = block.optString("signature", "")
+                                if (initialSignature.isNotEmpty()) {
+                                    val chunk = buildOpenAIChunk(
+                                        deltaJson = JSONObject()
+                                            .put("thinking_signature", initialSignature),
+                                        finishReason = null
+                                    )
+                                    outer.onEvent(eventSource, id, type, chunk)
+                                }
+                            }
                             "tool_use" -> {
                                 toolUseBlocks[index] = JSONObject()
                                     .put("id", block.optString("id", "tool_$index"))
@@ -1107,7 +1145,22 @@ object HttpController {
                                 val thinking = delta.optString("thinking", "")
                                 if (thinking.isNotEmpty()) {
                                     val chunk = buildOpenAIChunk(
-                                        deltaJson = JSONObject().put("reasoning_content", thinking),
+                                        deltaJson = JSONObject()
+                                            .put("reasoning_content", thinking)
+                                            .put(
+                                                "thinking",
+                                                JSONObject().put("thinking", thinking)
+                                            ),
+                                        finishReason = null
+                                    )
+                                    outer.onEvent(eventSource, id, type, chunk)
+                                }
+                            }
+                            "signature_delta" -> {
+                                val signature = delta.optString("signature", "")
+                                if (signature.isNotEmpty()) {
+                                    val chunk = buildOpenAIChunk(
+                                        deltaJson = JSONObject().put("thinking_signature", signature),
                                         finishReason = null
                                     )
                                     outer.onEvent(eventSource, id, type, chunk)
@@ -1246,13 +1299,23 @@ object HttpController {
     ): ChatCompletionRequest {
         val disableThinking = reasoningEffort == "no"
         val chatMessages = messages.map { message ->
+            val reasoningContent = parseOptionalText(
+                message["reasoning_content"] ?: message["reasoningContent"]
+            )
+            val thinkingSignature = parseOptionalText(
+                message["thinking_signature"] ?: message["thinkingSignature"]
+            )
             ChatCompletionMessage(
                 role = message["role"]?.toString().orEmpty().ifBlank { "user" },
                 content = parseChatMessageContent(message["content"]),
                 toolCalls = parseAssistantToolCalls(message["tool_calls"] ?: message["toolCalls"]),
-                reasoningContent = parseOptionalText(
-                    message["reasoning_content"] ?: message["reasoningContent"]
+                reasoningContent = reasoningContent,
+                thinking = parseThinkingContentBlock(
+                    rawThinking = message["thinking"],
+                    rawSignature = message["thinking_signature"] ?: message["thinkingSignature"],
+                    fallbackReasoning = reasoningContent
                 ),
+                thinkingSignature = thinkingSignature,
                 toolCallId = parseOptionalText(message["tool_call_id"] ?: message["toolCallId"]),
                 name = parseOptionalText(message["name"])
             )
@@ -1321,6 +1384,45 @@ object HttpController {
         return normalized.takeIf { it.isNotEmpty() }
     }
 
+    private fun parseThinkingContentBlock(
+        rawThinking: Any?,
+        rawSignature: Any?,
+        fallbackReasoning: String?
+    ): ChatCompletionThinkingContentBlock? {
+        val signature = parseOptionalText(rawSignature)
+        val normalized = when (rawThinking) {
+            is Map<*, *> -> {
+                val thinkingText = parseOptionalText(
+                    rawThinking["thinking"] ?: rawThinking["text"] ?: rawThinking["content"]
+                )
+                if (thinkingText == null) {
+                    null
+                } else {
+                    ChatCompletionThinkingContentBlock(
+                        thinking = thinkingText,
+                        signature = parseOptionalText(rawThinking["signature"]) ?: signature
+                    )
+                }
+            }
+            else -> {
+                val thinkingText = parseOptionalText(rawThinking) ?: fallbackReasoning
+                thinkingText?.let {
+                    ChatCompletionThinkingContentBlock(
+                        thinking = it,
+                        signature = signature
+                    )
+                }
+            }
+        }
+        if (normalized != null) return normalized
+        return fallbackReasoning?.let { fallback ->
+            ChatCompletionThinkingContentBlock(
+                thinking = fallback,
+                signature = signature
+            )
+        }
+    }
+
     private fun parseContentBlocks(raw: List<*>): KxJsonArray {
         val blocks = mutableListOf<KxJsonObject>()
         raw.forEach { item ->
@@ -1354,6 +1456,26 @@ object HttpController {
                             )
                             if (imageUrl.isNotBlank()) {
                                 blocks.add(buildImageContent(imageUrl))
+                            }
+                        }
+                        "thinking" -> {
+                            val thinkingText = item["thinking"]?.toString()
+                                ?.trim()
+                                ?.takeIf { it.isNotEmpty() }
+                                ?: item["text"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+                            if (thinkingText != null) {
+                                blocks.add(
+                                    buildJsonObject {
+                                        put("type", JsonPrimitive("thinking"))
+                                        put("thinking", JsonPrimitive(thinkingText))
+                                        item["signature"]?.toString()?.trim()
+                                            ?.takeIf { it.isNotEmpty() }
+                                            ?.let { put("signature", JsonPrimitive(it)) }
+                                        parseAnyToJsonElement(item["cache_control"])?.let {
+                                            put("cache_control", it)
+                                        }
+                                    }
+                                )
                             }
                         }
                     }
@@ -1628,13 +1750,90 @@ object HttpController {
 
     private fun stripAnthropicOnlyFields(payload: JsonElement): JsonElement {
         return when (payload) {
-            is KxJsonObject -> KxJsonObject(
-                payload
-                    .filterKeys { it != "cache_control" }
-                    .mapValues { (_, value) -> stripAnthropicOnlyFields(value) }
-            )
+            is KxJsonObject -> {
+                val isAssistantMessage = payload["role"]
+                    .let { it as? JsonPrimitive }
+                    ?.contentOrNull
+                    ?.trim()
+                    ?.equals("assistant", ignoreCase = true) == true
+                KxJsonObject(
+                    payload
+                        .filterKeys { key ->
+                            key != "cache_control" &&
+                                !(isAssistantMessage && (key == "thinking" || key == "thinking_signature"))
+                        }
+                        .mapValues { (_, value) -> stripAnthropicOnlyFields(value) }
+                )
+            }
             is KxJsonArray -> KxJsonArray(payload.map(::stripAnthropicOnlyFields))
             else -> payload
+        }
+    }
+
+    private fun appendAnthropicContentBlocks(target: JSONArray, content: Any?) {
+        when (content) {
+            null -> Unit
+            is JSONArray -> {
+                for (index in 0 until content.length()) {
+                    target.put(content.opt(index))
+                }
+            }
+            is JSONObject -> target.put(content)
+            else -> {
+                val text = content.toString().trim()
+                if (text.isNotEmpty()) {
+                    target.put(
+                        JSONObject()
+                            .put("type", "text")
+                            .put("text", text)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun buildAnthropicThinkingBlock(message: ChatCompletionMessage): JSONObject? {
+        val thinkingBlock = parseThinkingBlock(message)
+        val thinkingText = thinkingBlock?.thinking?.trim().orEmpty()
+            .ifEmpty { message.reasoningContent?.trim().orEmpty() }
+        if (thinkingText.isEmpty()) return null
+
+        val signature = thinkingBlock?.signature?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: message.thinkingSignature?.trim()?.takeIf { it.isNotEmpty() }
+
+        return JSONObject()
+            .put("type", "thinking")
+            .put("thinking", thinkingText)
+            .apply {
+                if (signature != null) {
+                    put("signature", signature)
+                }
+            }
+    }
+
+    private fun parseThinkingBlock(message: ChatCompletionMessage): ChatCompletionThinkingContentBlock? {
+        message.thinking?.let { return it }
+        val contentObj = message.content as? KxJsonObject ?: return null
+        val raw = contentObj["thinking"] ?: return null
+        return when (raw) {
+            is JsonPrimitive -> raw.contentOrNull?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { ChatCompletionThinkingContentBlock(thinking = it) }
+            is KxJsonObject -> {
+                val thinking = (raw["thinking"] as? JsonPrimitive)?.contentOrNull
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?: return null
+                val signature = (raw["signature"] as? JsonPrimitive)?.contentOrNull
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+                ChatCompletionThinkingContentBlock(
+                    thinking = thinking,
+                    signature = signature
+                )
+            }
+            else -> null
         }
     }
 
@@ -2599,6 +2798,7 @@ object HttpController {
             is JSONObject -> when {
                 contentRaw.has("text") -> contentRaw.optString("text")
                 contentRaw.has("content") -> contentRaw.optString("content")
+                contentRaw.has("thinking") -> contentRaw.optString("thinking")
                 else -> ""
             }
             else -> ""

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAIChatCompletionModels.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAIChatCompletionModels.kt
@@ -59,9 +59,18 @@ data class ChatCompletionMessage(
     val toolCalls: List<AssistantToolCall>? = null,
     @SerialName("reasoning_content")
     val reasoningContent: String? = null,
+    val thinking: ChatCompletionThinkingContentBlock? = null,
+    @SerialName("thinking_signature")
+    val thinkingSignature: String? = null,
     @SerialName("tool_call_id")
     val toolCallId: String? = null,
     val name: String? = null
+)
+
+@Serializable
+data class ChatCompletionThinkingContentBlock(
+    val thinking: String,
+    val signature: String? = null
 )
 
 @Serializable


### PR DESCRIPTION
## 变更摘要

修复 Anthropic 协议下多轮工具调用场景的 thinking 内容块回放问题，避免服务端返回 `content[].thinking` 相关 400 错误。
  本次改动确保在续轮请求中正确保留并回放必要的 thinking/signature 信息，同时保持 OpenAI 格式兼容路径不变。

## 变更类型

- [ ] Bug 修复


## 关联 Issue

#307

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

  1. 在会话历史与请求构造链路中补齐 Anthropic thinking 内容块的持久化与续轮回放逻辑。
  2. 调整流式累积/解析逻辑，保证 thinking/signature/tool_use 块在多轮中按协议衔接。

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

抓包日志正确返回：
<img width="1878" height="244" alt="H3C~ B5QHN4(LNWP)MU3KZC" src="https://github.com/user-attachments/assets/9b316729-2776-434a-a7ae-9eb99a1e6b6a" />

请求体结构包含 `content_block_start(type=thinking)`、`thinking_delta`、`signature_delta`、`tool_use`、`message_stop`
<img width="3547" height="67" alt="02C~4$CH7_1EIZ _LYKA(4T" src="https://github.com/user-attachments/assets/331a0df4-b1d7-4f1e-8d34-29aabd04f912" />


## UI 变更（如有）

无
## 风险与回滚

无

