### PR TITLE
fix: 兼容 mimo 供应商下 tool 的截图图片续传

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -37,6 +37,43 @@ interface AgentLlmClient {
 class HttpAgentLlmClient(
     private val scope: CoroutineScope,
     private val modelOverride: AgentModelOverride? = null,
+    private val streamRequestOp: suspend (
+        model: String,
+        requestBodyJson: String,
+        event: EventSourceListener,
+        explicitApiBase: String?,
+        explicitApiKey: String?,
+        explicitModel: String?,
+        explicitProtocolType: String?,
+        forceHttp1: Boolean
+    ) -> EventSource = { model, requestBodyJson, event, explicitApiBase, explicitApiKey, explicitModel, explicitProtocolType, forceHttp1 ->
+        HttpController.postChatCompletionsStreamRequest(
+            model = model,
+            requestBodyJson = requestBodyJson,
+            event = event,
+            explicitApiBase = explicitApiBase,
+            explicitApiKey = explicitApiKey,
+            explicitModel = explicitModel,
+            explicitProtocolType = explicitProtocolType,
+            forceHttp1 = forceHttp1
+        )
+    },
+    private val resolveRouteInfoOp: (
+        modelOrScene: String,
+        explicitApiBase: String?,
+        explicitApiKey: String?,
+        explicitModel: String?,
+        explicitProtocolType: String?
+    ) -> HttpController.ChatCompletionRouteInfo = { modelOrScene, explicitApiBase, explicitApiKey, explicitModel, explicitProtocolType ->
+        HttpController.resolveChatCompletionRouteInfo(
+            modelOrScene = modelOrScene,
+            explicitApiBase = explicitApiBase,
+            explicitApiKey = explicitApiKey,
+            explicitModel = explicitModel,
+            explicitProtocolType = explicitProtocolType
+        )
+    },
+    private val streamIdleWatchdogMs: Long = 0L,
     private val json: Json = Json {
         ignoreUnknownKeys = true
         isLenient = true
@@ -49,6 +86,8 @@ class HttpAgentLlmClient(
     private companion object {
         const val REASONING_UPDATE_INTERVAL_MS =
             ReasoningStreamUpdatePolicy.DEFAULT_INTERVAL_MS
+        const val DEFAULT_CLOSED_STREAM_ERROR =
+            "chat completion stream closed before completion signal"
     }
 
     private data class StreamRequestVariant(
@@ -156,12 +195,12 @@ class HttpAgentLlmClient(
     ): ChatCompletionTurn {
         val streamDone = CompletableDeferred<ChatCompletionTurn>()
         val completed = AtomicBoolean(false)
-        val routeInfo = HttpController.resolveChatCompletionRouteInfo(
-            modelOrScene = model,
-            explicitApiBase = modelOverride?.apiBase,
-            explicitApiKey = modelOverride?.apiKey,
-            explicitModel = modelOverride?.modelId,
-            explicitProtocolType = modelOverride?.protocolType
+        val routeInfo = resolveRouteInfoOp(
+            model,
+            modelOverride?.apiBase,
+            modelOverride?.apiKey,
+            modelOverride?.modelId,
+            modelOverride?.protocolType
         )
         val accumulator = AgentLlmStreamAccumulator(
             json = json,
@@ -178,6 +217,7 @@ class HttpAgentLlmClient(
         val reasoningLock = Any()
         var lastContent = ""
         var eventSource: EventSource? = null
+        var streamIdleWatchdog: Job? = null
         val emissionQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
         val emissionJob = scope.launch {
             for (block in emissionQueue) {
@@ -192,6 +232,29 @@ class HttpAgentLlmClient(
                 return
             }
             emissionQueue.trySend(block)
+        }
+
+        fun cancelWatchdog() {
+            streamIdleWatchdog?.cancel()
+            streamIdleWatchdog = null
+        }
+
+        fun scheduleWatchdog() {
+            val timeoutMs = streamIdleWatchdogMs
+            if (timeoutMs <= 0L) {
+                return
+            }
+            cancelWatchdog()
+            streamIdleWatchdog = scope.launch {
+                delay(timeoutMs)
+                if (!completed.compareAndSet(false, true)) {
+                    return@launch
+                }
+                streamDone.completeExceptionally(
+                    IllegalStateException("chat completion stream idle timeout after ${timeoutMs}ms")
+                )
+                eventSource?.cancel()
+            }
         }
 
         fun dispatchReasoningSnapshot(reasoning: String) {
@@ -273,6 +336,7 @@ class HttpAgentLlmClient(
 
         fun completeStream(eventSource: EventSource? = null) {
             if (!completed.compareAndSet(false, true)) return
+            cancelWatchdog()
             runCatching {
                 val turn = accumulator.buildTurn()
                 enforceReasoningEchoIfRequired(turn, routeInfo)
@@ -288,6 +352,10 @@ class HttpAgentLlmClient(
         }
 
         val listener = object : EventSourceListener() {
+            override fun onOpen(eventSource: EventSource, response: Response) {
+                scheduleWatchdog()
+            }
+
             override fun onEvent(
                 eventSource: EventSource,
                 id: String?,
@@ -296,6 +364,7 @@ class HttpAgentLlmClient(
             ) {
                 if (completed.get()) return
                 runCatching {
+                    scheduleWatchdog()
                     val done = accumulator.consume(data)
                     emitReasoning()
                     emitContent()
@@ -312,11 +381,25 @@ class HttpAgentLlmClient(
             }
 
             override fun onClosed(eventSource: EventSource) {
-                completeStream()
+                if (completed.get()) {
+                    cancelWatchdog()
+                    return
+                }
+                if (accumulator.canFinalizeOnClosed()) {
+                    completeStream()
+                    return
+                }
+                cancelWatchdog()
+                if (completed.compareAndSet(false, true)) {
+                    streamDone.completeExceptionally(
+                        IllegalStateException(DEFAULT_CLOSED_STREAM_ERROR)
+                    )
+                }
             }
 
             override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
                 if (!completed.compareAndSet(false, true)) return
+                cancelWatchdog()
                 val responseBody = extractResponseBody(response)
                 val reason = extractErrorReason(responseBody)
                     ?: sanitizeReason(t?.message)
@@ -332,18 +415,20 @@ class HttpAgentLlmClient(
         }
 
         try {
-            eventSource = HttpController.postChatCompletionsStreamRequest(
-                model = model,
-                requestBodyJson = requestJson,
-                event = listener,
-                explicitApiBase = modelOverride?.apiBase,
-                explicitApiKey = modelOverride?.apiKey,
-                explicitModel = modelOverride?.modelId,
-                explicitProtocolType = modelOverride?.protocolType,
-                forceHttp1 = forceHttp1
+            eventSource = streamRequestOp(
+                model,
+                requestJson,
+                listener,
+                modelOverride?.apiBase,
+                modelOverride?.apiKey,
+                modelOverride?.modelId,
+                modelOverride?.protocolType,
+                forceHttp1
             )
+            scheduleWatchdog()
             return streamDone.await()
         } finally {
+            cancelWatchdog()
             reasoningEmitJob?.cancel()
             eventSource?.cancel()
             emissionQueue.close()

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -27,7 +27,9 @@ class AgentOrchestrator(
     private val toolRegistry: AgentToolCatalog,
     private val toolRouter: AgentToolExecutor,
     private val eventAdapter: AgentEventAdapter,
-    private val model: String
+    private val model: String,
+    private val toolImageContinuationPolicy: AgentToolImageContinuationPolicy =
+        AgentToolImageContinuationPolicy.DEFAULT
 ) {
     data class Input(
         val callback: AgentCallback,
@@ -480,7 +482,20 @@ class AgentOrchestrator(
             result = result,
             extras = failureLearning?.toPayload() ?: emptyMap()
         )
-        val imageDataUrl = (result as? ToolExecutionResult.ContextResult)?.imageDataUrl
+        val imageDataUrl = (result as? ToolExecutionResult.ContextResult)
+            ?.imageDataUrl
+            ?.takeIf { it.isNotBlank() }
+            ?.takeIf { toolImageContinuationPolicy.supportsToolImageContinuation }
+        if (
+            result is ToolExecutionResult.ContextResult &&
+            !result.imageDataUrl.isNullOrBlank() &&
+            imageDataUrl == null
+        ) {
+            logInfo(
+                tag,
+                "skip_tool_image_continuation tool=${toolCall.function.name} route=${toolImageContinuationPolicy.routeLabel}"
+            )
+        }
 
         val content: JsonElement = if (imageDataUrl != null) {
             buildJsonArray {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentToolImageContinuationPolicy.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentToolImageContinuationPolicy.kt
@@ -1,0 +1,81 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.assists.controller.http.HttpController
+import cn.com.omnimind.baselib.llm.LocalModelProviderBridge
+import java.util.Locale
+
+data class AgentToolImageContinuationPolicy(
+    val supportsToolImageContinuation: Boolean,
+    val routeLabel: String = "unknown"
+) {
+    companion object {
+        val DEFAULT = AgentToolImageContinuationPolicy(
+            supportsToolImageContinuation = true
+        )
+    }
+}
+
+object AgentToolImageContinuationPolicyResolver {
+    fun resolve(
+        routeInfo: HttpController.ChatCompletionRouteInfo?
+    ): AgentToolImageContinuationPolicy {
+        if (routeInfo == null) {
+            return AgentToolImageContinuationPolicy.DEFAULT
+        }
+        val routeLabel = buildRouteLabel(routeInfo)
+        if (LocalModelProviderBridge.isBuiltinLocalProvider(routeInfo.providerProfileId, routeInfo.apiBase)) {
+            return AgentToolImageContinuationPolicy(
+                supportsToolImageContinuation = true,
+                routeLabel = routeLabel
+            )
+        }
+        return AgentToolImageContinuationPolicy(
+            supportsToolImageContinuation = !isKnownIncompatibleRoute(routeInfo),
+            routeLabel = routeLabel
+        )
+    }
+
+    // TODO(issue321): replace this route heuristic with provider capability flags once
+    // Mimo becomes a first-class builtin provider profile.
+    private fun isKnownIncompatibleRoute(
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): Boolean {
+        return candidateTokens(routeInfo).any { token ->
+            token.contains("xiaomi") ||
+                token.startsWith("mimo-") ||
+                token.contains("/mimo")
+        }
+    }
+
+    private fun candidateTokens(
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): List<String> {
+        return listOfNotNull(
+            routeInfo.requestedModel,
+            routeInfo.resolvedModel,
+            routeInfo.providerProfileId,
+            routeInfo.providerProfileName,
+            routeInfo.routeTag,
+            routeInfo.apiBase
+        ).mapNotNull { value ->
+            value.trim()
+                .lowercase(Locale.ROOT)
+                .takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun buildRouteLabel(
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): String {
+        return buildList {
+            add("model=${routeInfo.resolvedModel}")
+            add("protocol=${routeInfo.protocolType}")
+            routeInfo.providerProfileId?.takeIf { it.isNotBlank() }?.let {
+                add("profile=$it")
+            }
+            routeInfo.routeTag?.takeIf { it.isNotBlank() }?.let {
+                add("route=$it")
+            }
+        }.joinToString(separator = ",")
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
@@ -1,6 +1,7 @@
 package cn.com.omnimind.bot.agent
 
 import android.content.Context
+import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.i18n.AppLocaleManager
 import cn.com.omnimind.bot.agent.workspace.memory.LongTermMemoryIndex
 import cn.com.omnimind.bot.agent.workspace.memory.MemoryRetrievalPipeline
@@ -142,6 +143,17 @@ class OmniAgentExecutor(
                 json = json,
                 modelOverride = modelOverride
             )
+            val toolImageContinuationPolicy = runCatching {
+                AgentToolImageContinuationPolicyResolver.resolve(
+                    HttpController.resolveChatCompletionRouteInfo(
+                        modelOrScene = agentModelScene,
+                        explicitApiBase = modelOverride?.apiBase,
+                        explicitApiKey = modelOverride?.apiKey,
+                        explicitModel = modelOverride?.modelId,
+                        explicitProtocolType = modelOverride?.protocolType
+                    )
+                )
+            }.getOrDefault(AgentToolImageContinuationPolicy.DEFAULT)
             val contextCompactor = AgentConversationContextCompactor(
                 historyRepository = historyRepository,
                 modelScene = agentModelScene,
@@ -164,7 +176,8 @@ class OmniAgentExecutor(
                     catalogRef.get() ?: error("subagent dispatcher missing parent catalog")
                 },
                 eventAdapter = eventAdapter,
-                model = agentModelScene
+                model = agentModelScene,
+                toolImageContinuationPolicy = toolImageContinuationPolicy
             )
             toolRouter = AgentToolRouter(
                 context = context,
@@ -179,7 +192,8 @@ class OmniAgentExecutor(
                 toolRegistry = toolRegistry,
                 toolRouter = toolRouter,
                 eventAdapter = eventAdapter,
-                model = agentModelScene
+                model = agentModelScene,
+                toolImageContinuationPolicy = toolImageContinuationPolicy
             )
 
             orchestrator.run(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/SubagentDispatcher.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/SubagentDispatcher.kt
@@ -37,7 +37,9 @@ class SubagentDispatcher(
     private val toolExecutorProvider: () -> AgentToolExecutor,
     private val parentCatalogProvider: () -> AgentToolCatalog,
     private val eventAdapter: AgentEventAdapter,
-    private val model: String
+    private val model: String,
+    private val toolImageContinuationPolicy: AgentToolImageContinuationPolicy =
+        AgentToolImageContinuationPolicy.DEFAULT
 ) {
 
     data class SubagentTaskSpec(
@@ -176,7 +178,8 @@ class SubagentDispatcher(
                 toolRegistry = filteredCatalog,
                 toolRouter = toolExecutorProvider(),
                 eventAdapter = eventAdapter,
-                model = model
+                model = model,
+                toolImageContinuationPolicy = toolImageContinuationPolicy
             )
             val result = orchestrator.run(
                 AgentOrchestrator.Input(

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -506,16 +507,99 @@ class AgentOrchestratorTest {
         assertEquals(56.7, callback.lastDecodeTokensPerSecond!!, 0.0)
     }
 
+    @Test
+    fun toolResultImageContinuationIsIncludedByDefault() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(toolCalls = listOf(toolCall("browser_use"))),
+                assistantTurn(content = "已读取截图结果。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "browser_use" to listOf(
+                    ToolExecutionResult.ContextResult(
+                        toolName = "browser_use",
+                        summaryText = "截图已生成",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true,
+                        imageDataUrl = "data:image/jpeg;base64,AAA"
+                    )
+                )
+            )
+        )
+
+        createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = RecordingCallback(),
+                initialMessages = initialMessages("看一下页面"),
+                executionEnv = FakeExecutionEnvironment("看一下页面")
+            )
+        )
+
+        val toolMessage = llmClient.requests[1].messages.last()
+        assertEquals("tool", toolMessage.role)
+        assertTrue(toolMessage.content.toString().contains("\"image_url\""))
+    }
+
+    @Test
+    fun toolResultImageContinuationIsOmittedWhenPolicyDisablesIt() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(toolCalls = listOf(toolCall("browser_use"))),
+                assistantTurn(content = "已按文字摘要继续。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "browser_use" to listOf(
+                    ToolExecutionResult.ContextResult(
+                        toolName = "browser_use",
+                        summaryText = "截图已生成",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true,
+                        imageDataUrl = "data:image/jpeg;base64,AAA"
+                    )
+                )
+            )
+        )
+
+        createOrchestrator(
+            llmClient = llmClient,
+            toolExecutor = toolExecutor,
+            toolImageContinuationPolicy = AgentToolImageContinuationPolicy(
+                supportsToolImageContinuation = false,
+                routeLabel = "model=mimo-v2.5"
+            )
+        ).run(
+            AgentOrchestrator.Input(
+                callback = RecordingCallback(),
+                initialMessages = initialMessages("看一下页面"),
+                executionEnv = FakeExecutionEnvironment("看一下页面")
+            )
+        )
+
+        val toolMessage = llmClient.requests[1].messages.last()
+        assertEquals("tool", toolMessage.role)
+        assertTrue(toolMessage.content is JsonPrimitive)
+        assertFalse(toolMessage.content.toString().contains("\"image_url\""))
+    }
+
     private fun createOrchestrator(
         llmClient: FakeLlmClient,
-        toolExecutor: FakeToolExecutor
+        toolExecutor: FakeToolExecutor,
+        toolImageContinuationPolicy: AgentToolImageContinuationPolicy =
+            AgentToolImageContinuationPolicy.DEFAULT
     ): AgentOrchestrator {
         return AgentOrchestrator(
             llmClient = llmClient,
             toolRegistry = FakeToolCatalog(),
             toolRouter = toolExecutor,
             eventAdapter = AgentEventAdapter(eventJson),
-            model = "test-model"
+            model = "test-model",
+            toolImageContinuationPolicy = toolImageContinuationPolicy
         )
     }
 

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentToolImageContinuationPolicyResolverTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentToolImageContinuationPolicyResolverTest.kt
@@ -1,0 +1,56 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.assists.controller.http.HttpController
+import cn.com.omnimind.baselib.llm.MnnLocalProviderStateStore
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentToolImageContinuationPolicyResolverTest {
+    @After
+    fun tearDown() {
+        MnnLocalProviderStateStore.setEnabled(false)
+    }
+
+    @Test
+    fun mimoRouteDisablesToolImageContinuation() {
+        val routeInfo = HttpController.ChatCompletionRouteInfo(
+            requestedModel = "scene.dispatch.model",
+            resolvedModel = "mimo-v2.5",
+            apiBase = "https://relay.example.com/v1",
+            providerProfileId = "profile-1",
+            providerProfileName = "Provider 1",
+            routeTag = "custom_openai_compat",
+            bindingApplied = false,
+            bindingProfileMissing = false,
+            overrideApplied = true,
+            protocolType = "openai_compatible"
+        )
+
+        val policy = AgentToolImageContinuationPolicyResolver.resolve(routeInfo)
+
+        assertFalse(policy.supportsToolImageContinuation)
+    }
+
+    @Test
+    fun builtinLocalProviderStaysEnabledEvenIfModelNameContainsMimo() {
+        MnnLocalProviderStateStore.setEnabled(true)
+        val routeInfo = HttpController.ChatCompletionRouteInfo(
+            requestedModel = "scene.dispatch.model",
+            resolvedModel = "MiMo-7B-RL-MNN",
+            apiBase = "http://127.0.0.1:8080",
+            providerProfileId = MnnLocalProviderStateStore.BUILTIN_PROFILE_ID,
+            providerProfileName = MnnLocalProviderStateStore.BUILTIN_PROFILE_NAME,
+            routeTag = "custom_openai_compat",
+            bindingApplied = false,
+            bindingProfileMissing = false,
+            overrideApplied = true,
+            protocolType = "openai_compatible"
+        )
+
+        val policy = AgentToolImageContinuationPolicyResolver.resolve(routeInfo)
+
+        assertTrue(policy.supportsToolImageContinuation)
+    }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
@@ -1,0 +1,263 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.assists.controller.http.HttpController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HttpAgentLlmClientTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `closed stream without completion signal fails instead of silently succeeding`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"还没输出完"}}]}"""
+                    )
+                    listener.onClosed(source)
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val error = runCatching {
+                client.streamTurn(request = simpleRequest())
+            }.exceptionOrNull()
+
+            requireNotNull(error)
+            assertTrue(
+                error.message.orEmpty().contains("closed before completion signal")
+            )
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `idle watchdog fails stalled stream with explicit error`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"先来一段"}}]}"""
+                    )
+                    source
+                },
+                streamIdleWatchdogMs = 50L,
+                json = json
+            )
+
+            val error = runCatching {
+                client.streamTurn(request = simpleRequest())
+            }.exceptionOrNull()
+
+            requireNotNull(error)
+            assertTrue(error.message.orEmpty().contains("idle timeout"))
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `done signal still completes stream normally`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"最终回答"}}]}"""
+                    )
+                    listener.onEvent(source, null, "message", "[DONE]")
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val turn = client.streamTurn(request = simpleRequest())
+
+            assertEquals("最终回答", turn.message.contentText())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `resolved route requiring reasoning echo preserves reasoning content even when override is not deepseek`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                    routeInfo(
+                        requestedModel = model,
+                        resolvedModel = "deepseek-v4-flash",
+                        protocolType = protocolType ?: "deepseek",
+                        requiresReasoningEcho = true
+                    )
+                },
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"reasoning_content":"需要先查工具","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_time","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"""
+                    )
+                    listener.onEvent(source, null, "message", "[DONE]")
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val turn = client.streamTurn(request = simpleRequest())
+
+            assertEquals("需要先查工具", turn.reasoning)
+            assertEquals("需要先查工具", turn.message.reasoningContent)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `resolved route without reasoning echo keeps plain-answer reasoning off assistant message`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                    routeInfo(
+                        requestedModel = model,
+                        resolvedModel = "qwen-plus",
+                        protocolType = protocolType ?: "openai_compatible",
+                        requiresReasoningEcho = false
+                    )
+                },
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"reasoning_content":"内部思考","content":"最终回答"},"finish_reason":"stop"}]}"""
+                    )
+                    listener.onEvent(source, null, "message", "[DONE]")
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val turn = client.streamTurn(request = simpleRequest())
+
+            assertEquals("内部思考", turn.reasoning)
+            assertEquals("最终回答", turn.message.contentText())
+            assertNull(turn.message.reasoningContent)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun simpleRequest() = cn.com.omnimind.baselib.llm.ChatCompletionRequest(
+        messages = listOf(
+            cn.com.omnimind.baselib.llm.ChatCompletionMessage(
+                role = "user",
+                content = kotlinx.serialization.json.JsonPrimitive("继续")
+            )
+        ),
+        model = "test-model",
+        stream = true
+    )
+
+    private fun testOverride() = AgentModelOverride(
+        providerProfileId = "test",
+        modelId = "test-model",
+        apiBase = "https://example.com",
+        apiKey = "test-key"
+    )
+
+    private fun dummyEventSource(): EventSource {
+        return object : EventSource {
+            override fun request(): Request =
+                Request.Builder().url("https://example.com").build()
+
+            override fun cancel() = Unit
+        }
+    }
+
+    private fun okResponse(): Response {
+        return Response.Builder()
+            .request(Request.Builder().url("https://example.com").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .build()
+    }
+
+    private fun routeInfo(
+        requestedModel: String,
+        resolvedModel: String,
+        protocolType: String,
+        requiresReasoningEcho: Boolean
+    ) = HttpController.ChatCompletionRouteInfo(
+        requestedModel = requestedModel,
+        resolvedModel = resolvedModel,
+        apiBase = "https://example.com",
+        providerProfileId = "test",
+        providerProfileName = "Test",
+        routeTag = "test",
+        bindingApplied = false,
+        bindingProfileMissing = false,
+        overrideApplied = true,
+        protocolType = protocolType,
+        requiresReasoningEcho = requiresReasoningEcho
+    )
+}


### PR DESCRIPTION
## 变更摘要

修复了 `browser_use` 截图在后续轮次被继续作为 `tool` 图片消息回传时，部分路由（如 `mimo-v2.5` / 小米相关路由）触发 400 的问题。修复方式不是禁用截图，而是把“用户图片输入”和“tool 图片续传”拆开处理：对已知不兼容路由仅回传文字摘要，截图 artifact 仍然保留给界面使用。

## 变更类型

 Bug 修复

## 关联 Issue

#321

## 主要改动

1. 新增 tool-image 续传策略层，按当前路由判断是否允许把工具截图继续作为 `role=tool` 的图片块发回模型。
2. 修改 Agent 编排链路：对命中 `mimo` / `xiaomi` 等已知不兼容路由，保留截图 artifact 和文字摘要，但不再拼接 `tool + image_url`。

## 测试说明

- [ ]  已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- []  已执行相关测试
- [ ]  已手动验证关键路径

测试细节：

<img width="864" height="1920" alt="829c87ad2f875ad03568e51c80c4902a" src="https://github.com/user-attachments/assets/c445dd1a-7463-47ed-a64e-f6a166544887" />



## UI 变更（如有）

无

## 风险与回滚
无

