### PR TITLE
 fix: 解决百炼 qwen3.6-plus 的<think>标签泄露问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -42,6 +42,7 @@ class AgentLlmStreamAccumulator(
     private var lastChunkPreview: String = ""
     private var thinkSectionOpen = false
     private var inlineThinkTagObserved = false
+    private var autoInlineThinkTagMode = false
 
     private var chunkIndex = 0
 
@@ -509,23 +510,20 @@ class AgentLlmStreamAccumulator(
         if (text.isEmpty()) {
             return
         }
-        if (!preferInlineThinkTags) {
-            contentBuffer.append(text)
-            return
+        if (!preferInlineThinkTags && !autoInlineThinkTagMode && !thinkSectionOpen) {
+            val containsThinkTag = text.contains(THINK_OPEN_TAG) || text.contains(THINK_CLOSE_TAG)
+            val hasTrailingTagPrefix = partialInlineTagSuffixLength(text) > 0
+            if (!containsThinkTag && !hasTrailingTagPrefix) {
+                contentBuffer.append(text)
+                return
+            }
+            autoInlineThinkTagMode = true
         }
         inlineTextBuffer.append(text)
         flushInlineTextBuffer(final = false)
     }
 
     private fun flushInlineTextBuffer(final: Boolean) {
-        if (!preferInlineThinkTags) {
-            if (inlineTextBuffer.isNotEmpty()) {
-                appendVisibleText(inlineTextBuffer.toString())
-                inlineTextBuffer.setLength(0)
-            }
-            return
-        }
-
         while (inlineTextBuffer.isNotEmpty()) {
             val bufferText = inlineTextBuffer.toString()
             if (thinkSectionOpen) {
@@ -565,8 +563,12 @@ class AgentLlmStreamAccumulator(
                 continue
             }
 
-            if (closeIndex >= 0 && contentBuffer.isEmpty()) {
-                appendReasoningText(bufferText.substring(0, closeIndex))
+            if (closeIndex >= 0) {
+                if (contentBuffer.isEmpty()) {
+                    appendReasoningText(bufferText.substring(0, closeIndex))
+                } else {
+                    appendVisibleText(bufferText.substring(0, closeIndex))
+                }
                 inlineTextBuffer.delete(0, closeIndex + THINK_CLOSE_TAG.length)
                 inlineThinkTagObserved = true
                 continue
@@ -578,7 +580,7 @@ class AgentLlmStreamAccumulator(
                 return
             }
 
-            if (!inlineThinkTagObserved && contentBuffer.isEmpty()) {
+            if (preferInlineThinkTags && !inlineThinkTagObserved && contentBuffer.isEmpty()) {
                 return
             }
 

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
@@ -21,13 +21,13 @@ class AgentLlmStreamAccumulatorTest {
             preferInlineThinkTags = true
         )
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"先思考第一步"}}]}""")
-        accumulator.consume("""{"choices":[{"delta":{"content":"再思考第二步</think>最后回答"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"first thought "}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"second thought</think>final answer"}}]}""")
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("先思考第一步再思考第二步", turn.reasoning)
-        assertEquals("最后回答", turn.message.contentText())
+        assertEquals("first thought second thought", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
     }
 
     @Test
@@ -37,12 +37,12 @@ class AgentLlmStreamAccumulatorTest {
             preferInlineThinkTags = true
         )
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"普通回答"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"normal answer"}}]}""")
 
         val turn = accumulator.buildTurn()
 
         assertEquals("", turn.reasoning)
-        assertEquals("普通回答", turn.message.contentText())
+        assertEquals("normal answer", turn.message.contentText())
     }
 
     @Test
@@ -52,13 +52,13 @@ class AgentLlmStreamAccumulatorTest {
             preferInlineThinkTags = true
         )
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"先思考</th"}}]}""")
-        accumulator.consume("""{"choices":[{"delta":{"content":"ink>最终回答"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"first thought</th"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"ink>final answer"}}]}""")
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("先思考", turn.reasoning)
-        assertEquals("最终回答", turn.message.contentText())
+        assertEquals("first thought", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
     }
 
     @Test
@@ -68,20 +68,20 @@ class AgentLlmStreamAccumulatorTest {
             preferInlineThinkTags = true
         )
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"先展示前言<th"}}]}""")
-        accumulator.consume("""{"choices":[{"delta":{"content":"ink>深度思考</think>最后回答"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"visible prefix<th"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"ink>deep thought</think>final answer"}}]}""")
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("深度思考", turn.reasoning)
-        assertEquals("先展示前言最后回答", turn.message.contentText())
+        assertEquals("deep thought", turn.reasoning)
+        assertEquals("visible prefixfinal answer", turn.message.contentText())
     }
 
     @Test
     fun `reads tokens per second from usage performance payload`() {
         val accumulator = AgentLlmStreamAccumulator(json = json)
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"已完成。"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"done"}}]}""")
         accumulator.consume(
             """
             {"id":"chatcmpl-test","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":15,"completion_tokens":100,"total_tokens":115,"performance":{"prefill_tokens_per_second":36.6,"decode_tokens_per_second":12.4}}}
@@ -103,13 +103,13 @@ class AgentLlmStreamAccumulatorTest {
         )
 
         accumulator.consume(
-            """{"choices":[{"delta":{"reasoning_content":"需要查工具","content":"","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_time","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"""
+            """{"choices":[{"delta":{"reasoning_content":"need tool","content":"","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_time","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"""
         )
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("需要查工具", turn.reasoning)
-        assertEquals("需要查工具", turn.message.reasoningContent)
+        assertEquals("need tool", turn.reasoning)
+        assertEquals("need tool", turn.message.reasoningContent)
     }
 
     @Test
@@ -117,13 +117,13 @@ class AgentLlmStreamAccumulatorTest {
         val accumulator = AgentLlmStreamAccumulator(json = json)
 
         accumulator.consume(
-            """{"choices":[{"delta":{"reasoning_content":"继续调用工具前要回传思考","content":"","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_time","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"""
+            """{"choices":[{"delta":{"reasoning_content":"need echo reasoning for tool","content":"","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_time","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"""
         )
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("继续调用工具前要回传思考", turn.reasoning)
-        assertEquals("继续调用工具前要回传思考", turn.message.reasoningContent)
+        assertEquals("need echo reasoning for tool", turn.reasoning)
+        assertEquals("need echo reasoning for tool", turn.message.reasoningContent)
     }
 
     @Test
@@ -150,22 +150,53 @@ class AgentLlmStreamAccumulatorTest {
     fun `preserves surrogate pair split across chunks`() {
         val accumulator = AgentLlmStreamAccumulator(json = json)
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"前缀\uD83D"}}]}""")
-        accumulator.consume("""{"choices":[{"delta":{"content":"\uDE00后缀"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"prefix\uD83D"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"\uDE00suffix"}}]}""")
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("前缀😀后缀", turn.message.contentText())
+        assertEquals("prefix😀suffix", turn.message.contentText())
     }
 
     @Test
     fun `drops dangling surrogate from final content`() {
         val accumulator = AgentLlmStreamAccumulator(json = json)
 
-        accumulator.consume("""{"choices":[{"delta":{"content":"前缀\uD83D后缀"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"prefix\uD83Dsuffix"}}]}""")
 
         val turn = accumulator.buildTurn()
 
-        assertEquals("前缀后缀", turn.message.contentText())
+        assertEquals("prefixsuffix", turn.message.contentText())
+    }
+
+    @Test
+    fun `auto strips inline think close tags for non local providers`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"inner reasoning</think>final answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("inner reasoning", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
+    }
+
+    @Test
+    fun `auto strips inline think close tags split across chunks for non local providers`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"inner reasoning</th"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"ink>final answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("", turn.reasoning)
+        assertEquals("inner reasoningfinal answer", turn.message.contentText())
     }
 }

--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -248,6 +248,7 @@ object HttpController {
                 json.has("message") && json.opt("message") is String -> json.optString("message")
                 json.has("choices") -> {
                     val firstChoice = json.optJSONArray("choices")?.optJSONObject(0)
+                        ?: return@runCatching ""
                     val delta = firstChoice?.optJSONObject("delta")
                     val message = firstChoice?.optJSONObject("message")
 
@@ -278,7 +279,19 @@ object HttpController {
                                     .orEmpty()
                             }
                         }
-                        else -> trimmed
+                        else -> {
+                            extractTextPayload(firstChoice.opt("text")).ifBlank {
+                                listOf(
+                                    firstChoice.opt("reasoning_content"),
+                                    firstChoice.opt("reasoning"),
+                                    firstChoice.opt("thinking")
+                                )
+                                    .asSequence()
+                                    .map { extractTextPayload(it) }
+                                    .firstOrNull { it.isNotBlank() }
+                                    .orEmpty()
+                            }
+                        }
                     }
                 }
                 else -> trimmed


### PR DESCRIPTION
## 变更摘要

修复 `qwen3.6-plus` 在 openai-compatible 流式输出中 `</think>` 泄漏到正文/日志的问题。  同时修复 `HttpController` 流日志提取逻辑，避免 usage-only chunk 被拼接进 `Response Body`。  

## 变更类型

Bug 修复


## 关联 Issue

Closes #326

## 主要改动

1. 在 `AgentLlmStreamAccumulator` 增加自动 inline-think 识别模式：  
   非本地 provider 路径下，若流内容中出现 `<think>` / `</think>`（含跨 chunk 部分标签），自动启用标签语义解析，避免 `</think>` 进入可见正文。
2. 调整 `HttpController.extractStreamLogChunk()`：  
   对 `choices=[]`/无可提取文本的 chunk 返回空串，不再 fallback 整段 JSON，阻断 `{"choices":[],"usage":...}` 污染 `Response Body`。



测试细节：
抓包日志
修复前：(</think>与正文粘连)
<img width="2675" height="107" alt="QBJ}VJK LJHME9Z)4N4E@L9" src="https://github.com/user-attachments/assets/3ee17d07-166f-4c6a-8c63-1c27d9d1f4fd" />
修复后：
<img width="2714" height="229" alt="48D(AAKJC SKOU(G5)2DE@Q" src="https://github.com/user-attachments/assets/df1ab4d3-26d6-4fb0-9507-5597a5b40563" />


用户端测试结果：
<img width="864" height="1920" alt="8d7414f81af36d73dfd743121cfc43c2" src="https://github.com/user-attachments/assets/f8d0ad06-c8c7-4fb1-b296-b07135ae59d9" />


## UI 变更（如有）

无

## 风险与回滚

无


