### PR TITLE
 fix: 修复 md 等非图片附件被误当图片发送的问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/AgentImageAttachmentSupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/AgentImageAttachmentSupport.kt
@@ -15,6 +15,7 @@ internal object AgentImageAttachmentSupport {
     private const val NO_BYPASS_THRESHOLD = 0L
 
     internal data class PreparedAttachments(
+        val runtimeAttachments: List<Map<String, Any?>>,
         val modelAttachments: List<Map<String, Any?>>,
         val historyAttachments: List<Map<String, Any?>>
     )
@@ -92,20 +93,47 @@ internal object AgentImageAttachmentSupport {
 
     fun prepareAttachments(rawAttachments: List<Map<String, Any?>>): PreparedAttachments {
         if (rawAttachments.isEmpty()) {
-            return PreparedAttachments(emptyList(), emptyList())
+            return PreparedAttachments(
+                runtimeAttachments = emptyList(),
+                modelAttachments = emptyList(),
+                historyAttachments = emptyList()
+            )
         }
+        val runtimeAttachments = mutableListOf<Map<String, Any?>>()
         val modelAttachments = mutableListOf<Map<String, Any?>>()
         val historyAttachments = mutableListOf<Map<String, Any?>>()
         rawAttachments.forEach { raw ->
             val prepared = prepareSingleAttachment(raw) ?: return@forEach
-            if (shouldSendAttachmentToModel(raw)) {
+            val shouldSendToModel = shouldSendAttachmentToModel(raw)
+            val isImage = prepared.second["isImage"] == true
+            if (shouldSendToModel && isImage) {
                 modelAttachments += prepared.first
+            }
+            runtimeAttachments += if (shouldSendToModel && isImage) {
+                prepared.first
+            } else {
+                prepared.second
             }
             historyAttachments += prepared.second
         }
         return PreparedAttachments(
+            runtimeAttachments = runtimeAttachments,
             modelAttachments = modelAttachments,
             historyAttachments = historyAttachments
+        )
+    }
+
+    internal fun isImageAttachment(attachment: Map<String, Any?>): Boolean {
+        val localPath = localPathFromAttachment(attachment)
+        val remoteUrl = remoteUrlFromAttachment(attachment)
+        val dataUrl = dataUrlFromAttachment(attachment)
+        val mimeType = mimeTypeFromAttachment(attachment)
+        return detectImageAttachment(
+            attachment = attachment,
+            mimeType = mimeType,
+            localPath = localPath,
+            remoteUrl = remoteUrl,
+            dataUrl = dataUrl
         )
     }
 
@@ -176,7 +204,7 @@ internal object AgentImageAttachmentSupport {
         val remoteUrl = remoteUrlFromAttachment(raw)
         val dataUrl = dataUrlFromAttachment(raw)
         val mimeType = mimeTypeFromAttachment(raw)
-        val isImage = isImageAttachment(
+        val isImage = detectImageAttachment(
             attachment = raw,
             mimeType = mimeType,
             localPath = localPath,
@@ -353,7 +381,7 @@ internal object AgentImageAttachmentSupport {
         }?.takeIf { it >= 0L }
     }
 
-    private fun isImageAttachment(
+    private fun detectImageAttachment(
         attachment: Map<String, Any?>,
         mimeType: String,
         localPath: String?,

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -941,10 +941,16 @@ internal object AgentConversationHistorySupport {
         payload: Map<String, Any?>
     ): JsonElement? {
         val content = toStringAnyMap(payload["content"])
-        val text = AgentTextSanitizer.sanitizeUtf16(content["text"]?.toString().orEmpty())
         val attachments = toListOfStringAnyMap(content["attachments"])
+        val text = AgentAttachmentPromptSupport.buildUserMessageText(
+            text = content["text"]?.toString().orEmpty(),
+            attachments = attachments
+        )
         val imageBlocks = attachments.mapNotNull { attachment ->
             if (!shouldSendAttachmentToModel(attachment)) {
+                return@mapNotNull null
+            }
+            if (!AgentImageAttachmentSupport.isImageAttachment(attachment)) {
                 return@mapNotNull null
             }
             val imageUrl = resolveImageAttachmentUrl(attachment)

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
@@ -327,7 +327,13 @@ class OmniAgentExecutor(
         userMessage: String,
         attachments: List<Map<String, Any?>>
     ): cn.com.omnimind.baselib.llm.ChatCompletionMessage {
-        val normalizedAttachments = normalizeAttachments(attachments)
+        val rawText = AgentAttachmentPromptSupport.buildUserMessageText(
+            text = userMessage,
+            attachments = attachments
+        )
+        val normalizedAttachments = normalizeAttachments(
+            attachments.filter(AgentAttachmentPromptSupport::shouldSendAttachmentToModel)
+        )
         val imageParts = normalizedAttachments
             .filter { it.isImage }
             .mapNotNull { attachment ->
@@ -343,7 +349,6 @@ class OmniAgentExecutor(
                     }
                 }
             }
-        val rawText = userMessage
         val content = if (imageParts.isEmpty()) {
             JsonPrimitive(rawText)
         } else {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -59,6 +59,7 @@ import cn.com.omnimind.bot.agent.AgentAlarmToolService
 import cn.com.omnimind.bot.agent.AgentAiCapabilityConfigSync
 import cn.com.omnimind.bot.agent.AgentConversationContextCompactor
 import cn.com.omnimind.bot.agent.AgentImageAttachmentSupport
+import cn.com.omnimind.bot.agent.AgentWorkspaceAttachmentSupport
 import cn.com.omnimind.bot.agent.AgentStreamEvent
 import cn.com.omnimind.bot.agent.AgentTextSanitizer
 import cn.com.omnimind.bot.agent.AgentModelOverride
@@ -3922,11 +3923,16 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         )
         val legacyConversationHistory =
             call.argument<List<Map<String, Any?>>>("conversationHistory") ?: emptyList()
-        val attachments = (call.argument<List<Map<String, Any?>>>("attachments") ?: emptyList())
+        val rawAttachments = (call.argument<List<Map<String, Any?>>>("attachments") ?: emptyList())
             .map(::sanitizeInteropMap)
-        val modelAttachments = AgentImageAttachmentSupport
-            .prepareAttachments(attachments)
-            .modelAttachments
+        val normalizedAttachments = AgentWorkspaceAttachmentSupport.prepareAttachmentsForRuntime(
+            context = context,
+            taskId = taskId,
+            rawAttachments = rawAttachments
+        )
+        val preparedAttachments = AgentImageAttachmentSupport.prepareAttachments(normalizedAttachments)
+        val runtimeAttachments = preparedAttachments.runtimeAttachments
+        val historyAttachments = preparedAttachments.historyAttachments
         val userMessageCreatedAt = call.argument<Number>("userMessageCreatedAt")?.toLong()
         val conversationId = call.argument<Number>("conversationId")?.toLong()?.takeIf { it > 0L }
         val requestedConversationMode =
@@ -4490,14 +4496,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 }
 
                 conversationId?.let { normalizedConversationId ->
-                    if (userMessage.isNotBlank() || attachments.isNotEmpty()) {
+                    if (userMessage.isNotBlank() || historyAttachments.isNotEmpty()) {
                         persistConversationMutation("upsert user message") {
                             repository.upsertUserMessage(
                                 conversationId = normalizedConversationId,
                                 conversationMode = resolvedConversationMode,
                                 entryId = "$taskId-user",
                                 text = userMessage,
-                                attachments = attachments,
+                                attachments = historyAttachments,
                                 createdAt = userMessageCreatedAt ?: System.currentTimeMillis()
                             )
                         }
@@ -5083,7 +5089,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     legacyConversationHistory,
                     runtimeContextRepository,
                     currentPackageName,
-                    modelAttachments,
+                    runtimeAttachments,
                     conversationId,
                     resolvedConversationMode,
                     modelOverride,

--- a/app/src/main/java/cn/com/omnimind/bot/webchat/AgentRunService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/webchat/AgentRunService.kt
@@ -57,15 +57,7 @@ internal object AgentRunRequestNormalizer {
         val attachments = mutableListOf<Map<String, Any?>>()
         blocks.forEachIndexed { index, item ->
             val block = normalizeMap(item) ?: return@forEachIndexed
-            val type = block["type"]?.toString()?.trim()?.lowercase().orEmpty().ifEmpty {
-                when {
-                    block.containsKey("image_url") ||
-                        block.containsKey("imageUrl") ||
-                        block.containsKey("url") -> "image_url"
-                    block.containsKey("text") -> "text"
-                    else -> ""
-                }
-            }
+            val type = inferBlockType(block)
             when (type) {
                 "text", "input_text" -> {
                     val text = block["text"]?.toString().orEmpty()
@@ -101,12 +93,56 @@ internal object AgentRunRequestNormalizer {
                     }
                     attachments += attachment
                 }
+
+                "file", "attachment", "input_file" -> {
+                    val attachment = extractAttachment(block, index)
+                    if (attachment != null) {
+                        attachments += attachment
+                    }
+                }
             }
         }
         return NormalizedAgentRunPayload(
             userMessage = texts.joinToString("\n").trim(),
             attachments = attachments
         )
+    }
+
+    private fun inferBlockType(block: Map<String, Any?>): String {
+        val explicit = block["type"]?.toString()?.trim()?.lowercase().orEmpty()
+        if (explicit.isNotEmpty()) {
+            return explicit
+        }
+        if (block.containsKey("image_url") || block.containsKey("imageUrl")) {
+            return "image_url"
+        }
+        if (block.containsKey("text")) {
+            return "text"
+        }
+        if (block.containsKey("file") ||
+            block.containsKey("attachment") ||
+            block.containsKey("input_file")
+        ) {
+            return "attachment"
+        }
+        val mimeType = block["mimeType"]?.toString()?.trim().orEmpty()
+        if (mimeType.startsWith("image/", ignoreCase = true) &&
+            (block.containsKey("url") || block.containsKey("dataUrl"))
+        ) {
+            return "image_url"
+        }
+        return if (block.containsKey("url") ||
+            block.containsKey("path") ||
+            block.containsKey("filePath") ||
+            block.containsKey("promptPath") ||
+            block.containsKey("workspacePath") ||
+            block.containsKey("fileName") ||
+            block.containsKey("name")
+        ) {
+            "attachment"
+        } else {
+            ""
+        }
     }
 
     private fun extractImageUrl(block: Map<String, Any?>): String {
@@ -136,6 +172,108 @@ internal object AgentRunRequestNormalizer {
                 .trim()
         }
         return ""
+    }
+
+    private fun extractAttachment(
+        block: Map<String, Any?>,
+        index: Int
+    ): Map<String, Any?>? {
+        val nested = sequenceOf(
+            block["attachment"],
+            block["file"],
+            block["input_file"]
+        ).mapNotNull(::normalizeMap).firstOrNull()
+
+        fun readField(key: String): Any? = nested?.get(key) ?: block[key]
+
+        val attachment = linkedMapOf<String, Any?>()
+        val name = readField("name")?.toString()?.trim().orEmpty()
+        val fileName = readField("fileName")?.toString()?.trim().orEmpty()
+        val resolvedName = fileName.ifEmpty { name }
+        if (resolvedName.isNotEmpty()) {
+            attachment["name"] = resolvedName
+            attachment["fileName"] = resolvedName
+        } else {
+            attachment["fileName"] = "attachment_$index"
+            attachment["name"] = "attachment_$index"
+        }
+
+        val mimeType = readField("mimeType")?.toString()?.trim().orEmpty()
+        if (mimeType.isNotEmpty()) {
+            attachment["mimeType"] = mimeType
+        }
+
+        copyIfNotBlank(attachment, "id", readField("id")?.toString())
+        copyIfNotBlank(attachment, "path", firstNonBlank(readField("path"), readField("filePath")))
+        copyIfNotBlank(attachment, "promptPath", readField("promptPath")?.toString())
+        copyIfNotBlank(attachment, "workspacePath", readField("workspacePath")?.toString())
+        copyIfNotBlank(attachment, "url", readField("url")?.toString())
+        copyIfNotBlank(attachment, "dataUrl", readField("dataUrl")?.toString())
+
+        when (val raw = readField("size") ?: readField("sizeBytes")) {
+            is Number -> attachment["size"] = raw.toLong()
+            is String -> raw.trim().toLongOrNull()?.let { attachment["size"] = it }
+        }
+
+        val explicitImage = when (val raw = readField("isImage")) {
+            is Boolean -> raw
+            is String -> raw.equals("true", ignoreCase = true)
+            else -> false
+        }
+        val looksLikeImage = explicitImage ||
+            mimeType.startsWith("image/", ignoreCase = true) ||
+            attachment["dataUrl"]?.toString()?.startsWith("data:image/", ignoreCase = true) == true ||
+            firstNonBlank(attachment["path"], attachment["url"])
+                ?.let(::looksLikeImagePath) == true
+        attachment["isImage"] = looksLikeImage
+
+        when (val raw = readField("sendToModel")) {
+            is Boolean -> if (!raw) attachment["sendToModel"] = false
+            is String -> if (raw.equals("false", ignoreCase = true)) {
+                attachment["sendToModel"] = false
+            }
+        }
+
+        return if (
+            attachment["path"] != null ||
+            attachment["url"] != null ||
+            attachment["dataUrl"] != null ||
+            attachment["promptPath"] != null ||
+            attachment["workspacePath"] != null
+        ) {
+            attachment
+        } else {
+            null
+        }
+    }
+
+    private fun firstNonBlank(vararg values: Any?): String? {
+        return values.firstNotNullOfOrNull { value ->
+            value?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun copyIfNotBlank(
+        target: MutableMap<String, Any?>,
+        key: String,
+        value: String?
+    ) {
+        val normalized = value?.trim().orEmpty()
+        if (normalized.isNotEmpty()) {
+            target[key] = normalized
+        }
+    }
+
+    private fun looksLikeImagePath(value: String): Boolean {
+        val normalized = value.trim().lowercase().split('?').firstOrNull().orEmpty()
+        return normalized.endsWith(".png") ||
+            normalized.endsWith(".jpg") ||
+            normalized.endsWith(".jpeg") ||
+            normalized.endsWith(".webp") ||
+            normalized.endsWith(".gif") ||
+            normalized.endsWith(".bmp") ||
+            normalized.endsWith(".heic") ||
+            normalized.endsWith(".heif")
     }
 
     internal fun normalizeMap(value: Any?): Map<String, Any?>? {

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
@@ -643,6 +643,31 @@ class AgentConversationHistorySupportTest {
     }
 
     @Test
+    fun `buildPromptSeedFromEntries keeps non-image attachments as workspace path hints`() {
+        val entry = buildUserEntry(
+            id = 1,
+            entryId = "u-doc",
+            text = "你看看这个",
+            attachments = listOf(
+                mapOf(
+                    "path" to "/data/user/0/cn.com.omnimind.bot/workspace/.omnibot/shared/doc.md",
+                    "name" to "doc.md",
+                    "mimeType" to "text/markdown",
+                    "isImage" to false,
+                    "promptPath" to "/workspace/shared/doc.md",
+                    "sendToModel" to false
+                )
+            )
+        )
+
+        val seed = AgentConversationHistorySupport.buildPromptSeedFromEntries(listOf(entry))
+        val content = seed.historyMessages.single().content!!.jsonPrimitive.content
+
+        assertTrue(content.contains("doc.md"))
+        assertTrue(content.contains("/workspace/shared/doc.md"))
+    }
+
+    @Test
     fun `selectEntriesToCompact includes historical tool context before latest user`() {
         val entries = listOf(
             buildUserEntry(id = 1, entryId = "u1", text = "第一轮问题"),

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentImageAttachmentSupportTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentImageAttachmentSupportTest.kt
@@ -54,9 +54,14 @@ class AgentImageAttachmentSupportTest {
 
         assertEquals(1, prepared.modelAttachments.size)
         assertEquals(1, prepared.historyAttachments.size)
+        assertEquals(1, prepared.runtimeAttachments.size)
         assertEquals(
             "data:image/jpeg;base64,MODEL",
             prepared.modelAttachments.single()["dataUrl"]
+        )
+        assertEquals(
+            "data:image/jpeg;base64,MODEL",
+            prepared.runtimeAttachments.single()["dataUrl"]
         )
         assertEquals(
             "data:image/jpeg;base64,PREVIEW",
@@ -101,5 +106,30 @@ class AgentImageAttachmentSupportTest {
         assertFalse(result?.payload.toString().orEmpty().contains("base64"))
         assertEquals(1179, result?.payload?.get("width"))
         assertEquals(2556, result?.payload?.get("height"))
+    }
+
+    @Test
+    fun `prepareAttachments keeps non-image files out of model attachments`() {
+        val prepared = AgentImageAttachmentSupport.prepareAttachments(
+            listOf(
+                mapOf(
+                    "path" to "/tmp/notes.md",
+                    "name" to "notes.md",
+                    "mimeType" to "text/markdown",
+                    "isImage" to false,
+                    "promptPath" to "/workspace/shared/notes.md",
+                    "sendToModel" to false
+                )
+            )
+        )
+
+        assertEquals(0, prepared.modelAttachments.size)
+        assertEquals(1, prepared.runtimeAttachments.size)
+        assertEquals(1, prepared.historyAttachments.size)
+        assertEquals(false, prepared.runtimeAttachments.single()["sendToModel"])
+        assertEquals(
+            "/workspace/shared/notes.md",
+            prepared.runtimeAttachments.single()["promptPath"]
+        )
     }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/webchat/AgentRunRequestNormalizerTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/webchat/AgentRunRequestNormalizerTest.kt
@@ -85,4 +85,33 @@ class AgentRunRequestNormalizerTest {
         )
         assertTrue(normalized.attachments.single()["fileName"].toString().startsWith("image_"))
     }
+
+    @Test
+    fun `attachment blocks preserve file semantics instead of being coerced into images`() {
+        val normalized = AgentRunRequestNormalizer.normalize(
+            mapOf(
+                "content" to listOf(
+                    mapOf("type" to "text", "text" to "check this file"),
+                    mapOf(
+                        "type" to "attachment",
+                        "name" to "ezfpy_documentation.md",
+                        "path" to "/storage/emulated/0/ezfpy_documentation.md",
+                        "mimeType" to "text/markdown"
+                    )
+                )
+            )
+        )
+
+        assertEquals("check this file", normalized.userMessage)
+        assertEquals(1, normalized.attachments.size)
+        assertEquals(false, normalized.attachments.single()["isImage"])
+        assertEquals(
+            "/storage/emulated/0/ezfpy_documentation.md",
+            normalized.attachments.single()["path"]
+        )
+        assertEquals(
+            "text/markdown",
+            normalized.attachments.single()["mimeType"]
+        )
+    }
 }


### PR DESCRIPTION
## 变更摘要

修复 Agent 对非图片附件，尤其是`.md` / `.txt` / `.pdf` 等非图片附件的协议处理问题。改动后，文档类附件不会再被错误转换成 `image_url` 发送给模型，而是先落到 workspace，再通过路径提示让模型用 `file_read` 读取，避免出现 `invalid image format` 这类问题。

## 变更类型

- [x] Bug 修复

## 关联 Issue

 #241

## 主要改动

1. 新增非图片附件 workspace 适配逻辑：将 `.md` / `.txt` / `.pdf` 等非图片附件复制到共享 workspace，补齐 `promptPath` / `workspacePath`，并标记 `sendToModel=false`。
2. 调整当前轮消息和历史消息回放逻辑：只有真实图片附件才生成 `image_url`，非图片附件改为在用户文本中附带可读路径提示。
3. 扩展 Agent 入口协议兼容性：`AgentRunService` 现在显式支持 `file` / `attachment` / `input_file` 块，并补充对应单元测试覆盖。

## 测试说明

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）

测试细节：

后续抓包日志及用户端在多轮对话中均能正常支持文档等附件。

<img width="1864" height="252" alt="OGRZYUGCC5AG5 58T__@58E" src="https://github.com/user-attachments/assets/625a8fa0-ec4c-440b-aa08-f5afebb90df4" />

<img width="1864" height="100" alt="29K$WF%2TOB1{T25AW1F0CY" src="https://github.com/user-attachments/assets/0075d17d-0629-450a-a18e-c77f45e7dc0a" />

<img width="864" height="1920" alt="711fd11737039dd150391c0e63d6df23" src="https://github.com/user-attachments/assets/190886bc-000e-475f-9479-45b017f39042" />
<img width="864" height="1920" alt="711fd11737039dd150391c0e63d6df23" src="https://github.com/user-attachments/assets/190886bc-000e-475f-9479-45b017f39042" />


## UI 变更（如有）

无

## 风险与回滚

无

