### PR TITLE
 fix: 修复百炼 qwen 下</think> token前的reasoning 泄露问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -186,6 +186,24 @@ class HttpAgentLlmClient(
                 || error.reason.contains("stream was reset", ignoreCase = true)
     }
 
+    private fun shouldBufferLeadingInlineThinkTag(
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): Boolean {
+        val protocolType = routeInfo.protocolType.trim().ifEmpty { "openai_compatible" }
+        if (!protocolType.equals("openai_compatible", ignoreCase = true)) {
+            return false
+        }
+        return sequenceOf(routeInfo.resolvedModel, routeInfo.requestedModel)
+            .map { it.trim().lowercase() }
+            .any { model ->
+                model.startsWith("qwen") ||
+                    model.contains("/qwen") ||
+                    model.contains(":qwen") ||
+                    model.contains("_qwen") ||
+                    model.contains("-qwen")
+            }
+    }
+
     private suspend fun doStreamTurnOnce(
         model: String,
         requestJson: String,
@@ -208,7 +226,8 @@ class HttpAgentLlmClient(
                 modelOverride?.providerProfileId,
                 modelOverride?.apiBase
             ),
-            includeReasoningInAssistantMessage = routeInfo?.requiresReasoningEcho == true
+            includeReasoningInAssistantMessage = routeInfo.requiresReasoningEcho,
+            bufferLeadingTextUntilInlineThinkTag = shouldBufferLeadingInlineThinkTag(routeInfo)
         )
         var lastReasoning = ""
         var lastReasoningEmitLength = 0

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -20,7 +20,8 @@ import java.util.TreeMap
 class AgentLlmStreamAccumulator(
     private val json: Json,
     private val preferInlineThinkTags: Boolean = false,
-    private val includeReasoningInAssistantMessage: Boolean = false
+    private val includeReasoningInAssistantMessage: Boolean = false,
+    private val bufferLeadingTextUntilInlineThinkTag: Boolean = false
 ) {
     companion object {
         private const val TAG = "AgentLlmStreamAccumulator"
@@ -510,6 +511,11 @@ class AgentLlmStreamAccumulator(
         if (text.isEmpty()) {
             return
         }
+        if (shouldBufferLeadingInlineText()) {
+            inlineTextBuffer.append(text)
+            flushInlineTextBuffer(final = false)
+            return
+        }
         if (!preferInlineThinkTags && !autoInlineThinkTagMode && !thinkSectionOpen) {
             val containsThinkTag = text.contains(THINK_OPEN_TAG) || text.contains(THINK_CLOSE_TAG)
             val hasTrailingTagPrefix = partialInlineTagSuffixLength(text) > 0
@@ -580,7 +586,7 @@ class AgentLlmStreamAccumulator(
                 return
             }
 
-            if (preferInlineThinkTags && !inlineThinkTagObserved && contentBuffer.isEmpty()) {
+            if (shouldDelayVisibleInlineBufferCommit()) {
                 return
             }
 
@@ -593,6 +599,21 @@ class AgentLlmStreamAccumulator(
             inlineTextBuffer.delete(0, safeLength)
             return
         }
+    }
+
+    private fun shouldBufferLeadingInlineText(): Boolean {
+        return bufferLeadingTextUntilInlineThinkTag &&
+            !preferInlineThinkTags &&
+            !autoInlineThinkTagMode &&
+            !thinkSectionOpen &&
+            !inlineThinkTagObserved &&
+            contentBuffer.isEmpty()
+    }
+
+    private fun shouldDelayVisibleInlineBufferCommit(): Boolean {
+        return !inlineThinkTagObserved &&
+            contentBuffer.isEmpty() &&
+            (preferInlineThinkTags || bufferLeadingTextUntilInlineThinkTag)
     }
 
     private fun partialInlineTagSuffixLength(text: String): Int {

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
@@ -199,4 +199,53 @@ class AgentLlmStreamAccumulatorTest {
         assertEquals("", turn.reasoning)
         assertEquals("inner reasoningfinal answer", turn.message.contentText())
     }
+
+    @Test
+    fun `route-gated leading buffer reclassifies text before close tag for non local providers`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"inner reasoning</think>final answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("inner reasoning", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
+    }
+
+    @Test
+    fun `route-gated leading buffer reclassifies split close tag for non local providers`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"inner reasoning</th"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"ink>final answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("inner reasoning", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
+    }
+
+    @Test
+    fun `route-gated leading buffer flushes normal content when no think tag appears`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"normal answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("", turn.reasoning)
+        assertEquals("normal answer", turn.message.contentText())
+    }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
@@ -206,6 +206,52 @@ class HttpAgentLlmClientTest {
         }
     }
 
+    @Test
+    fun `qwen openai compatible route reclassifies leading content before closing think tag`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                    routeInfo(
+                        requestedModel = model,
+                        resolvedModel = "qwen3.6-plus",
+                        protocolType = protocolType ?: "openai_compatible",
+                        requiresReasoningEcho = false
+                    )
+                },
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"first reasoning</th"}}]}"""
+                    )
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"ink>final answer"}}]}"""
+                    )
+                    listener.onEvent(source, null, "message", "[DONE]")
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val turn = client.streamTurn(request = simpleRequest())
+
+            assertEquals("first reasoning", turn.reasoning)
+            assertEquals("final answer", turn.message.contentText())
+        } finally {
+            scope.cancel()
+        }
+    }
+
     private fun simpleRequest() = cn.com.omnimind.baselib.llm.ChatCompletionRequest(
         messages = listOf(
             cn.com.omnimind.baselib.llm.ChatCompletionMessage(


### PR DESCRIPTION
## 变更摘要

修复百炼 qwen 下</think> token前的reasoning 泄露问题。 
当上游先输出一段思考文本、后续 chunk 才补出 `</think>` 时，现在会按 Qwen 路由定向暂存前序文本，并在识别到关闭标签后重新归类到 reasoning，避免用户侧看到这段思考内容。

## 变更类型

Bug 修复

## 关联 Issue

Closes #326

## 主要改动

1. 在 `AgentLlmStreamAccumulator` 中新增受控的“前序正文暂存”能力 `bufferLeadingTextUntilInlineThinkTag`：  
   当开启该开关时，若流式输出前面先出现普通文本、后面才出现 `</think>`，则把关闭标签前的内容重新归类到 `reasoningBuffer`，只把关闭标签后的内容保留为可见正文。

## 测试说明
用户侧多次测试已不再出现 reasoning 泄露问题
<img width="864" height="1920" alt="ddef31216ebdd365398434a9fffb04f7" src="https://github.com/user-attachments/assets/a727dd0e-4650-4b8d-9d4f-939025f04282" />


## UI 变更（如有）

无

## 风险与回滚

潜在风险：

- 目前只针对 Qwen 系列模型
 
