### PR TITLE
 fix: 修复 Agent 编排误收尾导致断流现象(尤其是在qwen-plus模型下)；补齐请求失败自动重试兜底逻辑及前端显示(风格类似…

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -34,6 +34,16 @@ interface AgentLlmClient {
     ): ChatCompletionTurn
 }
 
+class AgentStreamRequestException(
+    val statusCode: Int?,
+    val reason: String,
+    val responseBody: String?
+) : RuntimeException(
+    "chat completion stream request failed${
+        statusCode?.let { "($it)" }.orEmpty()
+    }: $reason"
+)
+
 class HttpAgentLlmClient(
     private val scope: CoroutineScope,
     private val modelOverride: AgentModelOverride? = null,
@@ -95,16 +105,6 @@ class HttpAgentLlmClient(
         val requestJson: String
     )
 
-    private class StreamRequestFailure(
-        val statusCode: Int?,
-        val reason: String,
-        val responseBody: String?
-    ) : RuntimeException(
-        "chat completion stream request failed${
-            statusCode?.let { "($it)" }.orEmpty()
-        }: $reason"
-    )
-
     override suspend fun streamTurn(
         request: ChatCompletionRequest,
         onReasoningUpdate: (suspend (String) -> Unit)?,
@@ -114,7 +114,7 @@ class HttpAgentLlmClient(
         val variants = buildRequestVariants(
             sanitizeRequestForTarget(request)
         )
-        var lastFailure: StreamRequestFailure? = null
+        var lastFailure: AgentStreamRequestException? = null
 
         for (modelIndex in modelCandidates.indices) {
             val candidateModel = modelCandidates[modelIndex]
@@ -133,7 +133,7 @@ class HttpAgentLlmClient(
                         onReasoningUpdate = onReasoningUpdate,
                         onContentUpdate = onContentUpdate
                     )
-                } catch (error: StreamRequestFailure) {
+                } catch (error: AgentStreamRequestException) {
                     lastFailure = error
                     val canRetryVariant =
                         error.statusCode == 400 && variantIndex < variants.lastIndex
@@ -171,7 +171,7 @@ class HttpAgentLlmClient(
     ): ChatCompletionTurn {
         return try {
             doStreamTurnOnce(model, requestJson, onReasoningUpdate, onContentUpdate, forceHttp1 = false)
-        } catch (e: StreamRequestFailure) {
+        } catch (e: AgentStreamRequestException) {
             if (isHttp2ProtocolError(e)) {
                 OmniLog.w(tag, "HTTP/2 stream PROTOCOL_ERROR, retrying with HTTP/1.1")
                 doStreamTurnOnce(model, requestJson, onReasoningUpdate, onContentUpdate, forceHttp1 = true)
@@ -181,9 +181,27 @@ class HttpAgentLlmClient(
         }
     }
 
-    private fun isHttp2ProtocolError(error: StreamRequestFailure): Boolean {
+    private fun isHttp2ProtocolError(error: AgentStreamRequestException): Boolean {
         return error.reason.contains("PROTOCOL_ERROR", ignoreCase = true)
                 || error.reason.contains("stream was reset", ignoreCase = true)
+    }
+
+    private fun shouldBufferLeadingInlineThinkTag(
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): Boolean {
+        val protocolType = routeInfo.protocolType.trim().ifEmpty { "openai_compatible" }
+        if (!protocolType.equals("openai_compatible", ignoreCase = true)) {
+            return false
+        }
+        return sequenceOf(routeInfo.resolvedModel, routeInfo.requestedModel)
+            .map { it.trim().lowercase() }
+            .any { model ->
+                model.startsWith("qwen") ||
+                    model.contains("/qwen") ||
+                    model.contains(":qwen") ||
+                    model.contains("_qwen") ||
+                    model.contains("-qwen")
+            }
     }
 
     private suspend fun doStreamTurnOnce(
@@ -208,7 +226,8 @@ class HttpAgentLlmClient(
                 modelOverride?.providerProfileId,
                 modelOverride?.apiBase
             ),
-            includeReasoningInAssistantMessage = routeInfo?.requiresReasoningEcho == true
+            includeReasoningInAssistantMessage = routeInfo.requiresReasoningEcho,
+            bufferLeadingTextUntilInlineThinkTag = shouldBufferLeadingInlineThinkTag(routeInfo)
         )
         var lastReasoning = ""
         var lastReasoningEmitLength = 0
@@ -405,7 +424,7 @@ class HttpAgentLlmClient(
                     ?: sanitizeReason(t?.message)
                     ?: "unknown stream failure"
                 streamDone.completeExceptionally(
-                    StreamRequestFailure(
+                    AgentStreamRequestException(
                         statusCode = response?.code,
                         reason = reason,
                         responseBody = responseBody
@@ -644,7 +663,7 @@ class HttpAgentLlmClient(
         return candidates.toList()
     }
 
-    private fun isModelNotSupported(error: StreamRequestFailure): Boolean {
+    private fun isModelNotSupported(error: AgentStreamRequestException): Boolean {
         val code = error.statusCode
         if (code != 400 && code != 404) return false
         val haystack = buildString {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -20,7 +20,8 @@ import java.util.TreeMap
 class AgentLlmStreamAccumulator(
     private val json: Json,
     private val preferInlineThinkTags: Boolean = false,
-    private val includeReasoningInAssistantMessage: Boolean = false
+    private val includeReasoningInAssistantMessage: Boolean = false,
+    private val bufferLeadingTextUntilInlineThinkTag: Boolean = false
 ) {
     companion object {
         private const val TAG = "AgentLlmStreamAccumulator"
@@ -42,6 +43,7 @@ class AgentLlmStreamAccumulator(
     private var lastChunkPreview: String = ""
     private var thinkSectionOpen = false
     private var inlineThinkTagObserved = false
+    private var autoInlineThinkTagMode = false
 
     private var chunkIndex = 0
 
@@ -509,16 +511,26 @@ class AgentLlmStreamAccumulator(
         if (text.isEmpty()) {
             return
         }
-        if (!preferInlineThinkTags) {
-            contentBuffer.append(text)
+        if (shouldBufferLeadingInlineText()) {
+            inlineTextBuffer.append(text)
+            flushInlineTextBuffer(final = false)
             return
+        }
+        if (!preferInlineThinkTags && !autoInlineThinkTagMode && !thinkSectionOpen) {
+            val containsThinkTag = text.contains(THINK_OPEN_TAG) || text.contains(THINK_CLOSE_TAG)
+            val hasTrailingTagPrefix = partialInlineTagSuffixLength(text) > 0
+            if (!containsThinkTag && !hasTrailingTagPrefix) {
+                contentBuffer.append(text)
+                return
+            }
+            autoInlineThinkTagMode = true
         }
         inlineTextBuffer.append(text)
         flushInlineTextBuffer(final = false)
     }
 
     private fun flushInlineTextBuffer(final: Boolean) {
-        if (!preferInlineThinkTags) {
+        if (!preferInlineThinkTags && !autoInlineThinkTagMode && !bufferLeadingTextUntilInlineThinkTag) {
             if (inlineTextBuffer.isNotEmpty()) {
                 appendVisibleText(inlineTextBuffer.toString())
                 inlineTextBuffer.setLength(0)
@@ -578,7 +590,7 @@ class AgentLlmStreamAccumulator(
                 return
             }
 
-            if (!inlineThinkTagObserved && contentBuffer.isEmpty()) {
+            if (shouldDelayVisibleInlineBufferCommit()) {
                 return
             }
 
@@ -591,6 +603,21 @@ class AgentLlmStreamAccumulator(
             inlineTextBuffer.delete(0, safeLength)
             return
         }
+    }
+
+    private fun shouldBufferLeadingInlineText(): Boolean {
+        return bufferLeadingTextUntilInlineThinkTag &&
+            !preferInlineThinkTags &&
+            !autoInlineThinkTagMode &&
+            !thinkSectionOpen &&
+            !inlineThinkTagObserved &&
+            contentBuffer.isEmpty()
+    }
+
+    private fun shouldDelayVisibleInlineBufferCommit(): Boolean {
+        return !inlineThinkTagObserved &&
+            contentBuffer.isEmpty() &&
+            (preferInlineThinkTags || bufferLeadingTextUntilInlineThinkTag)
     }
 
     private fun partialInlineTagSuffixLength(text: String): Int {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentModels.kt
@@ -236,6 +236,17 @@ interface AgentCallback {
     }
 
     /**
+     * 当前轮次的流请求发生了可重试失败，正在等待自动重试。
+     */
+    suspend fun onRetrying(
+        retryCount: Int,
+        maxRetries: Int,
+        retryDelayMs: Long,
+        message: String,
+        retryReason: String?
+    ) = Unit
+
+    /**
      * 主模型一轮调用结束后的 prompt token 统计更新
      */
     suspend fun onPromptTokenUsageChanged(
@@ -266,6 +277,13 @@ interface AgentCallback {
      * Agent 执行错误
      */
     suspend fun onError(error: String)
+
+    /**
+     * Agent 执行错误，retryable=true 表示当前轮次可手动重试。
+     */
+    suspend fun onError(error: String, retryable: Boolean) {
+        onError(error)
+    }
 
     /**
      * 执行任务前缺少权限（陪伴模式未开启 或 无障碍权限未授予）

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -31,6 +32,24 @@ class AgentOrchestrator(
     private val toolImageContinuationPolicy: AgentToolImageContinuationPolicy =
         AgentToolImageContinuationPolicy.DEFAULT
 ) {
+    private data class RetryDecision(
+        val retryable: Boolean,
+        val reason: String
+    )
+
+    private class ExhaustedRetryableTurnFailure(
+        val errorMessage: String,
+        cause: Throwable
+    ) : RuntimeException(errorMessage, cause)
+
+    private data class TextOnlyStopDecision(
+        val allowFinish: Boolean,
+        val shouldRecover: Boolean,
+        val taskStillExecuting: Boolean,
+        val completeFinalAnswer: Boolean,
+        val reason: String
+    )
+
     data class Input(
         val callback: AgentCallback,
         val initialMessages: List<ChatCompletionMessage>,
@@ -47,6 +66,9 @@ class AgentOrchestrator(
     }
     private val tag = "AgentOrchestrator"
     private val maxLengthContinuationRounds = 3
+    private val maxMissingToolCallRecoveryRounds = 1
+    private val maxTurnRequestRetries = 3
+    private val turnRetryDelaysMs = listOf(500L, 1500L, 3000L)
 
     private fun t(zh: String, en: String): String {
         return if (AppLocaleManager.isEnglish()) en else zh
@@ -55,6 +77,7 @@ class AgentOrchestrator(
     suspend fun run(input: Input): AgentResult {
         val callback = input.callback
         val memory: AgentChatMemory = MutableListChatMemory(input.initialMessages)
+        val primaryUserGoal = resolvePrimaryUserGoal(input)
         val executedTools = mutableListOf<ToolExecutionResult>()
         var outputKind = AgentOutputKind.NONE
         var hasUserFacingOutput = false
@@ -67,7 +90,9 @@ class AgentOrchestrator(
         var lastDecodeTokensPerSecond: Double? = null
         var completedModelRounds = 0
         var lengthContinuationRounds = 0
+        var missingToolCallRecoveryRounds = 0
         var terminated = false
+        var terminalError: AgentResult.Error? = null
 
         try {
             roundLoop@ while (true) {
@@ -75,7 +100,8 @@ class AgentOrchestrator(
                 val round = completedModelRounds
                 val assistantContentPrefix = accumulatedAssistantContent
                 callback.onThinkingStart()
-                val toolChoiceForRound = if (memory.lastRole() == "tool") {
+                val roundStartsAfterToolResult = memory.lastRole() == "tool"
+                val toolChoiceForRound = if (roundStartsAfterToolResult) {
                     null
                 } else {
                     JsonPrimitive("auto")
@@ -85,36 +111,29 @@ class AgentOrchestrator(
                     "round=$round request_tools=${toolRegistry.toolsForModel.size}"
                 )
                 val disableThinking = input.executionEnv.reasoningEffort == "no"
-                val turn = llmClient.streamTurn(
-                    request = ChatCompletionRequest(
-                        messages = memory.snapshot(),
-                        model = model,
-                        maxCompletionTokens = 16384,
-                        stream = true,
-                        streamOptions = ChatCompletionStreamOptions(includeUsage = true),
-                        enableThinking = if (disableThinking) false else null,
-                        reasoningEffort = if (disableThinking) null else input.executionEnv.reasoningEffort,
-                        tools = toolRegistry.toolsForModel,
-                        toolChoice = toolChoiceForRound,
-                        parallelToolCalls = true
-                    ),
-                    onReasoningUpdate = { reasoning ->
-                        if (reasoning.isNotBlank()) {
-                            callback.onThinkingUpdate(normalizeThinkingText(reasoning))
-                        }
-                    },
-                    onContentUpdate = { content ->
-                        if (content.isNotBlank()) {
-                            callback.onChatMessage(
-                                combineContinuationContent(
-                                    prefix = assistantContentPrefix,
-                                    content = content
-                                ),
-                                false
-                            )
-                        }
-                    }
-                )
+                val turn = try {
+                    streamTurnWithRetry(
+                        callback = callback,
+                        request = ChatCompletionRequest(
+                            messages = memory.snapshot(),
+                            model = model,
+                            maxCompletionTokens = 16384,
+                            stream = true,
+                            streamOptions = ChatCompletionStreamOptions(includeUsage = true),
+                            enableThinking = if (disableThinking) false else null,
+                            reasoningEffort = if (disableThinking) null else input.executionEnv.reasoningEffort,
+                            tools = toolRegistry.toolsForModel,
+                            toolChoice = toolChoiceForRound,
+                            parallelToolCalls = true
+                        ),
+                        assistantContentPrefix = assistantContentPrefix
+                    )
+                } catch (e: ExhaustedRetryableTurnFailure) {
+                    callback.onError(e.errorMessage, true)
+                    terminalError = AgentResult.Error(e.errorMessage, e)
+                    terminated = true
+                    break@roundLoop
+                }
 
                 lastFinishReason = turn.finishReason
                 lastPrefillTokensPerSecond =
@@ -180,6 +199,34 @@ class AgentOrchestrator(
                         )
                         continue@roundLoop
                     }
+                    val textOnlyStopDecision = evaluateTextOnlyStopDecision(
+                        finishReason = lastFinishReason,
+                        assistantContent = lastAssistantContent,
+                        userGoal = primaryUserGoal,
+                        roundStartsAfterToolResult = roundStartsAfterToolResult,
+                        hasPriorToolCall = executedTools.any { it !is ToolExecutionResult.ChatMessage }
+                    )
+                    logInfo(
+                        tag,
+                        "round=$round text_only_stop allow_finish=${textOnlyStopDecision.allowFinish} " +
+                            "should_recover=${textOnlyStopDecision.shouldRecover} " +
+                            "task_still_executing=${textOnlyStopDecision.taskStillExecuting} " +
+                            "complete_final_answer=${textOnlyStopDecision.completeFinalAnswer} " +
+                            "reason=${textOnlyStopDecision.reason}"
+                    )
+                    if (
+                        textOnlyStopDecision.shouldRecover &&
+                        missingToolCallRecoveryRounds < maxMissingToolCallRecoveryRounds
+                    ) {
+                        missingToolCallRecoveryRounds += 1
+                        memory.add(buildMissingToolCallRecoveryMessage())
+                        logInfo(
+                            tag,
+                            "round=$round no_tool_call_with_action_intent " +
+                                "auto_recover=$missingToolCallRecoveryRounds/$maxMissingToolCallRecoveryRounds"
+                        )
+                        continue@roundLoop
+                    }
                     val fallbackMessage = lastAssistantContent.ifBlank {
                         "我已完成思考，但暂时无法生成回复，请重试。"
                     }
@@ -197,6 +244,7 @@ class AgentOrchestrator(
                 }
                 accumulatedAssistantContent = ""
                 lengthContinuationRounds = 0
+                missingToolCallRecoveryRounds = 0
 
                 var advanceToNextRound = false
                 val descriptorMap = mutableMapOf<String, AgentToolRegistry.RuntimeToolDescriptor>()
@@ -394,6 +442,8 @@ class AgentOrchestrator(
             runCatching { toolRouter.dispose() }
         }
 
+        terminalError?.let { return it }
+
         if (!hasUserFacingOutput) {
             val fallbackMessage = lastAssistantContent.ifBlank {
                 t(
@@ -427,6 +477,63 @@ class AgentOrchestrator(
         )
         callback.onComplete(finalResult)
         return finalResult
+    }
+
+    private suspend fun streamTurnWithRetry(
+        callback: AgentCallback,
+        request: ChatCompletionRequest,
+        assistantContentPrefix: String
+    ): ChatCompletionTurn {
+        var retryCount = 0
+        while (true) {
+            try {
+                return llmClient.streamTurn(
+                    request = request,
+                    onReasoningUpdate = { reasoning ->
+                        if (reasoning.isNotBlank()) {
+                            callback.onThinkingUpdate(normalizeThinkingText(reasoning))
+                        }
+                    },
+                    onContentUpdate = { content ->
+                        if (content.isNotBlank()) {
+                            callback.onChatMessage(
+                                combineContinuationContent(
+                                    prefix = assistantContentPrefix,
+                                    content = content
+                                ),
+                                false
+                            )
+                        }
+                    }
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val decision = classifyRetryableTurnFailure(e)
+                val canRetry = decision.retryable && retryCount < maxTurnRequestRetries
+                if (!canRetry) {
+                    if (decision.retryable) {
+                        throw ExhaustedRetryableTurnFailure(
+                            errorMessage = decision.reason,
+                            cause = e
+                        )
+                    }
+                    throw e
+                }
+
+                retryCount += 1
+                val retryDelayMs = turnRetryDelaysMs
+                    .getOrElse(retryCount - 1) { turnRetryDelaysMs.last() }
+                callback.onRetrying(
+                    retryCount = retryCount,
+                    maxRetries = maxTurnRequestRetries,
+                    retryDelayMs = retryDelayMs,
+                    message = buildRetryingStatusMessage(retryCount, maxTurnRequestRetries),
+                    retryReason = decision.reason
+                )
+                delay(retryDelayMs)
+            }
+        }
     }
 
     private suspend fun executeSingleTool(
@@ -648,11 +755,324 @@ class AgentOrchestrator(
             normalized == "max_completion_tokens"
     }
 
+    private fun isStopFinishReason(reason: String?): Boolean {
+        return reason?.trim()?.lowercase() == "stop"
+    }
+
+    private fun classifyRetryableTurnFailure(error: Throwable): RetryDecision {
+        if (error is AgentStreamRequestException) {
+            val statusCode = error.statusCode
+            val retryableStatus = statusCode == 408 ||
+                statusCode == 429 ||
+                statusCode == 502 ||
+                statusCode == 503 ||
+                statusCode == 504
+            val retryableReason = looksLikeTransientTransportFailure(error.reason)
+            if (retryableStatus || retryableReason) {
+                return RetryDecision(
+                    retryable = true,
+                    reason = formatTurnFailureReason(statusCode, error.reason)
+                )
+            }
+            return RetryDecision(
+                retryable = false,
+                reason = error.reason
+            )
+        }
+
+        val message = error.message?.trim().orEmpty()
+        if (looksLikeTransientTransportFailure(message)) {
+            return RetryDecision(
+                retryable = true,
+                reason = formatTurnFailureReason(null, message)
+            )
+        }
+        return RetryDecision(
+            retryable = false,
+            reason = message.ifEmpty { error::class.java.simpleName }
+        )
+    }
+
+    private fun looksLikeTransientTransportFailure(message: String): Boolean {
+        if (message.isBlank()) return false
+        val normalized = message.lowercase()
+        return normalized.contains("idle timeout") ||
+            normalized.contains("closed before completion signal") ||
+            normalized.contains("unknown stream failure") ||
+            normalized.contains("timeout") ||
+            normalized.contains("timed out") ||
+            normalized.contains("connection reset") ||
+            normalized.contains("unexpected end of stream") ||
+            normalized.contains("software caused connection abort") ||
+            normalized.contains("broken pipe") ||
+            normalized.contains("connection refused") ||
+            normalized.contains("connection aborted") ||
+            normalized.contains("eofexception") ||
+            normalized.contains("protocol_error") ||
+            normalized.contains("stream was reset") ||
+            normalized.contains("network") ||
+            normalized.contains("temporarily unavailable")
+    }
+
+    private fun formatTurnFailureReason(statusCode: Int?, reason: String): String {
+        val normalizedReason = reason.trim().ifEmpty {
+            t("请求失败，请稍后重试。", "Request failed. Please try again later.")
+        }
+        return statusCode?.let { "HTTP $it: $normalizedReason" } ?: normalizedReason
+    }
+
+    private fun buildRetryingStatusMessage(retryCount: Int, maxRetries: Int): String {
+        return t(
+            "连接中断，正在重试 $retryCount/$maxRetries…",
+            "Connection interrupted. Retrying $retryCount/$maxRetries..."
+        )
+    }
+
+    private fun resolvePrimaryUserGoal(input: Input): String {
+        val envUserMessage = AgentTextSanitizer.sanitizeUtf16(input.executionEnv.userMessage).trim()
+        if (envUserMessage.isNotEmpty()) {
+            return envUserMessage
+        }
+        return input.initialMessages
+            .asReversed()
+            .firstOrNull { it.role == "user" }
+            ?.contentText()
+            ?.let(AgentTextSanitizer::sanitizeUtf16)
+            ?.trim()
+            .orEmpty()
+    }
+
+    private fun evaluateTextOnlyStopDecision(
+        finishReason: String?,
+        assistantContent: String,
+        userGoal: String,
+        roundStartsAfterToolResult: Boolean,
+        hasPriorToolCall: Boolean
+    ): TextOnlyStopDecision {
+        if (!isStopFinishReason(finishReason)) {
+            return TextOnlyStopDecision(
+                allowFinish = true,
+                shouldRecover = false,
+                taskStillExecuting = false,
+                completeFinalAnswer = true,
+                reason = "non_stop_finish_reason"
+            )
+        }
+        val normalized = AgentTextSanitizer.sanitizeUtf16(assistantContent).trim()
+        if (normalized.isEmpty()) {
+            return TextOnlyStopDecision(
+                allowFinish = true,
+                shouldRecover = false,
+                taskStillExecuting = false,
+                completeFinalAnswer = false,
+                reason = "blank_text_reply"
+            )
+        }
+        val actionGoal = userGoalRequiresExternalAction(userGoal)
+        val actionIntent = containsActionIntentWithoutToolCall(normalized)
+        val intermediateUpdate = looksLikeIntermediateExecutionUpdate(normalized)
+        val explicitFinalCue = containsExplicitFinalAnswerCue(normalized)
+        val answerTooThinForActionGoal =
+            actionGoal &&
+                normalized.length < 18 &&
+                !explicitFinalCue &&
+                !roundStartsAfterToolResult
+        val completeFinalAnswer =
+            looksLikeCompleteFinalAnswer(
+                content = normalized,
+                explicitFinalCue = explicitFinalCue,
+                actionIntent = actionIntent,
+                intermediateUpdate = intermediateUpdate,
+                answerTooThinForActionGoal = answerTooThinForActionGoal
+            )
+        val taskStillExecuting =
+            roundStartsAfterToolResult ||
+                (hasPriorToolCall && (actionIntent || intermediateUpdate)) ||
+                actionIntent ||
+                intermediateUpdate ||
+                answerTooThinForActionGoal
+        val shouldRecover = taskStillExecuting && !completeFinalAnswer
+        val reason = when {
+            roundStartsAfterToolResult && !completeFinalAnswer -> "pending_tool_chain"
+            actionIntent && !completeFinalAnswer -> "action_intent_without_tool_call"
+            intermediateUpdate && !completeFinalAnswer -> "intermediate_status_without_result"
+            answerTooThinForActionGoal -> "action_goal_reply_too_thin"
+            completeFinalAnswer -> "complete_final_answer"
+            else -> "plain_text_terminal_reply"
+        }
+        return TextOnlyStopDecision(
+            allowFinish = !shouldRecover,
+            shouldRecover = shouldRecover,
+            taskStillExecuting = taskStillExecuting,
+            completeFinalAnswer = completeFinalAnswer,
+            reason = reason
+        )
+    }
+
+    private fun containsActionIntentWithoutToolCall(content: String): Boolean {
+        val normalized = content.lowercase()
+        val chineseActionCues = listOf(
+            "让我查一下",
+            "让我查一查",
+            "让我查询一下",
+            "我先查一下",
+            "我先查询一下",
+            "让我检查一下",
+            "我先检查一下",
+            "让我搜一下",
+            "让我搜索一下",
+            "我先搜一下",
+            "我先搜索一下",
+            "让我看一下",
+            "让我看一看",
+            "我先看一下",
+            "我先看一看",
+            "我去查一下",
+            "我去看一下"
+        )
+        if (chineseActionCues.any(normalized::contains)) {
+            return true
+        }
+        val chineseActionIntent = Regex(
+            """(?:让我|我)(?:先|再|再一次|最后一次|最后再|去)?(?:查找|寻找|查询|检查|搜索|搜|查看|看|核实|确认|回到|返回|回去|尝试|试着|筛选)""",
+            RegexOption.IGNORE_CASE
+        )
+        if (chineseActionIntent.containsMatchIn(content)) {
+            return true
+        }
+        val chineseDeferredActionIntent = Regex(
+            """(?:让我|我来|我会|我将|我先|我再|我去|我来为您|我来帮您|我帮您)(?:[^。！？；，,\n]{0,16})?(?:查找|寻找|查询|检查|搜索|搜|查看|看|核实|确认|回到|返回|回去|尝试|试着|筛选|过滤|定位|打开|点击|进入|读取|执行|运行)""",
+            RegexOption.IGNORE_CASE
+        )
+        if (chineseDeferredActionIntent.containsMatchIn(content)) {
+            return true
+        }
+        val englishActionIntent = Regex(
+            """\b(?:let me|i(?:'ll| will)|first,\s*let me)\s+(?:check|look|search|verify|see|find|try|return)\b""",
+            RegexOption.IGNORE_CASE
+        )
+        return englishActionIntent.containsMatchIn(content)
+    }
+
+    private fun userGoalRequiresExternalAction(content: String): Boolean {
+        val normalized = AgentTextSanitizer.sanitizeUtf16(content).trim()
+        if (normalized.isEmpty()) return false
+        val chineseActionGoal = Regex(
+            """(?:打开|查找|查询|搜索|搜一下|查看|看一下|点击|进入|导航|跳转|返回|回到|筛选|过滤|定位|读取|执行|运行|安装|下载|提交|填写|选择|勾选|切换|创建|删除|修改|重试)""",
+            RegexOption.IGNORE_CASE
+        )
+        if (chineseActionGoal.containsMatchIn(normalized)) {
+            return true
+        }
+        val englishActionGoal = Regex(
+            """\b(?:open|search|find|look up|check|click|navigate|go to|return|filter|read|run|install|download|submit|fill|select|toggle|create|delete|edit|retry)\b""",
+            RegexOption.IGNORE_CASE
+        )
+        return englishActionGoal.containsMatchIn(normalized)
+    }
+
+    private fun looksLikeIntermediateExecutionUpdate(content: String): Boolean {
+        val normalized = content.lowercase()
+        val chineseProgressCues = listOf(
+            "接下来",
+            "随后",
+            "稍后",
+            "稍等",
+            "等我",
+            "准备",
+            "正在",
+            "然后继续",
+            "继续筛选",
+            "继续查找",
+            "继续搜索",
+            "继续尝试",
+            "最后一次尝试",
+            "尝试返回",
+            "回到首页",
+            "返回首页"
+        )
+        if (chineseProgressCues.any(normalized::contains)) {
+            return true
+        }
+        val englishProgressCue = Regex(
+            """\b(?:next|then|after that|let me continue|continuing|continue to|continue with|still trying|one more try|trying to return)\b""",
+            RegexOption.IGNORE_CASE
+        )
+        return englishProgressCue.containsMatchIn(content)
+    }
+
+    private fun containsExplicitFinalAnswerCue(content: String): Boolean {
+        val normalized = content.lowercase()
+        val chineseFinalCues = listOf(
+            "建议",
+            "结论",
+            "总结",
+            "如下",
+            "步骤",
+            "推荐",
+            "答案",
+            "综合现有信息",
+            "已完成",
+            "处理完成",
+            "已经完成",
+            "已查到",
+            "已找到",
+            "读取失败",
+            "校验失败",
+            "当前限制",
+            "无法直接",
+            "不能直接",
+            "用户手动停止"
+        )
+        if (chineseFinalCues.any(normalized::contains)) {
+            return true
+        }
+        val structuredAnswer = Regex(
+            """(?:^|\n)\s*(?:\d+\.\s|-\s|•\s|一、|二、|三、)""",
+            RegexOption.MULTILINE
+        )
+        if (structuredAnswer.containsMatchIn(content)) {
+            return true
+        }
+        val englishFinalCue = Regex(
+            """\b(?:recommend|summary|conclusion|steps|result|answer|done|completed|cannot directly|can't directly)\b""",
+            RegexOption.IGNORE_CASE
+        )
+        return englishFinalCue.containsMatchIn(content)
+    }
+
+    private fun looksLikeCompleteFinalAnswer(
+        content: String,
+        explicitFinalCue: Boolean,
+        actionIntent: Boolean,
+        intermediateUpdate: Boolean,
+        answerTooThinForActionGoal: Boolean
+    ): Boolean {
+        if (content.isBlank()) return false
+        if (answerTooThinForActionGoal) return false
+        if (explicitFinalCue) return true
+        if (actionIntent) return false
+        if (intermediateUpdate) return false
+        return true
+    }
+
     private fun buildLengthContinuationMessage(): ChatCompletionMessage {
         return ChatCompletionMessage(
             role = "user",
             content = JsonPrimitive(
                 "上一条 assistant 回复因为达到输出长度上限被截断。请从中断处继续完成原任务，不要重复已经输出的内容，不要重新开头，不要解释本提示。"
+            )
+        )
+    }
+
+    private fun buildMissingToolCallRecoveryMessage(): ChatCompletionMessage {
+        return ChatCompletionMessage(
+            role = "user",
+            content = JsonPrimitive(
+                t(
+                    "你上一条回复还停留在执行中间态，但没有真正发起 tool_call，也没有给出完整最终答案。请继续同一任务：如果还需要操作、查询、点击、筛选或导航，必须返回标准 tool_call；如果不需要工具，请直接给出完整最终答案。不要只回复“我先查一下”“接下来继续处理”这类过渡语。",
+                    "Your previous reply was still in an in-progress execution state, but you did not emit a tool_call or provide a complete final answer. Continue the same task: if any action, lookup, click, filter, or navigation is still needed, you must return a standard tool_call; if no tool is needed, reply with the complete final answer directly. Do not answer with transitional text such as 'let me check' or 'next I will continue' only."
+                )
             )
         )
     }

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -531,6 +531,10 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         var promptTokenThreshold: Int? = null
     )
 
+    private data class FailedAgentRetryContext(
+        val arguments: Map<String, Any?>
+    )
+
     private class ActiveAgentRunContext(
         val taskId: String,
         val job: Job,
@@ -690,6 +694,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     private val activeAgentLock = Any()
 
     private val activeAgentRuns: MutableMap<String, ActiveAgentRunContext> = mutableMapOf()
+    private val failedAgentRetryContexts: MutableMap<String, FailedAgentRetryContext> = mutableMapOf()
     private val chatTaskPersistenceStates: MutableMap<String, ChatTaskPersistenceState> =
         mutableMapOf()
     private val conversationDomainService by lazy { ConversationDomainService(context) }
@@ -707,6 +712,24 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     private fun registerChatTaskPersistenceState(taskId: String, state: ChatTaskPersistenceState) {
         synchronized(activeAgentLock) {
             chatTaskPersistenceStates[taskId] = state
+        }
+    }
+
+    private fun registerFailedAgentRetryContext(taskId: String, context: FailedAgentRetryContext) {
+        synchronized(activeAgentLock) {
+            failedAgentRetryContexts[taskId] = context
+        }
+    }
+
+    private fun getFailedAgentRetryContext(taskId: String): FailedAgentRetryContext? {
+        return synchronized(activeAgentLock) {
+            failedAgentRetryContexts[taskId]
+        }
+    }
+
+    private fun removeFailedAgentRetryContext(taskId: String): FailedAgentRetryContext? {
+        return synchronized(activeAgentLock) {
+            failedAgentRetryContexts.remove(taskId)
         }
     }
 
@@ -1456,6 +1479,43 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             OmniLog.e(TAG, "通知总结Sheet准备就绪失败: ${e.message}")
             mainJob.launch(Dispatchers.Main) {
                 result.error("NOTIFY_SUMMARY_SHEET_READY_ERROR", e.message, null)
+            }
+        }
+    }
+
+    fun retryAgentTask(
+        call: MethodCall,
+        result: MethodChannel.Result
+    ) {
+        mainJob.launch {
+            try {
+                val taskId = call.argument<String>("taskId")?.trim().orEmpty()
+                if (taskId.isBlank()) {
+                    withContext(Dispatchers.Main) {
+                        result.error("INVALID_ARGUMENTS", "taskId is required", null)
+                    }
+                    return@launch
+                }
+                val retryContext = getFailedAgentRetryContext(taskId)
+                if (retryContext == null) {
+                    withContext(Dispatchers.Main) {
+                        result.error(
+                            "NO_RETRY_CONTEXT",
+                            "No retryable agent context found for taskId=$taskId",
+                            null
+                        )
+                    }
+                    return@launch
+                }
+                createAgentTask(
+                    MethodCall("createAgentTask", retryContext.arguments),
+                    result
+                )
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "retryAgentTask error: ${e.message}")
+                withContext(Dispatchers.Main) {
+                    result.error("RETRY_AGENT_TASK_ERROR", e.message, null)
+                }
             }
         }
     }
@@ -3917,6 +3977,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     }
 
     fun createAgentTask(call: MethodCall, result: MethodChannel.Result) {
+        val rawCallArguments = (call.arguments as? Map<*, *>)
+            ?.entries
+            ?.filter { it.key != null }
+            ?.associate { it.key.toString() to it.value }
+            ?: emptyMap()
         val taskId = (call.argument<String>("taskId") ?: "").trim()
         val userMessage = AgentTextSanitizer.sanitizeUtf16(
             (call.argument<String>("userMessage") ?: "").toString()
@@ -3958,12 +4023,25 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             result.error("INVALID_ARGUMENTS", "taskId is empty", null)
             return
         }
+        removeFailedAgentRetryContext(taskId)
         if (legacyConversationHistory.isNotEmpty()) {
             OmniLog.d(
                 TAG,
                 "Ignoring legacy conversationHistory for createAgentTask taskId=$taskId size=${legacyConversationHistory.size}"
             )
         }
+        val retryArguments = sanitizeInteropMap(
+            rawCallArguments + mapOf(
+                "taskId" to taskId,
+                "userMessage" to userMessage,
+                "attachments" to rawAttachments,
+                "userMessageCreatedAt" to userMessageCreatedAt,
+                "conversationId" to conversationId,
+                "conversationMode" to resolvedConversationMode,
+                "reasoningEffort" to reasoningEffort,
+                "terminalEnvironment" to terminalEnvironment
+            )
+        )
         val agentRunJob = SupervisorJob()
         val agentRunScope = CoroutineScope(agentRunJob + Dispatchers.Default)
         val agentRunContext = ActiveAgentRunContext(
@@ -4794,6 +4872,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     }
 
                     override suspend fun onComplete(result: AgentResult) {
+                        removeFailedAgentRetryContext(taskId)
                         val isSuccess = result is AgentResult.Success
                         val outputKind = (result as? AgentResult.Success)?.outputKind ?: "none"
                         val hasUserVisibleOutput =
@@ -4892,7 +4971,49 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         )
                     }
 
+                    override suspend fun onRetrying(
+                        retryCount: Int,
+                        maxRetries: Int,
+                        retryDelayMs: Long,
+                        message: String,
+                        retryReason: String?
+                    ) {
+                        val retryEntryId = activeAssistantEntryId ?: activeThinkingEntryId
+                        val retryRoundIndex = if (activeAssistantEntryId != null) {
+                            assistantRound.coerceAtLeast(1)
+                        } else {
+                            thinkingRound.coerceAtLeast(1)
+                        }
+                        sendStreamEvent(
+                            kind = "retrying",
+                            entryId = retryEntryId,
+                            roundIndex = retryRoundIndex,
+                            text = AgentTextSanitizer.sanitizeUtf16(message).trim(),
+                            stage = 1,
+                            extras = mapOf(
+                                "willRetry" to true,
+                                "retryable" to true,
+                                "retryCount" to retryCount,
+                                "maxRetries" to maxRetries,
+                                "retryDelayMs" to retryDelayMs,
+                                "retryReason" to retryReason
+                            )
+                        )
+                    }
+
                     override suspend fun onError(error: String) {
+                        onError(error, retryable = false)
+                    }
+
+                    override suspend fun onError(error: String, retryable: Boolean) {
+                        if (retryable) {
+                            registerFailedAgentRetryContext(
+                                taskId,
+                                FailedAgentRetryContext(arguments = retryArguments)
+                            )
+                        } else {
+                            removeFailedAgentRetryContext(taskId)
+                        }
                         val resolution = resolveAgentFinalErrorResolution(
                             streamed = scheduledAssistantBuffer.toString().ifBlank {
                                 latestAssistantVisibleText
@@ -4903,6 +5024,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                                 "I can't generate a reply right now. Please try again."
                             )
                         )
+                        val errorText = AgentTextSanitizer.sanitizeUtf16(error).trim().ifEmpty {
+                            t(
+                                "暂时无法生成回复，请重试。",
+                                "I can't generate a reply right now. Please try again."
+                            )
+                        }
                         val finalText = resolution.text
                         finalizeThinkingCardIfNeeded(publish = finalText.isBlank())
                         var errorEntryId: String? = activeAssistantEntryId
@@ -4951,7 +5078,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             entryId = errorEntryId,
                             roundIndex = errorRoundIndex,
                             error = error,
-                            extras = mapOf("persistAsError" to resolution.persistAsError)
+                            extras = mapOf(
+                                "persistAsError" to resolution.persistAsError,
+                                "willRetry" to false,
+                                "retryable" to retryable,
+                                "retryCount" to if (retryable) 3 else 0,
+                                "maxRetries" to 3,
+                                "errorText" to errorText
+                            )
                         )
                     }
 
@@ -5101,6 +5235,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             } catch (e: CancellationException) {
                 OmniLog.i(TAG, "createAgentTask cancelled: ${e.message}")
             } catch (e: Exception) {
+                removeFailedAgentRetryContext(taskId)
                 OmniLog.e(TAG, "createAgentTask error: ${e.message}")
                 val errorMessage = e.message?.trim()?.takeIf { it.isNotEmpty() }?.let {
                     "Agent execution failed: $it"

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
@@ -207,6 +207,9 @@ class AssistsCoreChannel {
                 "stopAgentToolCall" -> {
                     assistsCoreManager!!.stopAgentToolCall(call, result)
                 }
+                "retryAgentTask" -> {
+                    assistsCoreManager!!.retryAgentTask(call, result)
+                }
                 "isCompanionTaskRunning" -> {
                     assistsCoreManager!!.isCompanionTaskRunning( call, result)
                 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
@@ -168,4 +168,52 @@ class AgentLlmStreamAccumulatorTest {
 
         assertEquals("前缀后缀", turn.message.contentText())
     }
+    @Test
+    fun `route-gated leading buffer reclassifies text before close tag for non local providers`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"inner reasoning</think>final answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("inner reasoning", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
+    }
+
+    @Test
+    fun `route-gated leading buffer reclassifies split close tag for non local providers`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"inner reasoning</th"}}]}""")
+        accumulator.consume("""{"choices":[{"delta":{"content":"ink>final answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("inner reasoning", turn.reasoning)
+        assertEquals("final answer", turn.message.contentText())
+    }
+
+    @Test
+    fun `route-gated leading buffer flushes normal content when no think tag appears`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true
+        )
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"normal answer"}}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("", turn.reasoning)
+        assertEquals("normal answer", turn.message.contentText())
+    }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -6,18 +6,33 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import java.util.Locale
 
 class AgentOrchestratorTest {
+    private lateinit var originalLocale: Locale
     private val eventJson = Json {
         ignoreUnknownKeys = true
         isLenient = true
         encodeDefaults = true
         prettyPrint = true
+    }
+
+    @Before
+    fun setUpLocale() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.SIMPLIFIED_CHINESE)
+    }
+
+    @After
+    fun tearDownLocale() {
+        Locale.setDefault(originalLocale)
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -148,6 +148,239 @@ class AgentOrchestratorTest {
     }
 
     @Test
+    fun actionIntentWithoutToolCallsTriggersSingleRecoveryRound() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    content = "我先查一下相关资料，再继续处理。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(toolCalls = listOf(toolCall("file_search"))),
+                assistantTurn(content = "已查到相关资料并继续处理完成。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "file_search" to listOf(
+                    ToolExecutionResult.ContextResult(
+                        toolName = "file_search",
+                        summaryText = "已找到匹配资料",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true
+                    )
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("继续查资料"),
+                executionEnv = FakeExecutionEnvironment("继续查资料")
+            )
+        )
+
+        assertEquals(listOf("file_search"), toolExecutor.executeCalls)
+        assertEquals(3, llmClient.requests.size)
+        assertEquals("user", llmClient.requests[1].messages.last().role)
+        assertTrue(
+            llmClient.requests[1].messages.last().contentText().contains("没有真正发起 tool_call")
+        )
+        assertTrue(callback.finalChatMessages().last().contains("继续处理完成"))
+        assertTrue(result is AgentResult.Success)
+    }
+
+    @Test
+    fun actionIntentWithoutToolCallsCanRecoverIntoCompleteFinalAnswer() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    content = "让我检查一下现有信息。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(
+                    content = "综合现有信息，建议直接按灰蓝配色和 800 预算筛选低帮款。",
+                    finishReason = "stop"
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, FakeToolExecutor()).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("给我一个选购建议"),
+                executionEnv = FakeExecutionEnvironment("给我一个选购建议")
+            )
+        )
+
+        assertEquals(2, llmClient.requests.size)
+        assertEquals("user", llmClient.requests[1].messages.last().role)
+        assertTrue(callback.finalChatMessages().last().contains("综合现有信息"))
+        assertTrue(result is AgentResult.Success)
+    }
+
+    @Test
+    fun traceStyleDeferredSearchSentenceTriggersRecoveryRound() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    content = "根据您的需求（男性、预算800元、喜欢浅蓝色和灰色），我来为您筛选最适合的AJ运动板鞋。让我在耐克官网搜索符合这些条件的具体款式。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(toolCalls = listOf(toolCall("browser_use"))),
+                assistantTurn(
+                    content = "我已经在耐克官网打开 AJ 列表页，可以继续按浅蓝色、灰色和 800 元预算筛选男款。",
+                    finishReason = "stop"
+                )
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "browser_use" to listOf(
+                    ToolExecutionResult.ContextResult(
+                        toolName = "browser_use",
+                        summaryText = "已打开耐克官网并进入 AJ 列表页",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true
+                    )
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("帮我找适合的 AJ 男鞋"),
+                executionEnv = FakeExecutionEnvironment("帮我找适合的 AJ 男鞋")
+            )
+        )
+
+        assertEquals(listOf("browser_use"), toolExecutor.executeCalls)
+        assertEquals(3, llmClient.requests.size)
+        assertEquals("user", llmClient.requests[1].messages.last().role)
+        assertTrue(
+            llmClient.requests[1].messages.last().contentText().contains("完整最终答案")
+        )
+        assertTrue(callback.finalChatMessages().last().contains("打开 AJ 列表页"))
+        assertTrue(result is AgentResult.Success)
+    }
+
+    @Test
+    fun intermediateTextAfterToolChainAlsoTriggersRecoveryRound() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    content = "让我先查找 AJ1 页面上的产品列表，寻找浅蓝色和灰色的男款 AJ1。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(toolCalls = listOf(toolCall("browser_use"))),
+                assistantTurn(
+                    content = "我已经定位到 AJ1 列表页，接下来可以继续筛选。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(
+                    content = "已按你的条件定位到 AJ1 列表页，建议继续筛选浅蓝色和灰色男款。",
+                    finishReason = "stop"
+                )
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "browser_use" to listOf(
+                    ToolExecutionResult.ContextResult(
+                        toolName = "browser_use",
+                        summaryText = "已定位到 AJ1 列表页",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true
+                    )
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("继续在 AJ1 页面筛选"),
+                executionEnv = FakeExecutionEnvironment("继续在 AJ1 页面筛选")
+            )
+        )
+
+        assertEquals(listOf("browser_use"), toolExecutor.executeCalls)
+        assertEquals(4, llmClient.requests.size)
+        assertEquals("user", llmClient.requests[3].messages.last().role)
+        assertTrue(
+            llmClient.requests[3].messages.last().contentText().contains("完整最终答案")
+        )
+        assertTrue(callback.finalChatMessages().last().contains("建议继续筛选"))
+        assertTrue(result is AgentResult.Success)
+    }
+
+    @Test
+    fun actionIntentRecoveryStopsAfterSingleGuardRound() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    content = "我先搜索一下合适的结果。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(
+                    content = "让我再检查一下更多信息。",
+                    finishReason = "stop"
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, FakeToolExecutor()).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("继续执行"),
+                executionEnv = FakeExecutionEnvironment("继续执行")
+            )
+        )
+
+        assertEquals(2, llmClient.requests.size)
+        assertEquals("让我再检查一下更多信息。", callback.finalChatMessages().last())
+        assertTrue(result is AgentResult.Success)
+    }
+
+    @Test
+    fun traceStyleRetryIntentStillStopsAfterSingleGuardRound() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    content = "让我再尝试一次返回首页。",
+                    finishReason = "stop"
+                ),
+                assistantTurn(
+                    content = "让我最后一次尝试返回首页。",
+                    finishReason = "stop"
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, FakeToolExecutor()).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("继续尝试返回首页"),
+                executionEnv = FakeExecutionEnvironment("继续尝试返回首页")
+            )
+        )
+
+        assertEquals(2, llmClient.requests.size)
+        assertEquals("让我最后一次尝试返回首页。", callback.finalChatMessages().last())
+        assertTrue(result is AgentResult.Success)
+    }
+
+    @Test
     fun lengthFinishReasonContinuesAndPublishesCombinedFinalText() = runBlocking {
         val llmClient = FakeLlmClient(
             turns = listOf(
@@ -587,6 +820,73 @@ class AgentOrchestratorTest {
         assertFalse(toolMessage.content.toString().contains("\"image_url\""))
     }
 
+    @Test
+    fun `retries transient stream failures before succeeding`() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(assistantTurn(content = "已在重连后成功完成。")),
+            failures = listOf(
+                AgentStreamRequestException(
+                    statusCode = 503,
+                    reason = "upstream temporarily unavailable",
+                    responseBody = null
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(
+            llmClient = llmClient,
+            toolExecutor = FakeToolExecutor()
+        ).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("继续执行网页查询"),
+                executionEnv = FakeExecutionEnvironment("继续执行网页查询")
+            )
+        )
+
+        assertTrue(result is AgentResult.Success)
+        assertEquals(1, callback.retryingEvents.size)
+        assertEquals("已在重连后成功完成。", callback.finalChatMessages().last())
+        assertTrue(callback.errors.isEmpty())
+        assertFalse(callback.lastErrorRetryable)
+    }
+
+    @Test
+    fun `surfaces retryable terminal error after exhausting transient retries`() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = emptyList(),
+            failures = List(4) {
+                AgentStreamRequestException(
+                    statusCode = 503,
+                    reason = "upstream temporarily unavailable",
+                    responseBody = null
+                )
+            }
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(
+            llmClient = llmClient,
+            toolExecutor = FakeToolExecutor()
+        ).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("继续执行网页查询"),
+                executionEnv = FakeExecutionEnvironment("继续执行网页查询")
+            )
+        )
+
+        assertTrue(result is AgentResult.Error)
+        assertEquals(3, callback.retryingEvents.size)
+        assertEquals(
+            "HTTP 503: upstream temporarily unavailable",
+            callback.errors.single()
+        )
+        assertTrue(callback.lastErrorRetryable)
+        assertTrue(callback.finalChatMessages().isEmpty())
+    }
+
     private fun createOrchestrator(
         llmClient: FakeLlmClient,
         toolExecutor: FakeToolExecutor,
@@ -660,12 +960,14 @@ class AgentOrchestratorTest {
 
     private class FakeLlmClient(
         turns: List<ChatCompletionTurn>,
-        reasoningUpdates: List<List<String>> = emptyList()
+        reasoningUpdates: List<List<String>> = emptyList(),
+        failures: List<Throwable> = emptyList()
     ) : AgentLlmClient {
         private val queuedTurns = ArrayDeque(turns)
         private val queuedReasoningUpdates = ArrayDeque(
             reasoningUpdates.map { updates -> ArrayDeque(updates) }
         )
+        private val queuedFailures = ArrayDeque(failures)
         val requests = mutableListOf<ChatCompletionRequest>()
 
         override suspend fun streamTurn(
@@ -674,6 +976,9 @@ class AgentOrchestratorTest {
             onContentUpdate: (suspend (String) -> Unit)?
         ): ChatCompletionTurn {
             requests += request
+            if (queuedFailures.isNotEmpty()) {
+                throw queuedFailures.removeFirst()
+            }
             val reasoningQueue = if (queuedReasoningUpdates.isEmpty()) {
                 null
             } else {
@@ -738,9 +1043,11 @@ class AgentOrchestratorTest {
         val chatMessages = mutableListOf<Pair<String, Boolean>>()
         val promptTokenUpdates = mutableListOf<Int>()
         val errors = mutableListOf<String>()
+        val retryingEvents = mutableListOf<Triple<Int, Int, Long>>()
         var completedResult: AgentResult? = null
         var lastPrefillTokensPerSecond: Double? = null
         var lastDecodeTokensPerSecond: Double? = null
+        var lastErrorRetryable: Boolean = false
 
         override suspend fun onThinkingStart() = Unit
 
@@ -785,6 +1092,16 @@ class AgentOrchestratorTest {
             promptTokenUpdates += latestPromptTokens
         }
 
+        override suspend fun onRetrying(
+            retryCount: Int,
+            maxRetries: Int,
+            retryDelayMs: Long,
+            message: String,
+            retryReason: String?
+        ) {
+            retryingEvents += Triple(retryCount, maxRetries, retryDelayMs)
+        }
+
         override suspend fun onClarifyRequired(
             question: String,
             missingFields: List<String>?
@@ -796,6 +1113,11 @@ class AgentOrchestratorTest {
 
         override suspend fun onError(error: String) {
             errors += error
+        }
+
+        override suspend fun onError(error: String, retryable: Boolean) {
+            lastErrorRetryable = retryable
+            onError(error)
         }
 
         override suspend fun onPermissionRequired(missing: List<String>) = Unit

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
@@ -260,4 +260,49 @@ class HttpAgentLlmClientTest {
         protocolType = protocolType,
         requiresReasoningEcho = requiresReasoningEcho
     )
+    @Test
+    fun `qwen openai compatible route reclassifies leading content before closing think tag`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                    routeInfo(
+                        requestedModel = model,
+                        resolvedModel = "qwen3.6-plus",
+                        protocolType = protocolType ?: "openai_compatible",
+                        requiresReasoningEcho = false
+                    )
+                },
+                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"first reasoning</th"}}]}"""
+                    )
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"ink>final answer"}}]}"""
+                    )
+                    listener.onEvent(source, null, "message", "[DONE]")
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val turn = client.streamTurn(request = simpleRequest())
+
+            assertEquals("first reasoning", turn.reasoning)
+            assertEquals("final answer", turn.message.contentText())
+        } finally {
+            scope.cancel()
+        }
+    }
 }

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -16,6 +16,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
   static const double _kChatInputFallbackHeight = 80.0;
   static const double _kHdPadPaneCollapseWidthRatio = 0.12;
   static const double _kHdPadPaneCollapseMinWidthFactor = 0.72;
+  final Set<String> _pendingManualAgentRetryTaskIds = <String>{};
 
   ChatPageMode get _primaryChatMessagePageMode =>
       _activeMode == ChatPageMode.codex
@@ -845,6 +846,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     return ChatMessageList(
       messages: resolvedMessages,
       activeAgentTaskIds: activeAgentTaskIds,
+      onRetryAgentMessage: _retryFailedAgentTurn,
       expandedAgentRunTaskIds: _expandedAgentRunTaskIdsForMode(mode),
       onExpandedAgentRunTaskIdsChanged: (taskIds) {
         _updateExpandedAgentRunTaskIds(mode, taskIds);
@@ -2306,6 +2308,69 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     if (!mounted) return;
   }
 
+  Future<void> _retryFailedAgentTurn(ChatMessageModel message) async {
+    final taskId = _resolveRetryableAgentTaskId(message);
+    if (taskId == null) {
+      showToast(
+        LegacyTextLocalizer.isEnglish
+            ? 'This reply can no longer be retried'
+            : '这条回复当前无法继续重试',
+        type: ToastType.warning,
+      );
+      return;
+    }
+    if (_pendingManualAgentRetryTaskIds.contains(taskId) ||
+        message.content?['agentRetrying'] == true) {
+      return;
+    }
+    if (_isAiResponding) {
+      showToast(
+        LegacyTextLocalizer.isEnglish
+            ? 'Wait for the current response to finish first'
+            : '请先等待当前回复结束',
+        type: ToastType.warning,
+      );
+      return;
+    }
+
+    final messageIndex = _messages.indexWhere((item) => item.id == message.id);
+    final previousMessage = messageIndex == -1 ? null : _messages[messageIndex];
+    _pendingManualAgentRetryTaskIds.add(taskId);
+    if (previousMessage != null && mounted) {
+      setState(() {
+        _messages[messageIndex] = _buildPendingManualRetryMessage(
+          previousMessage,
+          taskId: taskId,
+        );
+      });
+    }
+
+    final success = await AssistsMessageService.retryAgentTask(taskId: taskId);
+    _pendingManualAgentRetryTaskIds.remove(taskId);
+    if (!mounted) {
+      return;
+    }
+    if (!success) {
+      if (previousMessage != null) {
+        final restoreIndex = _messages.indexWhere(
+          (item) => item.id == previousMessage.id,
+        );
+        if (restoreIndex != -1) {
+          setState(() {
+            _messages[restoreIndex] = previousMessage;
+          });
+        }
+      }
+      showToast(
+        LegacyTextLocalizer.isEnglish
+            ? 'Retry failed. Please try sending the message again.'
+            : '重试失败，请重新发送消息',
+        type: ToastType.error,
+      );
+      return;
+    }
+  }
+
   List<Map<String, dynamic>> _extractRetryAttachments(
     ChatMessageModel message,
   ) {
@@ -2315,6 +2380,42 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
         .whereType<Map>()
         .map((item) => item.map((k, v) => MapEntry(k.toString(), v)))
         .toList();
+  }
+
+  String? _resolveRetryableAgentTaskId(ChatMessageModel message) {
+    final contentTaskId = (message.content?['agentTaskId'] ?? '')
+        .toString()
+        .trim();
+    if (contentTaskId.isNotEmpty) {
+      return contentTaskId;
+    }
+    final streamTaskId = (message.streamMeta?['parentTaskId'] ?? '')
+        .toString()
+        .trim();
+    if (streamTaskId.isNotEmpty) {
+      return streamTaskId;
+    }
+    return null;
+  }
+
+  ChatMessageModel _buildPendingManualRetryMessage(
+    ChatMessageModel message, {
+    required String taskId,
+  }) {
+    final content = Map<String, dynamic>.from(message.content ?? const {});
+    content['agentTaskId'] = taskId;
+    content['agentRetrying'] = true;
+    content['agentRetryStatusText'] = LegacyTextLocalizer.isEnglish
+        ? 'Retrying connection...'
+        : '连接中断，正在重试…';
+    content['agentRetryCount'] = 0;
+    content['agentMaxRetries'] =
+        (content['agentMaxRetries'] as num?)?.toInt() ?? 3;
+    content['agentRetryDelayMs'] = 0;
+    content.remove('agentRetryReason');
+    content.remove('agentRetryable');
+    content.remove('agentErrorText');
+    return message.copyWith(content: content, isError: false);
   }
 
   String _formatTokenCount(int value) {

--- a/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
+++ b/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
@@ -150,6 +150,12 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
           completedThinkingCardId: thinkingCardToFinalize,
         );
         return;
+      case AgentStreamEventKind.retrying:
+        _applyAgentRetryingStreamEvent(
+          event,
+          completedThinkingCardId: thinkingCardToFinalize,
+        );
+        return;
       case AgentStreamEventKind.textSnapshot:
         _applyAgentTextStreamEvent(
           event,
@@ -247,20 +253,22 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
       _finalizeThinkingCardInMessages(event.taskId, completedThinkingCardId);
       final index = messages.indexWhere((msg) => msg.id == messageId);
       if (index == -1) {
+        final content = <String, dynamic>{
+          'text': text,
+          'id': messageId,
+          if (event.isFinal && event.prefillTokensPerSecond != null)
+            'prefillTokensPerSecond': event.prefillTokensPerSecond,
+          if (event.isFinal && event.decodeTokensPerSecond != null)
+            'decodeTokensPerSecond': event.decodeTokensPerSecond,
+        };
+        _clearAgentRetryPresentation(content);
         messages.insert(
           0,
           ChatMessageModel(
             id: messageId,
             type: 1,
             user: 2,
-            content: {
-              'text': text,
-              'id': messageId,
-              if (event.isFinal && event.prefillTokensPerSecond != null)
-                'prefillTokensPerSecond': event.prefillTokensPerSecond,
-              if (event.isFinal && event.decodeTokensPerSecond != null)
-                'decodeTokensPerSecond': event.decodeTokensPerSecond,
-            },
+            content: content,
             streamMeta: streamMeta,
             reasoningContent: reasoningContent,
           ),
@@ -275,6 +283,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         if (event.isFinal && event.decodeTokensPerSecond != null) {
           content['decodeTokensPerSecond'] = event.decodeTokensPerSecond;
         }
+        _clearAgentRetryPresentation(content);
         messages[index] = existing.copyWith(
           content: content,
           streamMeta: streamMeta,
@@ -291,6 +300,68 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
         isFinal: event.isFinal,
       ),
     );
+    _persistAgentConversationSafely();
+  }
+
+  void _applyAgentRetryingStreamEvent(
+    AgentStreamEvent event, {
+    String? completedThinkingCardId,
+  }) {
+    final entryId = (event.entryId ?? '').trim();
+    final retryText = _buildAgentRetryingText(event);
+    final streamMeta = ensureAgentStreamMessageMeta(
+      _streamMetaFromEvent(event),
+      entryId: entryId.isEmpty ? null : entryId,
+      isFinal: false,
+    );
+
+    setState(() {
+      final isThinkingCardTarget =
+          entryId.isNotEmpty &&
+          messages.any((msg) => msg.id == entryId && msg.type == 2);
+      if (!isThinkingCardTarget) {
+        _finalizeThinkingCardInMessages(event.taskId, completedThinkingCardId);
+      }
+      if (isThinkingCardTarget) {
+        updateThinkingCardForAgent(
+          event.taskId,
+          cardId: entryId,
+          thinkingContent: retryText,
+          isLoading: true,
+          stage: ThinkingStage.thinking.value,
+          streamMeta: streamMeta,
+          lockCompleted: false,
+        );
+      } else {
+        final messageId = entryId.isNotEmpty ? entryId : _nextAgentTextMessageId(event.taskId);
+        final index = messages.indexWhere((msg) => msg.id == messageId);
+        if (index == -1) {
+          final content = <String, dynamic>{'text': '', 'id': messageId};
+          _applyAgentRetryPresentation(content, event, retryText);
+          messages.insert(
+            0,
+            ChatMessageModel(
+              id: messageId,
+              type: 1,
+              user: 2,
+              content: content,
+              streamMeta: streamMeta,
+            ),
+          );
+        } else {
+          final existing = messages[index];
+          final content = Map<String, dynamic>.from(existing.content ?? {});
+          content['id'] = messageId;
+          _applyAgentRetryPresentation(content, event, retryText);
+          messages[index] = existing.copyWith(
+            content: content,
+            streamMeta: streamMeta ?? existing.streamMeta,
+            isError: false,
+          );
+        }
+      }
+      isAiResponding = true;
+    });
     _persistAgentConversationSafely();
   }
 
@@ -400,14 +471,26 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
   }) {
     final entryId = (event.entryId ?? '').trim();
     final shouldMarkError = event.raw['persistAsError'] == true;
+    final errorText = (event.raw['errorText'] ?? event.errorMessage).toString().trim();
     setState(() {
       currentThinkingStage = ThinkingStage.complete.value;
       isDeepThinking = false;
       _finalizeThinkingCardInMessages(event.taskId, completedThinkingCardId);
-      if (shouldMarkError && entryId.isNotEmpty) {
+      if (entryId.isNotEmpty) {
         final index = messages.indexWhere((msg) => msg.id == entryId);
         if (index != -1) {
-          messages[index] = messages[index].copyWith(isError: true);
+          final existing = messages[index];
+          final content = Map<String, dynamic>.from(existing.content ?? {});
+          _applyAgentErrorPresentation(content, event, errorText);
+          messages[index] = existing.copyWith(
+            content: content,
+            isError: shouldMarkError,
+            streamMeta: ensureAgentStreamMessageMeta(
+              _streamMetaFromEvent(event),
+              entryId: entryId,
+              isFinal: true,
+            ),
+          );
         }
       }
       isAiResponding = false;
@@ -512,6 +595,60 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     return buildAgentStreamMetaFromEvent(event);
   }
 
+  String _buildAgentRetryingText(AgentStreamEvent event) {
+    if (event.text.trim().isNotEmpty) {
+      return event.text.trim();
+    }
+    final retryCount = event.retryCount <= 0 ? 1 : event.retryCount;
+    final maxRetries = event.maxRetries <= 0 ? 3 : event.maxRetries;
+    return LegacyTextLocalizer.isEnglish
+        ? 'Connection interrupted. Retrying $retryCount/$maxRetries...'
+        : '连接中断，正在重试 $retryCount/$maxRetries…';
+  }
+
+  void _applyAgentRetryPresentation(
+    Map<String, dynamic> content,
+    AgentStreamEvent event,
+    String retryText,
+  ) {
+    content['agentTaskId'] = event.taskId;
+    content['agentRetrying'] = true;
+    content['agentRetryStatusText'] = retryText;
+    content['agentRetryCount'] = event.retryCount;
+    content['agentMaxRetries'] = event.maxRetries;
+    content['agentRetryDelayMs'] = event.retryDelayMs;
+    content['agentRetryReason'] = event.retryReason;
+    content.remove('agentErrorText');
+    content.remove('agentRetryable');
+  }
+
+  void _applyAgentErrorPresentation(
+    Map<String, dynamic> content,
+    AgentStreamEvent event,
+    String errorText,
+  ) {
+    content['agentTaskId'] = event.taskId;
+    content['agentRetrying'] = false;
+    content['agentRetryStatusText'] = '';
+    content['agentRetryCount'] = event.retryCount;
+    content['agentMaxRetries'] = event.maxRetries;
+    content['agentRetryDelayMs'] = 0;
+    content['agentRetryReason'] = event.retryReason;
+    content['agentRetryable'] = event.retryable;
+    content['agentErrorText'] = errorText;
+  }
+
+  void _clearAgentRetryPresentation(Map<String, dynamic> content) {
+    content.remove('agentRetrying');
+    content.remove('agentRetryStatusText');
+    content.remove('agentRetryCount');
+    content.remove('agentMaxRetries');
+    content.remove('agentRetryDelayMs');
+    content.remove('agentRetryReason');
+    content.remove('agentRetryable');
+    content.remove('agentErrorText');
+  }
+
   void handleAgentError(String error) {
     final taskId = currentDispatchTaskId ?? _lastAgentTaskId;
     if (taskId == null) return;
@@ -612,6 +749,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
             ? reduceResult.previousThinkingEntryId
             : null;
       case AgentStreamEventKind.textSnapshot:
+      case AgentStreamEventKind.retrying:
       case AgentStreamEventKind.toolStarted:
       case AgentStreamEventKind.toolProgress:
       case AgentStreamEventKind.toolCompleted:

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -1179,6 +1179,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       if (markdownRenderedLength != null) {
         content['markdownRenderedLength'] = markdownRenderedLength;
       }
+      _clearAgentRetryPresentation(content);
       runtime.messages.insert(
         0,
         ChatMessageModel(
@@ -1210,6 +1211,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     if (isFinal && decodeTokensPerSecond != null) {
       content['decodeTokensPerSecond'] = decodeTokensPerSecond;
     }
+    _clearAgentRetryPresentation(content);
     runtime.messages[index] = existing.copyWith(
       content: content,
       isError: isError,
@@ -1591,6 +1593,14 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
           completedThinkingCardId: thinkingCardToFinalize,
         );
         return;
+      case AgentStreamEventKind.retrying:
+        _applyAgentRetryingStreamEvent(
+          runtime,
+          binding,
+          event,
+          completedThinkingCardId: thinkingCardToFinalize,
+        );
+        return;
       case AgentStreamEventKind.textSnapshot:
         _applyAgentTextStreamEvent(
           runtime,
@@ -1865,6 +1875,76 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     );
   }
 
+  void _applyAgentRetryingStreamEvent(
+    ChatConversationRuntimeState runtime,
+    _TaskBinding binding,
+    AgentStreamEvent event, {
+    String? completedThinkingCardId,
+  }) {
+    final entryId = (event.entryId ?? '').trim();
+    final retryText = _buildAgentRetryingText(event);
+    final streamMeta = ensureAgentStreamMessageMeta(
+      _streamMetaFromEvent(event),
+      entryId: entryId.isEmpty ? null : entryId,
+      isFinal: false,
+    );
+    final isThinkingCardTarget =
+        entryId.isNotEmpty &&
+        runtime.messages.any((message) => message.id == entryId && message.type == 2);
+    if (!isThinkingCardTarget) {
+      _finalizeThinkingCard(
+        runtime,
+        event.taskId,
+        cardId: completedThinkingCardId,
+      );
+    }
+    if (isThinkingCardTarget) {
+      _updateThinkingCard(
+        runtime,
+        event.taskId,
+        cardId: entryId,
+        thinkingContent: retryText,
+        isLoading: true,
+        stage: 1,
+        streamMeta: streamMeta,
+        lockCompleted: false,
+      );
+    } else {
+      final messageId = entryId.isNotEmpty ? entryId : _nextAgentTextMessageId(runtime, event.taskId);
+      final index = runtime.messages.indexWhere((message) => message.id == messageId);
+      if (index == -1) {
+        final content = <String, dynamic>{'text': '', 'id': messageId};
+        _applyAgentRetryPresentation(content, event, retryText);
+        runtime.messages.insert(
+          0,
+          ChatMessageModel(
+            id: messageId,
+            type: 1,
+            user: 2,
+            content: content,
+            streamMeta: streamMeta,
+          ),
+        );
+      } else {
+        final existing = runtime.messages[index];
+        final content = Map<String, dynamic>.from(existing.content ?? const {});
+        content['id'] = messageId;
+        _applyAgentRetryPresentation(content, event, retryText);
+        runtime.messages[index] = existing.copyWith(
+          content: content,
+          streamMeta: streamMeta ?? existing.streamMeta,
+          isError: false,
+        );
+      }
+    }
+    runtime.isAiResponding = true;
+    notifyListeners();
+    schedulePersistRuntimeConversation(
+      conversationId: binding.conversationId,
+      mode: binding.mode,
+    );
+  }
+
   void _applyAgentClarifyStreamEvent(
     ChatConversationRuntimeState runtime,
     _TaskBinding binding,
@@ -1954,13 +2034,23 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
   }) {
     final entryId = (event.entryId ?? '').trim();
     final shouldMarkError = event.raw['persistAsError'] == true;
-    if (entryId.isNotEmpty && shouldMarkError) {
+    final errorText = (event.raw['errorText'] ?? event.errorMessage).toString().trim();
+    if (entryId.isNotEmpty) {
       final index = runtime.messages.indexWhere(
         (message) => message.id == entryId,
       );
       if (index != -1) {
+        final existing = runtime.messages[index];
+        final content = Map<String, dynamic>.from(existing.content ?? const {});
+        _applyAgentErrorPresentation(content, event, errorText);
         runtime.messages[index] = runtime.messages[index].copyWith(
-          isError: true,
+          content: content,
+          isError: shouldMarkError,
+          streamMeta: ensureAgentStreamMessageMeta(
+            _streamMetaFromEvent(event),
+            entryId: entryId,
+            isFinal: true,
+          ),
         );
       }
     }
@@ -2074,6 +2164,60 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
 
   Map<String, dynamic> _streamMetaFromEvent(AgentStreamEvent event) {
     return buildAgentStreamMetaFromEvent(event);
+  }
+
+  String _buildAgentRetryingText(AgentStreamEvent event) {
+    if (event.text.trim().isNotEmpty) {
+      return event.text.trim();
+    }
+    final retryCount = event.retryCount <= 0 ? 1 : event.retryCount;
+    final maxRetries = event.maxRetries <= 0 ? 3 : event.maxRetries;
+    return LegacyTextLocalizer.isEnglish
+        ? 'Connection interrupted. Retrying $retryCount/$maxRetries...'
+        : '连接中断，正在重试 $retryCount/$maxRetries…';
+  }
+
+  void _applyAgentRetryPresentation(
+    Map<String, dynamic> content,
+    AgentStreamEvent event,
+    String retryText,
+  ) {
+    content['agentTaskId'] = event.taskId;
+    content['agentRetrying'] = true;
+    content['agentRetryStatusText'] = retryText;
+    content['agentRetryCount'] = event.retryCount;
+    content['agentMaxRetries'] = event.maxRetries;
+    content['agentRetryDelayMs'] = event.retryDelayMs;
+    content['agentRetryReason'] = event.retryReason;
+    content.remove('agentErrorText');
+    content.remove('agentRetryable');
+  }
+
+  void _applyAgentErrorPresentation(
+    Map<String, dynamic> content,
+    AgentStreamEvent event,
+    String errorText,
+  ) {
+    content['agentTaskId'] = event.taskId;
+    content['agentRetrying'] = false;
+    content['agentRetryStatusText'] = '';
+    content['agentRetryCount'] = event.retryCount;
+    content['agentMaxRetries'] = event.maxRetries;
+    content['agentRetryDelayMs'] = 0;
+    content['agentRetryReason'] = event.retryReason;
+    content['agentRetryable'] = event.retryable;
+    content['agentErrorText'] = errorText;
+  }
+
+  void _clearAgentRetryPresentation(Map<String, dynamic> content) {
+    content.remove('agentRetrying');
+    content.remove('agentRetryStatusText');
+    content.remove('agentRetryCount');
+    content.remove('agentMaxRetries');
+    content.remove('agentRetryDelayMs');
+    content.remove('agentRetryReason');
+    content.remove('agentRetryable');
+    content.remove('agentErrorText');
   }
 
   void _upsertPureChatThinking(
@@ -2906,6 +3050,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
             ? reduceResult.previousThinkingEntryId
             : null;
       case AgentStreamEventKind.textSnapshot:
+      case AgentStreamEventKind.retrying:
       case AgentStreamEventKind.toolStarted:
       case AgentStreamEventKind.toolProgress:
       case AgentStreamEventKind.toolCompleted:

--- a/ui/lib/features/home/pages/chat/widgets/agent_run_group_message.dart
+++ b/ui/lib/features/home/pages/chat/widgets/agent_run_group_message.dart
@@ -16,6 +16,7 @@ class AgentRunGroupMessage extends StatefulWidget {
     required this.onToggleExpanded,
     required this.onBeforeTaskExecute,
     this.onCancelTask,
+    this.onRetryAgentMessage,
     this.parentScrollController,
     this.onParentScrollHandoff,
     this.onRequestAuthorize,
@@ -29,6 +30,7 @@ class AgentRunGroupMessage extends StatefulWidget {
   final VoidCallback onToggleExpanded;
   final OnBeforeTaskExecute onBeforeTaskExecute;
   final void Function(String taskId)? onCancelTask;
+  final ValueChanged<ChatMessageModel>? onRetryAgentMessage;
   final ScrollController? parentScrollController;
   final VoidCallback? onParentScrollHandoff;
   final OnRequestAuthorize? onRequestAuthorize;
@@ -147,6 +149,7 @@ class _AgentRunGroupMessageState extends State<AgentRunGroupMessage>
             message: message,
             onBeforeTaskExecute: widget.onBeforeTaskExecute,
             onCancelTask: widget.onCancelTask,
+            onRetryAgentMessage: () => widget.onRetryAgentMessage?.call(message),
             enableThinkingCollapse: false,
             parentScrollController: widget.parentScrollController,
             onParentScrollHandoff: widget.onParentScrollHandoff,
@@ -190,6 +193,8 @@ class _AgentRunGroupMessageState extends State<AgentRunGroupMessage>
                 message: message,
                 onBeforeTaskExecute: widget.onBeforeTaskExecute,
                 onCancelTask: widget.onCancelTask,
+                onRetryAgentMessage:
+                    () => widget.onRetryAgentMessage?.call(message),
                 enableThinkingCollapse: true,
                 thinkingAutoCollapseOnComplete: true,
                 showThinkingAvatarOverride: hideAvatar ? false : null,

--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -1390,6 +1390,7 @@ class ChatMessageList extends StatefulWidget {
   final ScrollController scrollController;
   final Future<void> Function() onBeforeTaskExecute;
   final void Function(String taskId)? onCancelTask;
+  final ValueChanged<ChatMessageModel>? onRetryAgentMessage;
   final void Function(List<String> requiredPermissionIds)? onRequestAuthorize;
   final double bottomOverlayInset;
   final void Function(ChatMessageModel message, LongPressStartDetails details)?
@@ -1419,6 +1420,7 @@ class ChatMessageList extends StatefulWidget {
     required this.scrollController,
     required this.onBeforeTaskExecute,
     this.onCancelTask,
+    this.onRetryAgentMessage,
     this.onRequestAuthorize,
     this.bottomOverlayInset = 0,
     this.onUserMessageLongPressStart,
@@ -1952,6 +1954,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
         padding: padding,
         onBeforeTaskExecute: widget.onBeforeTaskExecute,
         onCancelTask: widget.onCancelTask,
+        onRetryAgentMessage: widget.onRetryAgentMessage,
         parentScrollController: widget.scrollController,
         onParentScrollHandoff: _handleParentScrollHandoff,
         editingUserMessageRevealKey: _editingRevealKeyForMessage(
@@ -2128,6 +2131,7 @@ class _ChatTimelineListRow extends StatelessWidget {
     this.onUserMessageEditCancelled,
     this.onUserMessageEditSaved,
     this.onCancelTask,
+    this.onRetryAgentMessage,
     this.parentScrollController,
     this.onParentScrollHandoff,
     this.editingUserMessageRevealKey,
@@ -2149,6 +2153,7 @@ class _ChatTimelineListRow extends StatelessWidget {
   final VoidCallback? onUserMessageEditCancelled;
   final ValueChanged<ChatMessageModel>? onUserMessageEditSaved;
   final void Function(String taskId)? onCancelTask;
+  final ValueChanged<ChatMessageModel>? onRetryAgentMessage;
   final ScrollController? parentScrollController;
   final VoidCallback? onParentScrollHandoff;
   final GlobalKey? editingUserMessageRevealKey;
@@ -2175,6 +2180,7 @@ class _ChatTimelineListRow extends StatelessWidget {
         onToggleExpanded: () => onToggleAgentRunGroup(group.taskId),
         onBeforeTaskExecute: onBeforeTaskExecute,
         onCancelTask: onCancelTask,
+        onRetryAgentMessage: onRetryAgentMessage,
         parentScrollController: parentScrollController,
         onParentScrollHandoff: onParentScrollHandoff,
         onRequestAuthorize: onRequestAuthorize,
@@ -2199,6 +2205,7 @@ class _ChatTimelineListRow extends StatelessWidget {
       ),
       onBeforeTaskExecute: onBeforeTaskExecute,
       onCancelTask: onCancelTask,
+      onRetryAgentMessage: () => onRetryAgentMessage?.call(currentMessage),
       enableThinkingCollapse: true,
       parentScrollController: parentScrollController,
       onParentScrollHandoff: onParentScrollHandoff,

--- a/ui/lib/features/home/pages/command_overlay/widgets/message_bubble.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/message_bubble.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:ui/features/home/pages/omnibot_workspace/omnibot_artifact_preview_page.dart';
 import 'package:ui/l10n/l10n.dart';
+import 'package:ui/l10n/legacy_text_localizer.dart';
 import 'package:ui/models/chat_link_preview.dart';
 import 'package:ui/services/omnibot_resource_service.dart';
 import 'package:ui/widgets/image_preview_overlay.dart';
@@ -59,6 +60,7 @@ class MessageBubble extends StatelessWidget {
   final OnRequestAuthorize? onRequestAuthorize;
   final void Function(ChatMessageModel message, LongPressStartDetails details)?
   onUserMessageLongPressStart;
+  final VoidCallback? onRetryAgentMessage;
   final bool isUserMessageEditing;
   final TextEditingController? userMessageEditController;
   final VoidCallback? onCancelUserEdit;
@@ -79,6 +81,7 @@ class MessageBubble extends StatelessWidget {
     this.onParentScrollHandoff,
     this.onRequestAuthorize,
     this.onUserMessageLongPressStart,
+    this.onRetryAgentMessage,
     this.isUserMessageEditing = false,
     this.userMessageEditController,
     this.onCancelUserEdit,
@@ -1126,11 +1129,14 @@ class MessageBubble extends StatelessWidget {
       text,
       trailing: showVoiceButton ? _buildVoiceAction(context, text) : null,
     );
+    final retryingStatus = _buildAgentRetryingStatus(context);
+    final errorFooter = _buildAgentErrorFooter(context, text);
+    final showPrimaryText = text.isNotEmpty || message.isLoading || message.isSummarizing;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        aiText,
+        if (showPrimaryText) aiText,
         if (speed != null) ...[
           const SizedBox(height: 4),
           Text(
@@ -1144,6 +1150,100 @@ class MessageBubble extends StatelessWidget {
             ),
           ),
         ],
+        if (retryingStatus != null) ...[
+          if (showPrimaryText || speed != null) const SizedBox(height: 8),
+          retryingStatus,
+        ],
+        if (errorFooter != null) ...[
+          if (showPrimaryText || speed != null || retryingStatus != null)
+            const SizedBox(height: 8),
+          errorFooter,
+        ],
+      ],
+    );
+  }
+
+  Widget? _buildAgentRetryingStatus(BuildContext context) {
+    if (message.content?['agentRetrying'] != true) {
+      return null;
+    }
+    final statusText =
+        (message.content?['agentRetryStatusText'] ?? '').toString().trim();
+    if (statusText.isEmpty) {
+      return null;
+    }
+    final secondaryColor = _resolvedAiSecondaryTextColor(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(
+            strokeWidth: 1.8,
+            valueColor: AlwaysStoppedAnimation<Color>(secondaryColor),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Flexible(
+          child: Text(
+            statusText,
+            style: TextStyle(
+              fontSize: 12 * _chatTextScale,
+              color: secondaryColor,
+              height: 1.4,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget? _buildAgentErrorFooter(BuildContext context, String text) {
+    final errorText =
+        (message.content?['agentErrorText'] ?? '').toString().trim();
+    final retryable = message.content?['agentRetryable'] == true;
+    final showRetryButton = retryable && onRetryAgentMessage != null;
+    final showErrorText = errorText.isNotEmpty && errorText != text.trim();
+    if (!showErrorText && !showRetryButton) {
+      return null;
+    }
+    final warningColor = Theme.of(context).colorScheme.error;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (showErrorText)
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            decoration: BoxDecoration(
+              color: warningColor.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Text(
+              errorText,
+              style: TextStyle(
+                fontSize: 12 * _chatTextScale,
+                color: warningColor,
+                height: 1.4,
+              ),
+            ),
+          ),
+        if (showRetryButton)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: onRetryAgentMessage,
+              icon: const Icon(Icons.refresh_rounded, size: 16),
+              label: Text(
+                LegacyTextLocalizer.isEnglish ? 'Retry' : '重试本轮',
+              ),
+              style: TextButton.styleFrom(
+                padding: EdgeInsets.zero,
+                visualDensity: VisualDensity.compact,
+                foregroundColor: warningColor,
+              ),
+            ),
+          ),
       ],
     );
   }

--- a/ui/lib/models/agent_stream_event.dart
+++ b/ui/lib/models/agent_stream_event.dart
@@ -3,6 +3,7 @@ import 'package:ui/features/home/pages/chat/chat_page_models.dart';
 enum AgentStreamEventKind {
   thinkingStarted('thinking_started'),
   thinkingSnapshot('thinking_snapshot'),
+  retrying('retrying'),
   textSnapshot('text_snapshot'),
   toolStarted('tool_started'),
   toolProgress('tool_progress'),
@@ -32,6 +33,7 @@ enum AgentStreamPhase {
   thinking,
   tool,
   output,
+  retrying,
   completed,
   error,
   clarify,
@@ -58,6 +60,12 @@ class AgentStreamEvent {
     this.latestPromptTokens,
     this.promptTokenThreshold,
     this.errorMessage = '',
+    this.willRetry = false,
+    this.retryable = false,
+    this.retryCount = 0,
+    this.maxRetries = 0,
+    this.retryDelayMs = 0,
+    this.retryReason = '',
     this.question = '',
     this.missingFields = const <String>[],
     this.missingPermissions = const <String>[],
@@ -83,6 +91,12 @@ class AgentStreamEvent {
   final int? latestPromptTokens;
   final int? promptTokenThreshold;
   final String errorMessage;
+  final bool willRetry;
+  final bool retryable;
+  final int retryCount;
+  final int maxRetries;
+  final int retryDelayMs;
+  final String retryReason;
   final String question;
   final List<String> missingFields;
   final List<String> missingPermissions;
@@ -138,6 +152,12 @@ class AgentStreamEvent {
       latestPromptTokens: _asInt(raw['latestPromptTokens']),
       promptTokenThreshold: _asInt(raw['promptTokenThreshold']),
       errorMessage: (raw['error'] ?? '').toString(),
+      willRetry: raw['willRetry'] == true,
+      retryable: raw['retryable'] == true,
+      retryCount: _asInt(raw['retryCount']) ?? 0,
+      maxRetries: _asInt(raw['maxRetries']) ?? 0,
+      retryDelayMs: _asInt(raw['retryDelayMs']) ?? 0,
+      retryReason: (raw['retryReason'] ?? '').toString(),
       question: (raw['question'] ?? '').toString(),
       missingFields:
           (raw['missingFields'] as List<dynamic>?)

--- a/ui/lib/services/agent_stream_reducer.dart
+++ b/ui/lib/services/agent_stream_reducer.dart
@@ -134,6 +134,13 @@ class AgentStreamReducer {
           thinkingRounds[activeThinkingEntryId] = roundIndex;
         }
         break;
+      case AgentStreamEventKind.retrying:
+        phase = AgentStreamPhase.retrying;
+        thinkingStage = event.stage <= 0 ? 1 : event.stage;
+        isDeepThinking = false;
+        clearActiveThinkingEntryId = true;
+        activeThinkingEntryId = null;
+        break;
       case AgentStreamEventKind.textSnapshot:
         phase = AgentStreamPhase.output;
         thinkingStage = 4;

--- a/ui/lib/services/assists_core_service.dart
+++ b/ui/lib/services/assists_core_service.dart
@@ -676,6 +676,19 @@ class AssistsMessageService {
     }
   }
 
+  static Future<bool> retryAgentTask({required String taskId}) async {
+    try {
+      final result = await assistCore.invokeMethod(
+        'retryAgentTask',
+        <String, String>{'taskId': taskId},
+      );
+      return result == "SUCCESS";
+    } on PlatformException catch (e) {
+      print('retryAgentTask failed: ${e.message}');
+      return false;
+    }
+  }
+
   /// 取消陪伴任务的回到桌面操作
   /// 当用户在开启陪伴后离开主页时调用
   static Future<bool> cancelCompanionGoHome() async {

--- a/ui/lib/webchat/web_chat_app.dart
+++ b/ui/lib/webchat/web_chat_app.dart
@@ -843,6 +843,7 @@ class _WebChatHomeState extends State<_WebChatHome> {
         break;
       case AgentStreamEventKind.thinkingStarted:
       case AgentStreamEventKind.thinkingSnapshot:
+      case AgentStreamEventKind.retrying:
       case AgentStreamEventKind.textSnapshot:
       case AgentStreamEventKind.toolStarted:
       case AgentStreamEventKind.toolProgress:


### PR DESCRIPTION
…codex)。另外重新补充上前一次CI失败导致merge失败的qwen模型<think>泄露问题代码。

## 变更摘要

本次改动把 issue271 的两条问题链路一起补齐：
一是断流现象，这次稳定复现出qwen-plus的断流现象。修改方案是编排层不再把准备继续搜索/筛选的纯文本 stop 误收尾
另一条是 Agent API 请求失败后补上“本轮自动重试 + reconnecting/retrying 状态反馈 + 手动重试本轮”兜底链路。
对用户侧的直接变化是：执行型任务中如果模型还没真正发出 tool_call，编排层会先自动纠偏；如果网络或上游请求短暂失败，系统会先自动重试本轮，重试耗尽后再把可重试入口明确暴露给前端，而不是直接退化成一段静态报错文本。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能

## 关联 Issue

Refs #271

## 主要改动

1. 在 `AgentOrchestrator` 硬化纯文本 `stop` 的收尾判定：当回复仍属于“我来搜索/我来筛选/让我查看”这类执行中间态时，不再直接结束当前回合，而是触发一次 recovery，要求模型返回标准 `tool_call` 或完整最终答案。
2. 在 Native 编排层、桥接层和 Flutter/WebChat UI 之间补齐“按轮次自动重试”闭环：同一轮 API 请求失败后最多自动重试 3 次，重试期间持续透出 `reconnecting/retrying` 状态；若仍失败，则保留错误文本并提供“重试本轮”按钮，而不是要求用户整段重发。
3. 补齐与上述两条链路对应的验证与文档：单元测试覆盖 transient retry、重试耗尽后的可重试错误透出，以及执行中纯文本 `stop` 的 recovery 分支；真实 trace 也验证了 `action_intent_without_tool_call -> auto_recover -> tool_call -> 最终正常 stop 收尾` 的完整路径。

## 测试说明

修复前的断流现象：
<img width="864" height="1920" alt="断流qwen-plus" src="https://github.com/user-attachments/assets/80df2889-b9be-4685-9e67-4201d15afff8" />

抓包日志：
<img width="2749" height="299" alt="0)YX{}GI YV6 L7B%62T4VA" src="https://github.com/user-attachments/assets/064a463f-3ae9-457e-b28b-bf674c26eddd" />

即原始qwen-plus模型会把回复误判成了最终答案，导致用户侧出现“”断流“”现象。

修复后：
<img width="864" height="1920" alt="710ef580aa475a21e66f432b9f5f206b" src="https://github.com/user-attachments/assets/316a8426-cd7d-42e6-81c2-cf786e604a1c" />

抓包日志：
<img width="2605" height="606" alt="}426IQIVU@)7$BIZ2~JJW1S" src="https://github.com/user-attachments/assets/1d328cce-a24a-4c0b-930b-d8679153528e" />

修复后会将其识别为未完成态，使其继续完成。



## UI 变更（如有）

有
重试机制下，利用断网查看重连效果：
![Uploading 5de7c21c7a6236c35c5acdd299aa5477.jpg…]()
<img width="864" height="1920" alt="5de7c21c7a6236c35c5acdd299aa5477" src="https://github.com/user-attachments/assets/9944d556-14c3-406a-beea-c62d99239249" />

自动重试期间显示 reconnecting/retrying 状态文案。
自动重试耗尽后保留错误文本。

## 风险与回滚

无

## 备注
上次qwen的<think>泄露问题因为没有正常CI导致merge到主分支也失败了，本次重新补充对应文件。
