### PR TITLE
fix: 修复 NVIDIA Kimi 流式输出思维链泄露与错误回退问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -3,6 +3,7 @@ package cn.com.omnimind.bot.agent
 import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import cn.com.omnimind.baselib.llm.ChatCompletionThinking
 import cn.com.omnimind.baselib.llm.ChatCompletionTurn
 import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.llm.LocalModelProviderBridge
@@ -24,6 +25,7 @@ import kotlinx.serialization.json.contentOrNull
 import okhttp3.Response
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
+import java.net.URI
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface AgentLlmClient {
@@ -43,6 +45,10 @@ class AgentStreamRequestException(
         statusCode?.let { "($it)" }.orEmpty()
     }: $reason"
 )
+
+class AgentStreamReasoningLeakException(
+    reason: String
+) : RuntimeException(reason)
 
 class HttpAgentLlmClient(
     private val scope: CoroutineScope,
@@ -111,13 +117,19 @@ class HttpAgentLlmClient(
         onContentUpdate: (suspend (String) -> Unit)?
     ): ChatCompletionTurn {
         val modelCandidates = buildModelCandidates(request.model)
-        val variants = buildRequestVariants(
-            sanitizeRequestForTarget(request)
-        )
+        val sanitizedRequest = sanitizeRequestForTarget(request)
         var lastFailure: AgentStreamRequestException? = null
 
         for (modelIndex in modelCandidates.indices) {
             val candidateModel = modelCandidates[modelIndex]
+            val routeInfo = resolveRouteInfoOp(
+                candidateModel,
+                modelOverride?.apiBase,
+                modelOverride?.apiKey,
+                modelOverride?.modelId,
+                modelOverride?.protocolType
+            )
+            val variants = buildRequestVariants(sanitizedRequest, routeInfo)
             for (variantIndex in variants.indices) {
                 val variant = variants[variantIndex]
                 try {
@@ -156,6 +168,15 @@ class HttpAgentLlmClient(
                         break
                     }
                     throw error
+                } catch (error: AgentStreamReasoningLeakException) {
+                    if (shouldRetryNextVariantAfterReasoningLeak(routeInfo, variants, variantIndex)) {
+                        OmniLog.w(
+                            tag,
+                            "stream variant=${variant.name} leaked inline reasoning on guarded route; retrying next conservative variant"
+                        )
+                        continue
+                    }
+                    throw error
                 }
             }
         }
@@ -189,6 +210,9 @@ class HttpAgentLlmClient(
     private fun shouldBufferLeadingInlineThinkTag(
         routeInfo: HttpController.ChatCompletionRouteInfo
     ): Boolean {
+        if (shouldGuardNvidiaKimiReasoningLeak(routeInfo)) {
+            return true
+        }
         val protocolType = routeInfo.protocolType.trim().ifEmpty { "openai_compatible" }
         if (!protocolType.equals("openai_compatible", ignoreCase = true)) {
             return false
@@ -227,7 +251,8 @@ class HttpAgentLlmClient(
                 modelOverride?.apiBase
             ),
             includeReasoningInAssistantMessage = routeInfo.requiresReasoningEcho,
-            bufferLeadingTextUntilInlineThinkTag = shouldBufferLeadingInlineThinkTag(routeInfo)
+            bufferLeadingTextUntilInlineThinkTag = shouldBufferLeadingInlineThinkTag(routeInfo),
+            guardLeadingReasoningLeak = shouldGuardNvidiaKimiReasoningLeak(routeInfo)
         )
         var lastReasoning = ""
         var lastReasoningEmitLength = 0
@@ -335,7 +360,7 @@ class HttpAgentLlmClient(
                 }
             }
             if (snapshot != null) {
-                dispatchReasoningSnapshot(snapshot!!)
+                dispatchReasoningSnapshot(snapshot)
             }
         }
 
@@ -392,9 +417,13 @@ class HttpAgentLlmClient(
                     }
                 }.onFailure { error ->
                     if (completed.compareAndSet(false, true)) {
-                        streamDone.completeExceptionally(
+                        val failure = if (error is AgentStreamReasoningLeakException) {
+                            error
+                        } else {
                             IllegalStateException("invalid chat completion stream chunk: ${error.message}", error)
-                        )
+                        }
+                        streamDone.completeExceptionally(failure)
+                        eventSource.cancel()
                     }
                 }
             }
@@ -474,7 +503,10 @@ class HttpAgentLlmClient(
         )
     }
 
-    private fun buildRequestVariants(request: ChatCompletionRequest): List<StreamRequestVariant> {
+    private fun buildRequestVariants(
+        request: ChatCompletionRequest,
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): List<StreamRequestVariant> {
         val variants = mutableListOf<StreamRequestVariant>()
         val seenPayloads = LinkedHashSet<String>()
         fun add(name: String, candidate: ChatCompletionRequest) {
@@ -482,6 +514,19 @@ class HttpAgentLlmClient(
             if (seenPayloads.add(encoded)) {
                 variants.add(StreamRequestVariant(name = name, requestJson = encoded))
             }
+        }
+
+        if (shouldGuardNvidiaKimiReasoningLeak(routeInfo)) {
+            val noThinkingRequest = request.copy(
+                enableThinking = false,
+                reasoningEffort = "none",
+                thinking = ChatCompletionThinking(type = "disabled")
+            )
+            add("nvidia_no_thinking", noThinkingRequest)
+            add(
+                "nvidia_no_thinking_minimal",
+                noThinkingRequest.copy(streamOptions = null)
+            )
         }
 
         add("default", request)
@@ -513,6 +558,49 @@ class HttpAgentLlmClient(
             )
         }
         return variants
+    }
+
+    private fun shouldRetryNextVariantAfterReasoningLeak(
+        routeInfo: HttpController.ChatCompletionRouteInfo,
+        variants: List<StreamRequestVariant>,
+        variantIndex: Int
+    ): Boolean {
+        if (!shouldGuardNvidiaKimiReasoningLeak(routeInfo)) {
+            return false
+        }
+        return variants
+            .drop(variantIndex + 1)
+            .any { it.name.startsWith("nvidia_no_thinking") }
+    }
+
+    private fun shouldGuardNvidiaKimiReasoningLeak(
+        routeInfo: HttpController.ChatCompletionRouteInfo
+    ): Boolean {
+        val protocolType = routeInfo.protocolType.trim().ifEmpty { "openai_compatible" }
+        if (!protocolType.equals("openai_compatible", ignoreCase = true)) {
+            return false
+        }
+        if (!isNvidiaIntegrateApiBase(routeInfo.apiBase)) {
+            return false
+        }
+        return sequenceOf(routeInfo.resolvedModel, routeInfo.requestedModel)
+            .map(::normalizeReasoningLeakGuardModel)
+            .any { it == "kimi-k2.6" }
+    }
+
+    private fun isNvidiaIntegrateApiBase(apiBase: String?): Boolean {
+        val normalized = apiBase?.trim()?.takeIf { it.isNotEmpty() } ?: return false
+        val host = runCatching { URI(normalized).host?.lowercase() }
+            .getOrNull()
+            ?.removePrefix("www.")
+            ?: return false
+        return host == "integrate.api.nvidia.com"
+    }
+
+    private fun normalizeReasoningLeakGuardModel(model: String): String {
+        return model.trim().lowercase()
+            .substringAfterLast('/')
+            .substringAfterLast(':')
     }
 
     private fun sanitizeRequestForTarget(request: ChatCompletionRequest): ChatCompletionRequest {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -21,13 +21,26 @@ class AgentLlmStreamAccumulator(
     private val json: Json,
     private val preferInlineThinkTags: Boolean = false,
     private val includeReasoningInAssistantMessage: Boolean = false,
-    private val bufferLeadingTextUntilInlineThinkTag: Boolean = false
+    private val bufferLeadingTextUntilInlineThinkTag: Boolean = false,
+    private val guardLeadingReasoningLeak: Boolean = false
 ) {
     companion object {
         private const val TAG = "AgentLlmStreamAccumulator"
         private const val THINK_OPEN_TAG = "<think>"
         private const val THINK_CLOSE_TAG = "</think>"
+        private const val LEADING_VISIBLE_BUFFER_MAX_CHARS = 900
+        private const val LEADING_VISIBLE_BUFFER_MAX_CHUNKS = 6
         private val INLINE_THINK_TAGS = listOf(THINK_OPEN_TAG, THINK_CLOSE_TAG)
+        private val LEADING_REASONING_LEAK_STRONG_PATTERNS = listOf(
+            Regex("# Understanding the User's Question", RegexOption.IGNORE_CASE)
+        )
+        private val LEADING_REASONING_LEAK_SECONDARY_PATTERNS = listOf(
+            Regex("The user is asking", RegexOption.IGNORE_CASE),
+            Regex("Let me consider", RegexOption.IGNORE_CASE),
+            Regex("I should provide", RegexOption.IGNORE_CASE),
+            Regex("Let me structure a response", RegexOption.IGNORE_CASE),
+            Regex("Given that the user", RegexOption.IGNORE_CASE)
+        )
     }
 
     private val contentBuffer = StringBuilder()
@@ -44,6 +57,8 @@ class AgentLlmStreamAccumulator(
     private var thinkSectionOpen = false
     private var inlineThinkTagObserved = false
     private var autoInlineThinkTagMode = false
+    private var leadingVisibleBufferChunks = 0
+    private var leadingVisibleBufferReleased = false
 
     private var chunkIndex = 0
 
@@ -511,6 +526,9 @@ class AgentLlmStreamAccumulator(
         if (text.isEmpty()) {
             return
         }
+        if (shouldTrackLeadingVisibleGuard()) {
+            leadingVisibleBufferChunks++
+        }
         if (shouldBufferLeadingInlineText()) {
             inlineTextBuffer.append(text)
             flushInlineTextBuffer(final = false)
@@ -584,6 +602,14 @@ class AgentLlmStreamAccumulator(
                 continue
             }
 
+            if (shouldApplyLeadingVisibleGuard()) {
+                detectLeadingReasoningLeak(bufferText)
+                if (final || shouldReleaseLeadingVisibleBuffer(bufferText)) {
+                    releaseLeadingVisibleBuffer(bufferText)
+                }
+                return
+            }
+
             if (final) {
                 appendVisibleText(bufferText)
                 inlineTextBuffer.setLength(0)
@@ -611,6 +637,7 @@ class AgentLlmStreamAccumulator(
             !autoInlineThinkTagMode &&
             !thinkSectionOpen &&
             !inlineThinkTagObserved &&
+            !leadingVisibleBufferReleased &&
             contentBuffer.isEmpty()
     }
 
@@ -618,6 +645,55 @@ class AgentLlmStreamAccumulator(
         return !inlineThinkTagObserved &&
             contentBuffer.isEmpty() &&
             (preferInlineThinkTags || bufferLeadingTextUntilInlineThinkTag)
+    }
+
+    private fun shouldTrackLeadingVisibleGuard(): Boolean {
+        return guardLeadingReasoningLeak &&
+            !leadingVisibleBufferReleased &&
+            !inlineThinkTagObserved &&
+            !thinkSectionOpen &&
+            contentBuffer.isEmpty()
+    }
+
+    private fun shouldApplyLeadingVisibleGuard(): Boolean {
+        return guardLeadingReasoningLeak &&
+            !leadingVisibleBufferReleased &&
+            !inlineThinkTagObserved &&
+            !thinkSectionOpen &&
+            contentBuffer.isEmpty()
+    }
+
+    private fun shouldReleaseLeadingVisibleBuffer(bufferText: String): Boolean {
+        return bufferText.length >= LEADING_VISIBLE_BUFFER_MAX_CHARS ||
+            leadingVisibleBufferChunks >= LEADING_VISIBLE_BUFFER_MAX_CHUNKS
+    }
+
+    private fun releaseLeadingVisibleBuffer(bufferText: String) {
+        appendVisibleText(bufferText)
+        inlineTextBuffer.setLength(0)
+        leadingVisibleBufferReleased = true
+    }
+
+    private fun detectLeadingReasoningLeak(bufferText: String) {
+        val strongMatch = LEADING_REASONING_LEAK_STRONG_PATTERNS.firstOrNull {
+            it.containsMatchIn(bufferText)
+        }
+        if (strongMatch != null) {
+            throw AgentStreamReasoningLeakException(
+                "guarded route leaked reasoning-looking content before visible release: ${strongMatch.pattern}"
+            )
+        }
+        val secondaryMatches = LEADING_REASONING_LEAK_SECONDARY_PATTERNS.filter {
+            it.containsMatchIn(bufferText)
+        }
+        if (secondaryMatches.size < 2) {
+            return
+        }
+        throw AgentStreamReasoningLeakException(
+            "guarded route leaked reasoning-looking content before visible release: ${
+                secondaryMatches.joinToString(" + ") { it.pattern }
+            }"
+        )
     }
 
     private fun partialInlineTagSuffixLength(text: String): Int {
@@ -638,6 +714,7 @@ class AgentLlmStreamAccumulator(
         if (text.isEmpty()) {
             return
         }
+        leadingVisibleBufferReleased = true
         contentBuffer.append(text)
     }
 

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
@@ -216,4 +216,59 @@ class AgentLlmStreamAccumulatorTest {
         assertEquals("", turn.reasoning)
         assertEquals("normal answer", turn.message.contentText())
     }
+
+    @Test
+    fun `guarded leading buffer releases large normal content before stream end`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true,
+            guardLeadingReasoningLeak = true
+        )
+        val safeChunk = "A".repeat(950)
+
+        accumulator.consume("""{"choices":[{"delta":{"content":"$safeChunk"}}]}""")
+
+        assertEquals(safeChunk, accumulator.currentContent())
+    }
+
+    @Test
+    fun `guarded leading buffer aborts on high confidence reasoning leak pattern`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true,
+            guardLeadingReasoningLeak = true
+        )
+
+        val error = runCatching {
+            accumulator.consume(
+                """{"choices":[{"delta":{"content":"# Understanding the User's Question\nThe user is asking for a fix"}}]}"""
+            )
+        }.exceptionOrNull()
+
+        requireNotNull(error)
+        assertTrue(error is AgentStreamReasoningLeakException)
+        assertTrue(error.message.orEmpty().contains("guarded route leaked reasoning-looking content"))
+        assertEquals("", accumulator.currentContent())
+    }
+
+    @Test
+    fun `guarded leading buffer does not abort on single secondary pattern`() {
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            preferInlineThinkTags = false,
+            bufferLeadingTextUntilInlineThinkTag = true,
+            guardLeadingReasoningLeak = true
+        )
+
+        accumulator.consume(
+            """{"choices":[{"delta":{"content":"The user is asking about the build fix."}}]}"""
+        )
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("", turn.reasoning)
+        assertEquals("The user is asking about the build fix.", turn.message.contentText())
+    }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
@@ -246,11 +246,12 @@ class HttpAgentLlmClientTest {
         requestedModel: String,
         resolvedModel: String,
         protocolType: String,
-        requiresReasoningEcho: Boolean
+        requiresReasoningEcho: Boolean,
+        apiBase: String = "https://example.com"
     ) = HttpController.ChatCompletionRouteInfo(
         requestedModel = requestedModel,
         resolvedModel = resolvedModel,
-        apiBase = "https://example.com",
+        apiBase = apiBase,
         providerProfileId = "test",
         providerProfileName = "Test",
         routeTag = "test",
@@ -301,6 +302,113 @@ class HttpAgentLlmClientTest {
 
             assertEquals("first reasoning", turn.reasoning)
             assertEquals("final answer", turn.message.contentText())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `nvidia kimi guarded route retries conservative no thinking variant after leak`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        val requestBodies = mutableListOf<String>()
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                    routeInfo(
+                        requestedModel = model,
+                        resolvedModel = "kimi-k2.6",
+                        protocolType = protocolType ?: "openai_compatible",
+                        requiresReasoningEcho = false,
+                        apiBase = "https://integrate.api.nvidia.com/v1"
+                    )
+                },
+                streamRequestOp = { _, requestBodyJson, listener, _, _, _, _, _ ->
+                    requestBodies += requestBodyJson
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    if (requestBodies.size == 1) {
+                        listener.onEvent(
+                            source,
+                            null,
+                            "message",
+                            """{"choices":[{"delta":{"content":"# Understanding the User's Question\nThe user is asking for a fix"}}]}"""
+                        )
+                    } else {
+                        listener.onEvent(
+                            source,
+                            null,
+                            "message",
+                            """{"choices":[{"delta":{"content":"final answer"}}]}"""
+                        )
+                        listener.onEvent(source, null, "message", "[DONE]")
+                    }
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val turn = client.streamTurn(request = simpleRequest())
+
+            assertEquals("final answer", turn.message.contentText())
+            assertEquals(2, requestBodies.size)
+            assertTrue(requestBodies[0].contains(""""enable_thinking":false"""))
+            assertTrue(requestBodies[0].contains(""""reasoning_effort":"none""""))
+            assertTrue(requestBodies[0].contains(""""thinking":{"type":"disabled"}"""))
+            assertTrue(requestBodies[0].contains("stream_options"))
+            assertTrue(requestBodies[1].contains(""""enable_thinking":false"""))
+            assertTrue(requestBodies[1].contains(""""reasoning_effort":"none""""))
+            assertTrue(requestBodies[1].contains(""""thinking":{"type":"disabled"}"""))
+            assertTrue(!requestBodies[1].contains("stream_options"))
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `nvidia kimi guarded route fails after conservative variants still leak`() = runBlocking {
+        val scope = CoroutineScope(Job() + Dispatchers.Default)
+        val requestBodies = mutableListOf<String>()
+        try {
+            val client = HttpAgentLlmClient(
+                scope = scope,
+                modelOverride = testOverride(),
+                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                    routeInfo(
+                        requestedModel = model,
+                        resolvedModel = "kimi-k2.6",
+                        protocolType = protocolType ?: "openai_compatible",
+                        requiresReasoningEcho = false,
+                        apiBase = "https://integrate.api.nvidia.com/v1"
+                    )
+                },
+                streamRequestOp = { _, requestBodyJson, listener, _, _, _, _, _ ->
+                    requestBodies += requestBodyJson
+                    val source = dummyEventSource()
+                    listener.onOpen(source, okResponse())
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
+                        """{"choices":[{"delta":{"content":"# Understanding the User's Question\nThe user is asking for a fix"}}]}"""
+                    )
+                    source
+                },
+                streamIdleWatchdogMs = 5_000L,
+                json = json
+            )
+
+            val error = runCatching {
+                client.streamTurn(request = simpleRequest())
+            }.exceptionOrNull()
+
+            requireNotNull(error)
+            assertTrue(error is AgentStreamReasoningLeakException)
+            assertEquals(2, requestBodies.size)
+            assertTrue(requestBodies[0].contains("stream_options"))
+            assertTrue(!requestBodies[1].contains("stream_options"))
         } finally {
             scope.cancel()
         }


### PR DESCRIPTION
## 变更摘要

针对 `NVIDIA integrate.api.nvidia.com + openai_compatible + kimi-k2.6` 这条已确认高风险路由，补上了请求级禁用 thinking、流式前序正文缓冲和早期泄露拦截，避免保守分支失效后直接掉回会泄露思维链的默认流。  

## 变更类型

- [x]  Bug 修复

## 关联 Issue

Closes #355 

## 主要改动

1. 补充 </think> 的检测和泄露情况。
2. 在 app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt 中为 NVIDIA + kimi-k2.6 增加定向守卫路由，优先发送 nvidia_no_thinking / nvidia_no_thinking_minimal 两个保守请求变体。

测试细节：
英伟达平台的kimi-k2.6模型会把思考内容直接传到content正文里
<img width="2048" height="53" alt="1da4d5ef-97a9-45cf-8ffc-65ab82059c46" src="https://github.com/user-attachments/assets/fb979f53-ac55-4450-8762-5e60fd167649" />

修复后，会进行非思考回退。

<img width="864" height="1920" alt="7cf9ac8206694a94df83d24e64071459" src="https://github.com/user-attachments/assets/fb1c6a91-b1ce-4581-84a6-d77589d2a885" />

## UI 变更（如有）

无

## 风险与回滚

潜在风险：

英伟达平台模型的上游很不规范，目前的修复也只是尽可能规避，但它平台API更新迭代较快，未来考虑再去补充完善。
