### PR TITLE
fix:补齐主链路未完成的 tool call 响应消息

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -247,9 +247,11 @@ class AgentOrchestrator(
                 missingToolCallRecoveryRounds = 0
 
                 var advanceToNextRound = false
+                var pendingToolCallBackfillReason: String? = null
                 val descriptorMap = mutableMapOf<String, AgentToolRegistry.RuntimeToolDescriptor>()
                 val parsedArgsMap = mutableMapOf<String, JsonObject>()
                 val validatedCalls = mutableListOf<AssistantToolCall>()
+                val writtenToolCallIds = linkedSetOf<String>()
 
                 // Phase A — parse + validate all tool arguments synchronously.
                 // Any parse/validation failure aborts the current turn's tool execution
@@ -281,9 +283,14 @@ class AgentOrchestrator(
                             result = result,
                             failureLearning = failureLearning
                         )
+                        writtenToolCallIds += toolCall.id
                         hasUserFacingOutput =
                             hasUserFacingOutput || eventAdapter.hasUserVisibleOutput(result)
                         advanceToNextRound = true
+                        pendingToolCallBackfillReason = t(
+                            "工具参数 JSON 解析失败，当前 assistant 消息中的剩余 tool_call 未执行。",
+                            "Tool arguments JSON parsing failed, so the remaining tool calls in this assistant message were not executed."
+                        )
                         break@parsePhase
                     }
                     val validationError = runCatching {
@@ -310,9 +317,14 @@ class AgentOrchestrator(
                             result = result,
                             failureLearning = failureLearning
                         )
+                        writtenToolCallIds += toolCall.id
                         hasUserFacingOutput =
                             hasUserFacingOutput || eventAdapter.hasUserVisibleOutput(result)
                         advanceToNextRound = true
+                        pendingToolCallBackfillReason = t(
+                            "工具参数校验失败，当前 assistant 消息中的剩余 tool_call 未执行。",
+                            "Tool argument validation failed, so the remaining tool calls in this assistant message were not executed."
+                        )
                         break@parsePhase
                     }
                     parsedArgsMap[toolCall.id] = parsedArgs
@@ -320,7 +332,7 @@ class AgentOrchestrator(
                 }
 
                 // Phase B — partition validated calls into batches and execute.
-                if (validatedCalls.isNotEmpty()) {
+                if (!advanceToNextRound && validatedCalls.isNotEmpty()) {
                     val batches = AgentToolConcurrencyPolicy.partitionToolCalls(
                         validatedCalls,
                         parsedArgsMap
@@ -397,26 +409,37 @@ class AgentOrchestrator(
                                 result = result,
                                 failureLearning = failureLearning
                             )
+                            writtenToolCallIds += call.id
 
-                            if (eventAdapter.hasUserVisibleOutput(result)) {
+                            if (!terminated && !advanceToNextRound && eventAdapter.hasUserVisibleOutput(result)) {
                                 hasUserFacingOutput = true
                             }
-                            val mappedKind = eventAdapter.mapOutputKind(result)
-                            if (mappedKind != AgentOutputKind.NONE) {
-                                outputKind = mappedKind
+                            if (!terminated && !advanceToNextRound) {
+                                val mappedKind = eventAdapter.mapOutputKind(result)
+                                if (mappedKind != AgentOutputKind.NONE) {
+                                    outputKind = mappedKind
+                                }
                             }
-                            if (eventAdapter.isConversationStoppingResult(result)) {
+                            if (!terminated && eventAdapter.isConversationStoppingResult(result)) {
                                 terminated = true
-                                break@roundLoop
+                                pendingToolCallBackfillReason = t(
+                                    "工具 ${call.function.name} 的结果已结束当前对话，当前 assistant 消息中的剩余 tool_call 未继续处理。",
+                                    "The result of tool ${call.function.name} ended the conversation, so the remaining tool calls in this assistant message were not processed."
+                                )
                             }
                             if (
-                                call.function.name == "terminal_execute" ||
-                                call.function.name == "android_privileged_action" ||
-                                call.function.name == "android_privileged_session_start" ||
-                                call.function.name == "android_privileged_session_exec" ||
-                                call.function.name == "android_privileged_session_read" ||
-                                call.function.name == "android_privileged_session_stop"
+                                !terminated &&
+                                !advanceToNextRound &&
+                                isExclusiveTurnBoundaryTool(call.function.name)
                             ) {
+                                advanceToNextRound = true
+                                breakBatchLoopAfterPost = true
+                                pendingToolCallBackfillReason = t(
+                                    "独占工具 ${call.function.name} 已占用本轮，当前 assistant 消息中的剩余 tool_call 未执行。",
+                                    "Exclusive tool ${call.function.name} occupied this turn, so the remaining tool calls in this assistant message were not executed."
+                                )
+                            }
+                            if (terminated) {
                                 breakBatchLoopAfterPost = true
                             }
                         }
@@ -424,6 +447,17 @@ class AgentOrchestrator(
                             break@batchLoop
                         }
                     }
+                }
+
+                pendingToolCallBackfillReason?.let { reason ->
+                    appendSyntheticToolResultMessages(
+                        memory = memory,
+                        toolCalls = toolCalls,
+                        descriptorMap = descriptorMap,
+                        writtenToolCallIds = writtenToolCallIds,
+                        round = round,
+                        reason = reason
+                    )
                 }
 
                 if (terminated) {
@@ -628,6 +662,60 @@ class AgentOrchestrator(
                 content = content
             )
         )
+    }
+
+    private fun appendSyntheticToolResultMessages(
+        memory: AgentChatMemory,
+        toolCalls: List<AssistantToolCall>,
+        descriptorMap: MutableMap<String, AgentToolRegistry.RuntimeToolDescriptor>,
+        writtenToolCallIds: MutableSet<String>,
+        round: Int,
+        reason: String
+    ) {
+        val syntheticIds = mutableListOf<String>()
+        val actualIds = writtenToolCallIds.toList()
+        for (toolCall in toolCalls) {
+            if (toolCall.id in writtenToolCallIds) {
+                continue
+            }
+            val descriptor = descriptorMap.getOrPut(toolCall.id) {
+                toolRegistry.runtimeDescriptor(toolCall.function.name)
+            }
+            appendToolResultMessage(
+                memory = memory,
+                toolCall = toolCall,
+                descriptor = descriptor,
+                result = ToolExecutionResult.Error(
+                    toolName = toolCall.function.name,
+                    message = buildSyntheticToolSkipMessage(reason)
+                )
+            )
+            writtenToolCallIds += toolCall.id
+            syntheticIds += toolCall.id
+        }
+        if (syntheticIds.isNotEmpty()) {
+            logInfo(
+                tag,
+                "round=$round tool_calls=${toolCalls.size} actual_tool_call_ids=${actualIds.joinToString(",")} " +
+                    "synthetic_tool_call_ids=${syntheticIds.joinToString(",")} reason=$reason"
+            )
+        }
+    }
+
+    private fun buildSyntheticToolSkipMessage(reason: String): String {
+        return t(
+            "本轮未执行该工具。原因：$reason 如仍需要此工具，请由模型在下一轮重新发起。",
+            "This tool was not executed in this turn. Reason: $reason If it is still needed, the model should call it again in the next turn."
+        )
+    }
+
+    private fun isExclusiveTurnBoundaryTool(toolName: String): Boolean {
+        return toolName == "terminal_execute" ||
+            toolName == "android_privileged_action" ||
+            toolName == "android_privileged_session_start" ||
+            toolName == "android_privileged_session_exec" ||
+            toolName == "android_privileged_session_read" ||
+            toolName == "android_privileged_session_stop"
     }
 
     private fun buildInterruptedToolResult(

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -525,6 +525,44 @@ class AgentOrchestratorTest {
     }
 
     @Test
+    fun invalidToolArgumentsBackfillRemainingToolCallIds() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    toolCalls = listOf(
+                        toolCall(
+                            name = "file_read",
+                            arguments = "[",
+                            id = "call-read"
+                        ),
+                        toolCall(
+                            name = "file_search",
+                            arguments = """{"query":"README"}""",
+                            id = "call-search"
+                        )
+                    )
+                ),
+                assistantTurn(content = "参数不合法，我改成直接说明原因。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor()
+
+        createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = RecordingCallback(),
+                initialMessages = initialMessages("读取文件"),
+                executionEnv = FakeExecutionEnvironment("读取文件")
+            )
+        )
+
+        val toolMessages = llmClient.requests[1].messages.filter { it.role == "tool" }
+        assertEquals(2, llmClient.requests.size)
+        assertTrue(toolExecutor.executeCalls.isEmpty())
+        assertEquals(listOf("call-read", "call-search"), toolMessages.map { it.toolCallId })
+        assertTrue(toolMessages.last().content.toString().contains("本轮未执行该工具"))
+    }
+
+    @Test
     fun validationFailureIsFedBackAsToolResultInsteadOfStopping() = runBlocking {
         val llmClient = FakeLlmClient(
             turns = listOf(
@@ -561,6 +599,103 @@ class AgentOrchestratorTest {
         assertEquals(2, llmClient.requests.size)
         assertEquals("tool", llmClient.requests[1].messages.last().role)
         assertTrue(callback.finalChatMessages().last().contains("校验失败"))
+    }
+
+    @Test
+    fun validationFailureBackfillsRemainingToolCallIds() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    toolCalls = listOf(
+                        toolCall(
+                            name = "file_read",
+                            arguments = """{"path":"README.md"}""",
+                            id = "call-read"
+                        ),
+                        toolCall(
+                            name = "file_search",
+                            arguments = """{"query":"README"}""",
+                            id = "call-search"
+                        )
+                    )
+                ),
+                assistantTurn(content = "校验失败后，我改成文本解释。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor()
+        val toolCatalog = FakeToolCatalog(
+            validationErrors = mapOf("file_read" to "缺少必填字段")
+        )
+
+        AgentOrchestrator(
+            llmClient = llmClient,
+            toolRegistry = toolCatalog,
+            toolRouter = toolExecutor,
+            eventAdapter = AgentEventAdapter(eventJson),
+            model = "test-model"
+        ).run(
+            AgentOrchestrator.Input(
+                callback = RecordingCallback(),
+                initialMessages = initialMessages("读取文件"),
+                executionEnv = FakeExecutionEnvironment("读取文件")
+            )
+        )
+
+        val toolMessages = llmClient.requests[1].messages.filter { it.role == "tool" }
+        assertEquals(2, llmClient.requests.size)
+        assertTrue(toolExecutor.executeCalls.isEmpty())
+        assertEquals(listOf("call-read", "call-search"), toolMessages.map { it.toolCallId })
+        assertTrue(toolMessages.last().content.toString().contains("本轮未执行该工具"))
+    }
+
+    @Test
+    fun exclusiveToolBackfillsRemainingToolCallIds() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(
+                    toolCalls = listOf(
+                        toolCall(
+                            name = "terminal_execute",
+                            arguments = """{"command":"echo hi"}""",
+                            id = "call-terminal"
+                        ),
+                        toolCall(
+                            name = "file_search",
+                            arguments = """{"query":"README"}""",
+                            id = "call-search"
+                        )
+                    )
+                ),
+                assistantTurn(content = "终端命令执行后，我改成直接说明状态。")
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "terminal_execute" to listOf(
+                    ToolExecutionResult.TerminalResult(
+                        toolName = "terminal_execute",
+                        summaryText = "命令执行完成",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true
+                    )
+                )
+            )
+        )
+
+        createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = RecordingCallback(),
+                initialMessages = initialMessages("执行 echo hi"),
+                executionEnv = FakeExecutionEnvironment("执行 echo hi")
+            )
+        )
+
+        val toolMessages = llmClient.requests[1].messages.filter { it.role == "tool" }
+        assertEquals(2, llmClient.requests.size)
+        assertEquals(listOf("terminal_execute"), toolExecutor.executeCalls)
+        assertEquals(listOf("call-terminal", "call-search"), toolMessages.map { it.toolCallId })
+        assertTrue(toolMessages.last().content.toString().contains("本轮未执行该工具"))
     }
 
     @Test


### PR DESCRIPTION
## 变更摘要

本次改动修复了 Agent 主链路在同一轮返回多个 `tool_calls` 时，因参数解析失败、参数校验失败、独占工具截断或会话提前结束而导致历史消息不完整的问题。  
修复后，`AgentOrchestrator` 会为本轮未执行但已出现在 assistant 消息中的剩余 `tool_call_id` 自动补齐 synthetic `tool` message，避免下一轮请求触发 `An assistant message with 'tool_calls' must be followed by tool messages...` 这类 400 协议错误。

## 变更类型

- [x]  Bug 修复

## 关联 Issue

Closes #365 

## 主要改动

1. 在 `AgentOrchestrator` 中记录本轮已经写回 `tool` message 的 `tool_call_id`，并在提前截断分支统一收集 backfill 原因。
2. 新增 synthetic `tool` message 补齐逻辑，确保同一条 assistant 消息中的每个 `tool_call_id` 最终都有对应 `tool` message。
3. 增加 3 条定向单测，覆盖参数 JSON 解析失败、参数校验失败、独占工具 `terminal_execute` 截断后的补齐行为。


测试细节：
修复前：
<img width="2656" height="134" alt="03c30c61-bd51-4bf7-9c20-1156a19fbc92" src="https://github.com/user-attachments/assets/fcc6eb1d-67fb-46a7-b17f-8f598f4561e5" />


修复后：
<img width="2048" height="76" alt="c1079863-8614-4e20-9d1f-7540ceeae32e" src="https://github.com/user-attachments/assets/c18d85cc-772a-443d-bd53-220b137f14b8" />

<img width="864" height="1920" alt="b3bda602-b041-4017-a391-22be920678c8" src="https://github.com/user-attachments/assets/1aa414a1-c303-4154-895a-97b1880c09ac" />



## UI 变更（如有）

无

## 风险与回滚

潜在风险：
- synthetic `tool` message 的文案会进入下一轮上下文，可能轻微影响模型后续输出措辞，但不会破坏协议完整性。



