### PR TITLE
refactor(chat): 移除自动显示模型层功能并简化显示层逻辑

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -192,7 +192,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
       KeyboardInsetMotionTracker();
   final Map<ChatPageMode, ChatIslandDisplayLayer>
   _chatIslandDisplayLayerByMode = {
-    ChatPageMode.normal: ChatIslandDisplayLayer.tools,
+    ChatPageMode.normal: ChatIslandDisplayLayer.mode,
     ChatPageMode.openclaw: ChatIslandDisplayLayer.mode,
     ChatPageMode.codex: ChatIslandDisplayLayer.mode,
   };
@@ -360,9 +360,6 @@ abstract class _ChatPageStateBase extends State<ChatPage>
       'chat_hd_pad_left_pane_width';
   static const String _hdPadRightPaneWidthStorageKey =
       'chat_hd_pad_right_pane_width';
-  static const Duration _normalSurfaceModelRevealDelay = Duration(
-    milliseconds: 1700,
-  );
   bool _workspaceBrowserCanGoUp = false;
   Future<OmnibotWorkspacePaths>? _workspacePathsLoadFuture;
   bool _hasInitializedHalfScreen = false;
@@ -415,8 +412,6 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   int? _pageGesturePointerId;
   double _pageHorizontalDragDelta = 0;
   double _pageVerticalDragDelta = 0;
-  Timer? _normalSurfaceModelRevealTimer;
-  bool _normalSurfaceModelRevealInterrupted = false;
   int _surfaceSwitchRequestId = 0;
   bool _isSurfacePageScrolling = false;
   final HdPadPaneLayoutResolver _hdPadPaneLayoutResolver =
@@ -513,12 +508,16 @@ abstract class _ChatPageStateBase extends State<ChatPage>
     _conversationLifecycleGuard.invalidate();
   }
 
-  ChatIslandDisplayLayer _chatIslandDisplayLayerForMode(ChatPageMode mode) =>
-      _runtimeForMode(mode)?.chatIslandDisplayLayer ??
-      (_chatIslandDisplayLayerByMode[mode] ??
-          (mode == ChatPageMode.normal
-              ? ChatIslandDisplayLayer.tools
-              : ChatIslandDisplayLayer.mode));
+  ChatIslandDisplayLayer _chatIslandDisplayLayerForMode(ChatPageMode mode) {
+    final stored =
+        _runtimeForMode(mode)?.chatIslandDisplayLayer ??
+        _chatIslandDisplayLayerByMode[mode];
+    if (stored != null) {
+      return stored;
+    }
+    return ChatIslandDisplayLayer.mode;
+  }
+
   bool get _isOpenClawSurface => _activeSurfaceMode == ChatSurfaceMode.openclaw;
   bool get _isWorkspaceSurface =>
       _activeSurfaceMode == ChatSurfaceMode.workspace;
@@ -922,109 +921,30 @@ abstract class _ChatPageStateBase extends State<ChatPage>
     _chatIslandDisplayLayerByMode[_activeMode] = value;
   }
 
-  void _cancelNormalSurfaceModelReveal() {
-    _normalSurfaceModelRevealTimer?.cancel();
-    _normalSurfaceModelRevealTimer = null;
-  }
-
-  void _interruptNormalSurfaceModelReveal() {
-    _cancelNormalSurfaceModelReveal();
-    _normalSurfaceModelRevealInterrupted = true;
-  }
-
-  void _resetNormalSurfaceModelRevealInterruption() {
-    _normalSurfaceModelRevealInterrupted = false;
-  }
-
-  bool _canAutoRevealNormalSurfaceModel() {
-    final modelId = _activeNormalChatModelId?.trim() ?? '';
-    return _activeSurfaceMode == ChatSurfaceMode.normal &&
-        !_isSurfacePageScrolling &&
-        !_normalSurfaceModelRevealInterrupted &&
-        modelId.isNotEmpty &&
-        _chatIslandDisplayLayerForMode(ChatPageMode.normal) ==
-            ChatIslandDisplayLayer.mode;
-  }
-
-  void _scheduleNormalSurfaceModelReveal() {
-    _cancelNormalSurfaceModelReveal();
-    if (!_canAutoRevealNormalSurfaceModel()) {
-      return;
-    }
-    _normalSurfaceModelRevealTimer = Timer(_normalSurfaceModelRevealDelay, () {
-      _normalSurfaceModelRevealTimer = null;
-      if (!mounted || !_canAutoRevealNormalSurfaceModel()) {
-        return;
-      }
-      setState(() {
-        _setChatIslandDisplayLayerForMode(
-          ChatPageMode.normal,
-          ChatIslandDisplayLayer.model,
-        );
-      });
-    });
-  }
-
-  void _forceNormalSurfaceToolLayer() {
-    if (_chatIslandDisplayLayerForMode(ChatPageMode.normal) ==
-        ChatIslandDisplayLayer.tools) {
-      return;
-    }
-    _setChatIslandDisplayLayerForMode(
-      ChatPageMode.normal,
-      ChatIslandDisplayLayer.tools,
-    );
-  }
-
   void _handleSurfaceScrollStart() {
-    _cancelNormalSurfaceModelReveal();
     if (!mounted) {
       _isSurfacePageScrolling = true;
-      _forceNormalSurfaceToolLayer();
       return;
     }
-    if (_isSurfacePageScrolling &&
-        _chatIslandDisplayLayerForMode(ChatPageMode.normal) ==
-            ChatIslandDisplayLayer.tools) {
+    if (_isSurfacePageScrolling) {
       return;
     }
     setState(() {
       _isSurfacePageScrolling = true;
-      _forceNormalSurfaceToolLayer();
     });
   }
 
-  void _handleSurfaceScrollSettled(ChatSurfaceMode mode) {
-    _cancelNormalSurfaceModelReveal();
+  void _handleSurfaceScrollSettled() {
     if (!mounted) {
       _isSurfacePageScrolling = false;
-      if (mode == ChatSurfaceMode.normal) {
-        _resetNormalSurfaceModelRevealInterruption();
-        _forceNormalSurfaceToolLayer();
-      }
       return;
     }
-    final shouldSettleState =
-        _isSurfacePageScrolling ||
-        (mode == ChatSurfaceMode.normal &&
-            _chatIslandDisplayLayerForMode(ChatPageMode.normal) !=
-                ChatIslandDisplayLayer.tools);
-    if (shouldSettleState) {
+    if (_isSurfacePageScrolling) {
       setState(() {
         _isSurfacePageScrolling = false;
-        if (mode == ChatSurfaceMode.normal) {
-          _resetNormalSurfaceModelRevealInterruption();
-          _forceNormalSurfaceToolLayer();
-        }
       });
     } else {
       _isSurfacePageScrolling = false;
-      if (mode == ChatSurfaceMode.normal) {
-        _resetNormalSurfaceModelRevealInterruption();
-      }
-    }
-    if (mode == ChatSurfaceMode.normal) {
-      _scheduleNormalSurfaceModelReveal();
     }
   }
 
@@ -1046,14 +966,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
       return false;
     }
     if (notification is ScrollEndNotification) {
-      final pageMetrics = notification.metrics;
-      final rawPage = pageMetrics is PageMetrics
-          ? pageMetrics.page
-          : (_modePageController.hasClients ? _modePageController.page : null);
-      final settledPageIndex =
-          (rawPage ?? _pageIndexForSurface(_activeSurfaceMode).toDouble())
-              .round();
-      _handleSurfaceScrollSettled(_surfaceForPageIndex(settledPageIndex));
+      _handleSurfaceScrollSettled();
     }
     return false;
   }
@@ -1225,6 +1138,17 @@ abstract class _ChatPageStateBase extends State<ChatPage>
       return defaultModel;
     }
     return null;
+  }
+
+  bool get _hasSelectableNormalChatModels {
+    return _modelProviderProfiles.any((profile) {
+      if (!profile.configured) {
+        return false;
+      }
+      final models =
+          _modelOptionsByProfileId[profile.id] ?? const <ProviderModelOption>[];
+      return models.isNotEmpty;
+    });
   }
 
   _ChatModelOverrideSelection? get _activeDispatchSceneSelection {
@@ -1638,9 +1562,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
     _currentConversationByMode[mode] = null;
     _isInputAreaVisibleByMode[mode] = true;
     _isExecutingTaskByMode[mode] = false;
-    _chatIslandDisplayLayerByMode[mode] = mode == ChatPageMode.normal
-        ? ChatIslandDisplayLayer.tools
-        : ChatIslandDisplayLayer.mode;
+    _chatIslandDisplayLayerByMode[mode] = ChatIslandDisplayLayer.mode;
     _lastAgentToolTypeByMode[mode] = null;
     _runtimeChromeSignatureByMode[mode] = '';
     _runtimeMessageMutationRevisionByMode[mode] = 0;

--- a/ui/lib/features/home/pages/chat/chat_page_browser.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_browser.dart
@@ -8,19 +8,7 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
   static const double _kBrowserOverlayHorizontalMargin = 16;
   static const double _kBrowserOverlayTopMargin = 64;
   static const double _kBrowserOverlayBottomMargin = 16;
-  static const double _kPageSwipeThreshold = 18;
   static const double _kDrawerSwipeThreshold = 36;
-  static const double _kRevealInterruptThreshold = 6;
-
-  void _applyPageVerticalIntent(double delta) {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
-        delta.abs() < _kPageSwipeThreshold) {
-      return;
-    }
-    _handleChatIslandDisplayLayerChanged(
-      delta > 0 ? ChatIslandDisplayLayer.tools : ChatIslandDisplayLayer.model,
-    );
-  }
 
   bool _maybeOpenDrawerFromPageSwipe() {
     if (!mounted ||
@@ -95,12 +83,6 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     }
     _pageHorizontalDragDelta += event.delta.dx;
     _pageVerticalDragDelta += event.delta.dy;
-    if (_normalSurfaceModelRevealTimer != null &&
-        !_normalSurfaceModelRevealInterrupted &&
-        (_pageVerticalDragDelta.abs() >= _kRevealInterruptThreshold ||
-            _pageHorizontalDragDelta.abs() >= _kRevealInterruptThreshold)) {
-      _interruptNormalSurfaceModelReveal();
-    }
   }
 
   @override
@@ -115,10 +97,7 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
       _pageVerticalDragDelta = 0;
       return;
     }
-    final handledDrawerSwipe = _maybeOpenDrawerFromPageSwipe();
-    if (!handledDrawerSwipe) {
-      _applyPageVerticalIntent(_pageVerticalDragDelta);
-    }
+    _maybeOpenDrawerFromPageSwipe();
     _pageGesturePointerId = null;
     _pageHorizontalDragDelta = 0;
     _pageVerticalDragDelta = 0;
@@ -284,7 +263,6 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     if (_activeSurfaceMode != ChatSurfaceMode.normal) {
       return;
     }
-    _cancelNormalSurfaceModelReveal();
     setState(() {
       _setChatIslandDisplayLayerForMode(ChatPageMode.normal, layer);
       if (layer != ChatIslandDisplayLayer.tools) {
@@ -298,7 +276,6 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     if (_activeSurfaceMode != ChatSurfaceMode.normal) {
       return;
     }
-    _cancelNormalSurfaceModelReveal();
     setState(() {
       _setChatIslandDisplayLayerForMode(
         ChatPageMode.normal,
@@ -320,7 +297,6 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     if (_activeSurfaceMode != ChatSurfaceMode.normal) {
       return;
     }
-    _cancelNormalSurfaceModelReveal();
     if (!Platform.isAndroid) {
       showToast('当前平台暂不支持浏览器工具视图', type: ToastType.warning);
       return;

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -76,10 +76,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
         _isHdPadLandscapeForMediaQuery(mediaQuery) &&
         _activeSurfaceMode == ChatSurfaceMode.workspace) {
       _activeSurfaceMode = ChatSurfaceMode.normal;
-      _setChatIslandDisplayLayerForMode(
-        ChatPageMode.normal,
-        ChatIslandDisplayLayer.tools,
-      );
     }
     final route = ModalRoute.of(context);
     if (route is PageRoute && route != _subscribedRoute) {
@@ -259,7 +255,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       _draftMessageByMode[targetMode] = '';
       _pendingAttachmentsByMode[targetMode]?.clear();
     }
-    _cancelNormalSurfaceModelReveal();
     if (isStaleRequest()) return;
     setState(() {
       _resolvedThreadTarget = effectiveTarget;
@@ -600,7 +595,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     unawaited(_clearVisibleChatConversation());
     WidgetsBinding.instance.removeObserver(this);
     unawaited(_runtimeCoordinator.flushAllPendingPersistence());
-    _cancelNormalSurfaceModelReveal();
     _conversationListChangedSubscription?.cancel();
     _conversationMessagesChangedSubscription?.cancel();
     _browserSessionSnapshotChangedSubscription?.cancel();
@@ -833,15 +827,9 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (!mounted) return;
     if (_activeSurfaceMode == resolvedTargetMode) {
       if (syncPage) _jumpToCurrentModePage();
-      if (resolvedTargetMode == ChatSurfaceMode.normal &&
-          !_isSurfacePageScrolling &&
-          (!syncPage || !_modePageController.hasClients)) {
-        _scheduleNormalSurfaceModelReveal();
-      }
       return;
     }
 
-    _cancelNormalSurfaceModelReveal();
     _storeDraftForActiveConversationMode();
     await _persistVisibleThreadTargetIfNeeded();
     if (isStaleRequest()) return;
@@ -857,7 +845,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
         _messageController.clear();
         _setChatIslandDisplayLayerForMode(
           ChatPageMode.normal,
-          ChatIslandDisplayLayer.tools,
+          ChatIslandDisplayLayer.mode,
         );
         _isBrowserOverlayVisible = false;
       });
@@ -874,13 +862,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     setState(() {
       _activeSurfaceMode = ChatSurfaceMode.normal;
       _activeConversationMode = targetConversationMode;
-      _resetNormalSurfaceModelRevealInterruption();
-      _setChatIslandDisplayLayerForMode(
-        targetConversationMode,
-        targetConversationMode == ChatPageMode.normal
-            ? ChatIslandDisplayLayer.tools
-            : ChatIslandDisplayLayer.mode,
-      );
     });
     _applyDraftForConversationMode(targetConversationMode);
     await _persistVisibleThreadTargetIfNeeded();
@@ -891,10 +872,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       unawaited(_loadNormalChatModelContext());
     }
     if (syncPage) _jumpToCurrentModePage();
-    if (!_isSurfacePageScrolling &&
-        (!syncPage || !_modePageController.hasClients)) {
-      _scheduleNormalSurfaceModelReveal();
-    }
   }
 
   @override

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -28,7 +28,6 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
           overrideSelection: _activeConversationModelOverrideSelection,
         );
       });
-      _scheduleNormalSurfaceModelReveal();
       await _syncInvalidNormalConversationOverrideIfNeeded();
       await _syncActiveNormalConversationPromptTokenThreshold();
     } catch (e) {
@@ -436,15 +435,7 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
         _openClawPanelExpanded = false;
       });
     }
-    final hasSelectableModels = _modelProviderProfiles.any((profile) {
-      if (!profile.configured) {
-        return false;
-      }
-      final models =
-          _modelOptionsByProfileId[profile.id] ?? const <ProviderModelOption>[];
-      return models.isNotEmpty;
-    });
-    if (!hasSelectableModels) {
+    if (!_hasSelectableNormalChatModels) {
       return;
     }
     _inputFocusNode.unfocus();
@@ -453,7 +444,10 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     if (anchorBox == null || !anchorBox.hasSize || anchorRect == null) {
       return;
     }
-    final popupWidth = anchorBox.size.width.clamp(160.0, 320.0).toDouble();
+    final popupWidth = math
+        .max(260.0, anchorBox.size.width)
+        .clamp(260.0, 320.0)
+        .toDouble();
     const popupMaxHeight = 360.0;
     final selected = await showGlassPopup<_ChatModelOverrideSelection>(
       context: context,

--- a/ui/lib/features/home/pages/chat/chat_page_models.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_models.dart
@@ -8,7 +8,6 @@ import 'package:ui/models/chat_message_model.dart';
 
 enum ChatIslandDisplayLayer {
   mode('mode'),
-  model('model'),
   tools('tools');
 
   const ChatIslandDisplayLayer(this.wireName);
@@ -17,6 +16,9 @@ enum ChatIslandDisplayLayer {
 
   static ChatIslandDisplayLayer fromWireName(String? value) {
     final normalized = value?.trim().toLowerCase() ?? '';
+    if (normalized == 'model') {
+      return ChatIslandDisplayLayer.tools;
+    }
     for (final layer in ChatIslandDisplayLayer.values) {
       if (layer.wireName == normalized) {
         return layer;

--- a/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
@@ -43,7 +43,6 @@ mixin _ChatPageTerminalEnvMixin on _ChatPageStateBase {
     if (_activeMode != ChatPageMode.normal) {
       return;
     }
-    _cancelNormalSurfaceModelReveal();
     if (_showSlashCommandPanel ||
         _showModelMentionPanel ||
         _openClawPanelExpanded) {

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1027,14 +1027,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     );
   }
 
-  ChatIslandDisplayLayer _resolveChatPaneDisplayLayer({
-    required bool showSurfaceSwitcher,
-  }) {
-    if (!showSurfaceSwitcher) {
-      return _chatIslandDisplayLayer == ChatIslandDisplayLayer.tools
-          ? ChatIslandDisplayLayer.tools
-          : ChatIslandDisplayLayer.model;
-    }
+  ChatIslandDisplayLayer _resolveChatPaneDisplayLayer() {
     return _activeSurfaceMode == ChatSurfaceMode.normal
         ? _chatIslandDisplayLayer
         : ChatIslandDisplayLayer.mode;
@@ -1162,31 +1155,6 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     final appBarMode = showSurfaceSwitcher
         ? _activeSurfaceMode
         : ChatSurfaceMode.normal;
-    final activeAppBarModelId = appBarMode == ChatSurfaceMode.normal
-        ? switch (_activeMode) {
-            ChatPageMode.normal => _activeNormalChatModelId,
-            ChatPageMode.codex => _activeCodexModelId,
-            ChatPageMode.openclaw => null,
-          }
-        : null;
-    final ValueChanged<BuildContext>? onAppBarModelTap =
-        appBarMode == ChatSurfaceMode.normal
-        ? switch (_activeMode) {
-            ChatPageMode.normal => (anchorContext) {
-              unawaited(_openConversationModelSelector(anchorContext));
-            },
-            ChatPageMode.codex => (anchorContext) {
-              _messageController.value = const TextEditingValue(
-                text: '/model ',
-                selection: TextSelection.collapsed(offset: 7),
-              );
-              _inputFocusNode.requestFocus();
-              _handleSlashCommandInput();
-              unawaited(_loadCodexModelOptions());
-            },
-            ChatPageMode.openclaw => null,
-          }
-        : null;
     final bottomRegionBackgroundColor = !backgroundActive && context.isDarkTheme
         ? context.omniPalette.pageBackground
         : Colors.transparent;
@@ -1221,12 +1189,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
               onModeChanged: (value) {
                 unawaited(_switchChatMode(value, syncPage: true));
               },
-              activeModelId: activeAppBarModelId,
-              onModelTap: onAppBarModelTap,
-              displayLayer: _resolveChatPaneDisplayLayer(
-                showSurfaceSwitcher: showSurfaceSwitcher,
-              ),
-              onInteracted: _cancelNormalSurfaceModelReveal,
+              displayLayer: _resolveChatPaneDisplayLayer(),
               onDisplayLayerChanged: _handleChatIslandDisplayLayerChanged,
               onTerminalEnvironmentTap: (anchorContext) {
                 unawaited(_openTerminalEnvironmentEditor(anchorContext));
@@ -1325,6 +1288,15 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                       onLongPressContextUsageRing:
                           _activeMode == ChatPageMode.normal
                           ? _handleContextUsageRingLongPress
+                          : null,
+                      modelPickerSettings: _activeMode == ChatPageMode.normal
+                          ? ChatModelPickerSettings(
+                              modelId: _activeNormalChatModelId ?? '',
+                              hasSelectableModels:
+                                  _hasSelectableNormalChatModels,
+                              onOpen: (anchorContext) =>
+                                  _openConversationModelSelector(anchorContext),
+                            )
                           : null,
                       codexRunSettings: _activeMode == ChatPageMode.codex
                           ? CodexRunSettings(

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -80,9 +80,7 @@ class ChatConversationRuntimeState {
   ChatConversationRuntimeState({
     required this.conversationId,
     required this.mode,
-  }) : chatIslandDisplayLayer = mode == kChatRuntimeModeNormal
-           ? ChatIslandDisplayLayer.tools
-           : ChatIslandDisplayLayer.mode;
+  }) : chatIslandDisplayLayer = ChatIslandDisplayLayer.mode;
 
   final int conversationId;
   final String mode;

--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -60,10 +60,7 @@ class ChatAppBar extends StatelessWidget {
   final VoidCallback onCompanionTap;
   final ChatSurfaceMode activeMode;
   final ValueChanged<ChatSurfaceMode> onModeChanged;
-  final String? activeModelId;
-  final ValueChanged<BuildContext>? onModelTap;
   final ChatIslandDisplayLayer displayLayer;
-  final VoidCallback? onInteracted;
   final ValueChanged<ChatIslandDisplayLayer> onDisplayLayerChanged;
   final ValueChanged<BuildContext> onTerminalEnvironmentTap;
   final VoidCallback onTerminalTap;
@@ -101,10 +98,7 @@ class ChatAppBar extends StatelessWidget {
     required this.onCompanionTap,
     required this.activeMode,
     required this.onModeChanged,
-    this.activeModelId,
-    this.onModelTap,
     this.displayLayer = ChatIslandDisplayLayer.mode,
-    this.onInteracted,
     required this.onDisplayLayerChanged,
     required this.onTerminalEnvironmentTap,
     required this.onTerminalTap,
@@ -151,7 +145,6 @@ class ChatAppBar extends StatelessWidget {
         showWorkspacePaneButton && onWorkspacePaneTap != null;
     final showUpdateShortcutButton =
         showAppUpdateIndicator && onAppUpdateTap != null;
-    const showModeShortcutButton = true;
     final appBarBackgroundColor = showSurfaceSwitcher
         ? palette.pageBackground
         : palette.surfacePrimary;
@@ -172,7 +165,7 @@ class ChatAppBar extends StatelessWidget {
               final rightActionCount =
                   (showUpdateShortcutButton ? 1 : 0) +
                   (showWorkspaceButton ? 1 : 0) +
-                  (showModeShortcutButton ? 1 : 0);
+                  1;
               final rightReservedSpace =
                   rightActionCount * _kChatAppBarRightActionSlotWidth +
                   _kChatAppBarAccessoryGap;
@@ -261,13 +254,10 @@ class ChatAppBar extends StatelessWidget {
                     child: SizedBox(
                       key: const ValueKey('chat-app-bar-island'),
                       width: islandWidth,
-                      child: _ChatModeModelSwitcher(
+                      child: _ChatIslandSwitcher(
                         activeMode: activeMode,
                         onModeChanged: onModeChanged,
-                        activeModelId: activeModelId,
-                        onModelTap: onModelTap,
                         displayLayer: displayLayer,
-                        onInteracted: onInteracted,
                         onDisplayLayerChanged: onDisplayLayerChanged,
                         onTerminalEnvironmentTap: onTerminalEnvironmentTap,
                         onTerminalTap: onTerminalTap,
@@ -324,27 +314,26 @@ class ChatAppBar extends StatelessWidget {
                               ),
                             ),
                           ),
-                        if (showModeShortcutButton)
-                          SizedBox(
-                            width: _kChatAppBarRightActionSlotWidth,
-                            height: _kChatAppBarRightActionSlotWidth,
-                            child: Center(
-                              child: _ChatAppBarModeShortcutButton(
-                                key: const ValueKey(
-                                  'chat-app-bar-pure-chat-button',
-                                ),
-                                iconTint: iconTint,
-                                isCodexLoading: isCodexLoading,
-                                isCodexSelected: isCodexSelected,
-                                isAgentSelected: isAgentSelected,
-                                isPureChatSelected: isPureChatSelected,
-                                isPureChatToggleLocked: isPureChatToggleLocked,
-                                onAgentTap: onAgentTap,
-                                onCodexTap: onCodexTap,
-                                onPureChatToggleTap: onPureChatToggleTap,
+                        SizedBox(
+                          width: _kChatAppBarRightActionSlotWidth,
+                          height: _kChatAppBarRightActionSlotWidth,
+                          child: Center(
+                            child: _ChatAppBarModeShortcutButton(
+                              key: const ValueKey(
+                                'chat-app-bar-pure-chat-button',
                               ),
+                              iconTint: iconTint,
+                              isCodexLoading: isCodexLoading,
+                              isCodexSelected: isCodexSelected,
+                              isAgentSelected: isAgentSelected,
+                              isPureChatSelected: isPureChatSelected,
+                              isPureChatToggleLocked: isPureChatToggleLocked,
+                              onAgentTap: onAgentTap,
+                              onCodexTap: onCodexTap,
+                              onPureChatToggleTap: onPureChatToggleTap,
                             ),
                           ),
+                        ),
                       ],
                     ),
                   ),
@@ -740,9 +729,7 @@ class _ChatAppBarModeShortcutMenuContent extends StatelessWidget {
       child: OmniGlassPanel(
         // 上边直 + 下半圆 (radius 20 = 半宽),跟上方触发按钮的"上半圆 + 下边直"
         // 在中线 zero-gap 处无缝拼接,整体看上去是一个完整的胶囊。
-        borderRadius: const BorderRadius.vertical(
-          bottom: Radius.circular(20),
-        ),
+        borderRadius: const BorderRadius.vertical(bottom: Radius.circular(20)),
         // 接缝处:省略顶边 1px 边线 + 关闭顶部高光条,
         // 否则与上方触发按钮的下边线会叠成可见的横线。
         omitTopBorder: true,
@@ -755,6 +742,9 @@ class _ChatAppBarModeShortcutMenuContent extends StatelessWidget {
             children: [
               for (final item in items)
                 _ChatAppBarModeShortcutMenuRow(
+                  key: ValueKey(
+                    'chat-app-bar-mode-menu-${_chatModeShortcutActionSlug(item.action)}',
+                  ),
                   item: item,
                   selectedColor: selectedColor,
                   iconTint: iconTint,
@@ -768,8 +758,17 @@ class _ChatAppBarModeShortcutMenuContent extends StatelessWidget {
   }
 }
 
+String _chatModeShortcutActionSlug(_ChatAppBarModeShortcutAction action) {
+  return switch (action) {
+    _ChatAppBarModeShortcutAction.agent => 'agent',
+    _ChatAppBarModeShortcutAction.codex => 'codex',
+    _ChatAppBarModeShortcutAction.pureChat => 'pure-chat',
+  };
+}
+
 class _ChatAppBarModeShortcutMenuRow extends StatelessWidget {
   const _ChatAppBarModeShortcutMenuRow({
+    super.key,
     required this.item,
     required this.selectedColor,
     required this.iconTint,
@@ -809,14 +808,11 @@ class _ChatAppBarModeShortcutMenuRow extends StatelessWidget {
   }
 }
 
-class _ChatModeModelSwitcher extends StatefulWidget {
-  const _ChatModeModelSwitcher({
+class _ChatIslandSwitcher extends StatefulWidget {
+  const _ChatIslandSwitcher({
     required this.activeMode,
     required this.onModeChanged,
-    this.activeModelId,
-    this.onModelTap,
     required this.displayLayer,
-    this.onInteracted,
     required this.onDisplayLayerChanged,
     required this.onTerminalEnvironmentTap,
     required this.onTerminalTap,
@@ -833,10 +829,7 @@ class _ChatModeModelSwitcher extends StatefulWidget {
 
   final ChatSurfaceMode activeMode;
   final ValueChanged<ChatSurfaceMode> onModeChanged;
-  final String? activeModelId;
-  final ValueChanged<BuildContext>? onModelTap;
   final ChatIslandDisplayLayer displayLayer;
-  final VoidCallback? onInteracted;
   final ValueChanged<ChatIslandDisplayLayer> onDisplayLayerChanged;
   final ValueChanged<BuildContext> onTerminalEnvironmentTap;
   final VoidCallback onTerminalTap;
@@ -851,10 +844,10 @@ class _ChatModeModelSwitcher extends StatefulWidget {
   final VoidCallback? onPrimaryModeTap;
 
   @override
-  State<_ChatModeModelSwitcher> createState() => _ChatModeModelSwitcherState();
+  State<_ChatIslandSwitcher> createState() => _ChatIslandSwitcherState();
 }
 
-class _ChatModeModelSwitcherState extends State<_ChatModeModelSwitcher> {
+class _ChatIslandSwitcherState extends State<_ChatIslandSwitcher> {
   static const String _terminalIconAsset = 'assets/home/chat/terminal.svg';
   static const String _browserIconAsset = 'assets/home/chat/browser.svg';
   static const String _environmentIconAsset =
@@ -866,87 +859,26 @@ class _ChatModeModelSwitcherState extends State<_ChatModeModelSwitcher> {
   static const double _offstageLayerGap = 2;
 
   double _verticalDragDelta = 0;
-  double _horizontalDragDelta = 0;
 
-  int get _activeVisibleModeIndex {
-    final index = kVisibleChatSurfaceModes.indexOf(widget.activeMode);
-    if (index >= 0) {
-      return index;
-    }
-    return 0;
-  }
-
-  String get _modelLabel {
-    final text = (widget.activeModelId ?? '').trim();
-    if (text.isEmpty) {
-      return LegacyTextLocalizer.isEnglish ? 'No model set' : '未设置模型';
-    }
-    return text;
-  }
-
-  bool get _canRevealModelLabel =>
-      widget.activeMode == ChatSurfaceMode.normal &&
-      (widget.activeModelId ?? '').trim().isNotEmpty;
-
-  List<ChatIslandDisplayLayer> get _visibleLayers => widget.showSurfaceLayer
-      ? const <ChatIslandDisplayLayer>[
-          ChatIslandDisplayLayer.tools,
-          ChatIslandDisplayLayer.model,
-          ChatIslandDisplayLayer.mode,
-        ]
-      : const <ChatIslandDisplayLayer>[
-          ChatIslandDisplayLayer.tools,
-          ChatIslandDisplayLayer.model,
-        ];
+  List<ChatIslandDisplayLayer> get _visibleLayers =>
+      const <ChatIslandDisplayLayer>[
+        ChatIslandDisplayLayer.tools,
+        ChatIslandDisplayLayer.mode,
+      ];
 
   ChatIslandDisplayLayer get _effectiveDisplayLayer =>
       _visibleLayers.contains(widget.displayLayer)
       ? widget.displayLayer
-      : ChatIslandDisplayLayer.model;
+      : _visibleLayers.last;
 
   int _layerOrder(ChatIslandDisplayLayer layer) =>
       _visibleLayers.indexOf(layer);
 
-  void _handleSliderInteraction() {
-    widget.onInteracted?.call();
-  }
-
-  void _handleHorizontalDragUpdate(DragUpdateDetails details) {
-    if (!widget.showSurfaceLayer ||
-        widget.activeMode != ChatSurfaceMode.normal ||
-        widget.displayLayer != ChatIslandDisplayLayer.model) {
-      return;
-    }
-    _horizontalDragDelta += details.delta.dx;
-  }
-
-  void _handleHorizontalDragEnd(DragEndDetails details) {
-    if (!widget.showSurfaceLayer ||
-        widget.activeMode != ChatSurfaceMode.normal ||
-        widget.displayLayer != ChatIslandDisplayLayer.model) {
-      _horizontalDragDelta = 0;
-      return;
-    }
-    final velocity = details.primaryVelocity ?? 0;
-    final shouldSwitch =
-        _horizontalDragDelta.abs() > 14 || velocity.abs() > 250;
-    if (!shouldSwitch) {
-      _horizontalDragDelta = 0;
-      return;
-    }
-    final intent = _horizontalDragDelta + velocity * 0.015;
-    _horizontalDragDelta = 0;
-    final currentIndex = _activeVisibleModeIndex;
-    final delta = intent > 0 ? 1 : -1;
-    final targetIndex = (currentIndex + delta).clamp(
-      0,
-      kVisibleChatSurfaceModes.length - 1,
-    );
-    widget.onInteracted?.call();
-    widget.onModeChanged(kVisibleChatSurfaceModes[targetIndex]);
-  }
-
   void _handleVerticalDragUpdate(DragUpdateDetails details) {
+    if (widget.activeMode != ChatSurfaceMode.normal ||
+        _visibleLayers.length < 2) {
+      return;
+    }
     _verticalDragDelta += details.delta.dy;
   }
 
@@ -965,58 +897,23 @@ class _ChatModeModelSwitcherState extends State<_ChatModeModelSwitcher> {
     if (widget.activeMode != ChatSurfaceMode.normal) {
       return;
     }
-    widget.onInteracted?.call();
-    if (intent > 0) {
-      if (_effectiveDisplayLayer != ChatIslandDisplayLayer.tools) {
-        widget.onDisplayLayerChanged(ChatIslandDisplayLayer.tools);
-      }
-      return;
-    }
-    if ((_canRevealModelLabel || !widget.showSurfaceLayer) &&
-        _effectiveDisplayLayer != ChatIslandDisplayLayer.model) {
-      widget.onDisplayLayerChanged(ChatIslandDisplayLayer.model);
+    final targetLayer = intent > 0
+        ? ChatIslandDisplayLayer.tools
+        : ChatIslandDisplayLayer.mode;
+    if (_visibleLayers.contains(targetLayer) &&
+        _effectiveDisplayLayer != targetLayer) {
+      widget.onDisplayLayerChanged(targetLayer);
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final palette = context.omniPalette;
-    final restingLabelColor = widget.translucent
-        ? widget.visualProfile.subtleTextColor
-        : context.isDarkTheme
-        ? palette.textSecondary
-        : const Color(0xFF9DA9BB);
     final islandBaseColor = widget.translucent
         ? palette.surfacePrimary
         : context.isDarkTheme
         ? palette.surfaceSecondary
         : palette.surfacePrimary;
-    final modelLabelWidget = Builder(
-      builder: (anchorContext) {
-        final text = Text(
-          _modelLabel,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 14,
-            color: restingLabelColor,
-            fontWeight: FontWeight.w500,
-          ),
-        );
-        if (widget.onModelTap == null) {
-          return Center(child: text);
-        }
-        return InkWell(
-          onTap: () {
-            widget.onInteracted?.call();
-            widget.onModelTap?.call(anchorContext);
-          },
-          borderRadius: BorderRadius.circular(999),
-          child: Center(child: text),
-        );
-      },
-    );
     final toolLayerWidget = _ChatToolSlider(
       environmentIconAsset: _environmentIconAsset,
       terminalIconAsset: _terminalIconAsset,
@@ -1024,21 +921,29 @@ class _ChatModeModelSwitcherState extends State<_ChatModeModelSwitcher> {
       activeToolType: widget.activeToolType,
       hasTerminalEnvironment: widget.hasTerminalEnvironment,
       onTerminalEnvironmentTap: (anchorContext) {
-        widget.onInteracted?.call();
         widget.onTerminalEnvironmentTap(anchorContext);
       },
       isBrowserEnabled: widget.isBrowserEnabled,
       onTerminalTap: () {
-        widget.onInteracted?.call();
         widget.onTerminalTap();
       },
       onBrowserTap: () {
-        widget.onInteracted?.call();
         widget.onBrowserTap();
       },
-      onInteracted: _handleSliderInteraction,
       visualProfile: widget.visualProfile,
     );
+    final modeLayerWidget = widget.showSurfaceLayer
+        ? ChatModeSlider(
+            activeMode: widget.activeMode,
+            onChanged: widget.onModeChanged,
+            visualProfile: widget.visualProfile,
+            primaryIconAsset: widget.primaryModeIconAsset,
+            onPrimaryModeTap: widget.onPrimaryModeTap,
+          )
+        : _ChatSingleModePill(
+            iconAsset: widget.primaryModeIconAsset,
+            onTap: widget.onPrimaryModeTap,
+          );
     final currentOrder = _layerOrder(_effectiveDisplayLayer);
 
     double topFor(ChatIslandDisplayLayer layer) {
@@ -1068,8 +973,6 @@ class _ChatModeModelSwitcherState extends State<_ChatModeModelSwitcher> {
           height: _switcherHeight,
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
-            onHorizontalDragUpdate: _handleHorizontalDragUpdate,
-            onHorizontalDragEnd: _handleHorizontalDragEnd,
             onVerticalDragUpdate: _handleVerticalDragUpdate,
             onVerticalDragEnd: _handleVerticalDragEnd,
             onVerticalDragCancel: () {
@@ -1086,27 +989,7 @@ class _ChatModeModelSwitcherState extends State<_ChatModeModelSwitcher> {
                   right: 0,
                   height: _switcherHeight,
                   top: topFor(ChatIslandDisplayLayer.mode),
-                  child: widget.showSurfaceLayer
-                      ? ClipRect(
-                          child: ChatModeSlider(
-                            activeMode: widget.activeMode,
-                            onChanged: widget.onModeChanged,
-                            onInteracted: _handleSliderInteraction,
-                            visualProfile: widget.visualProfile,
-                            primaryIconAsset: widget.primaryModeIconAsset,
-                            onPrimaryModeTap: widget.onPrimaryModeTap,
-                          ),
-                        )
-                      : const SizedBox.shrink(),
-                ),
-                AnimatedPositioned(
-                  duration: _switchDuration,
-                  curve: Curves.easeInOutCubicEmphasized,
-                  left: 0,
-                  right: 0,
-                  height: _switcherHeight,
-                  top: topFor(ChatIslandDisplayLayer.model),
-                  child: modelLabelWidget,
+                  child: ClipRect(child: modeLayerWidget),
                 ),
                 AnimatedPositioned(
                   duration: _switchDuration,
@@ -1136,7 +1019,6 @@ class _ChatToolSlider extends StatelessWidget {
   final bool isBrowserEnabled;
   final VoidCallback onTerminalTap;
   final VoidCallback onBrowserTap;
-  final VoidCallback? onInteracted;
   final AppBackgroundVisualProfile visualProfile;
 
   const _ChatToolSlider({
@@ -1149,7 +1031,6 @@ class _ChatToolSlider extends StatelessWidget {
     this.isBrowserEnabled = false,
     required this.onTerminalTap,
     required this.onBrowserTap,
-    this.onInteracted,
     this.visualProfile = AppBackgroundVisualProfile.defaultProfile,
   });
 
@@ -1255,10 +1136,7 @@ class _ChatToolSlider extends StatelessWidget {
               : '管理终端环境变量',
           child: InkWell(
             key: const ValueKey('chat-island-terminal-env-button'),
-            onTap: () {
-              onInteracted?.call();
-              onTerminalEnvironmentTap(anchorContext);
-            },
+            onTap: () => onTerminalEnvironmentTap(anchorContext),
             borderRadius: BorderRadius.circular(999),
             child: SizedBox.expand(
               child: AnimatedContainer(
@@ -1307,12 +1185,7 @@ class _ChatToolSlider extends StatelessWidget {
       message: tooltip,
       child: InkWell(
         key: key,
-        onTap: isEnabled
-            ? () {
-                onInteracted?.call();
-                onTap();
-              }
-            : null,
+        onTap: isEnabled ? onTap : null,
         borderRadius: BorderRadius.circular(999),
         child: Center(
           child: AnimatedScale(
@@ -1330,10 +1203,57 @@ class _ChatToolSlider extends StatelessWidget {
   }
 }
 
+class _ChatSingleModePill extends StatelessWidget {
+  const _ChatSingleModePill({required this.iconAsset, this.onTap});
+
+  final String iconAsset;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final activeGradient = context.isDarkTheme
+        ? _kDarkChatAccentGradient
+        : const <Color>[Color(0xFF2DA5F0), Color(0xFF1930D9)];
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        height: 32,
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          color: Colors.transparent,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: activeGradient,
+            ),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Center(
+            child: SvgPicture.asset(
+              iconAsset,
+              key: const ValueKey('chat-island-single-mode-icon'),
+              width: 16,
+              height: 16,
+              colorFilter: ColorFilter.mode(
+                Theme.of(context).colorScheme.onPrimary,
+                BlendMode.srcIn,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class ChatModeSlider extends StatefulWidget {
   final ChatSurfaceMode activeMode;
   final ValueChanged<ChatSurfaceMode> onChanged;
-  final VoidCallback? onInteracted;
   final AppBackgroundVisualProfile visualProfile;
   final String primaryIconAsset;
   final VoidCallback? onPrimaryModeTap;
@@ -1342,7 +1262,6 @@ class ChatModeSlider extends StatefulWidget {
     super.key,
     required this.activeMode,
     required this.onChanged,
-    this.onInteracted,
     this.visualProfile = AppBackgroundVisualProfile.defaultProfile,
     this.primaryIconAsset = _kChatAppBarAgentIconAsset,
     this.onPrimaryModeTap,
@@ -1392,14 +1311,11 @@ class _ChatModeSliderState extends State<ChatModeSlider> {
       behavior: HitTestBehavior.opaque,
       onHorizontalDragUpdate: (details) {
         _dragDelta += details.delta.dx;
-        widget.onInteracted?.call();
       },
       onHorizontalDragEnd: (details) {
-        widget.onInteracted?.call();
         _handleDragEnd(velocity: details.primaryVelocity ?? 0);
       },
       onTapUp: (details) {
-        widget.onInteracted?.call();
         final box = context.findRenderObject() as RenderBox?;
         if (box == null || !box.hasSize) return;
         final local = box.globalToLocal(details.globalPosition);
@@ -2470,6 +2386,7 @@ class ChatInputWrapper extends StatelessWidget {
   final String? contextUsageTooltipMessage;
   final VoidCallback? onLongPressContextUsageRing;
   final ValueChanged<double>? onInputHeightChanged;
+  final ChatModelPickerSettings? modelPickerSettings;
   final CodexRunSettings? codexRunSettings;
   final CodexRunSettingsChanged? onCodexRunSettingsChanged;
   final FutureOr<void> Function()? onCodexRunSettingsOpened;
@@ -2504,6 +2421,7 @@ class ChatInputWrapper extends StatelessWidget {
     this.contextUsageTooltipMessage,
     this.onLongPressContextUsageRing,
     this.onInputHeightChanged,
+    this.modelPickerSettings,
     this.codexRunSettings,
     this.onCodexRunSettingsChanged,
     this.onCodexRunSettingsOpened,
@@ -2546,6 +2464,7 @@ class ChatInputWrapper extends StatelessWidget {
             contextUsageRatio: contextUsageRatio,
             contextUsageTooltipMessage: contextUsageTooltipMessage,
             onLongPressContextUsageRing: onLongPressContextUsageRing,
+            modelPickerSettings: modelPickerSettings,
             codexRunSettings: codexRunSettings,
             onCodexRunSettingsChanged: onCodexRunSettingsChanged,
             onCodexRunSettingsOpened: onCodexRunSettingsOpened,

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
@@ -58,6 +58,18 @@ class CodexRunSettings {
   final String? modelListError;
 }
 
+class ChatModelPickerSettings {
+  const ChatModelPickerSettings({
+    required this.modelId,
+    required this.hasSelectableModels,
+    required this.onOpen,
+  });
+
+  final String modelId;
+  final bool hasSelectableModels;
+  final FutureOr<void> Function(BuildContext anchorContext) onOpen;
+}
+
 class ChatInputAttachment {
   final String id;
   final String name;
@@ -120,6 +132,7 @@ class ChatInputArea extends StatefulWidget {
   final double? contextUsageRatio;
   final String? contextUsageTooltipMessage;
   final VoidCallback? onLongPressContextUsageRing;
+  final ChatModelPickerSettings? modelPickerSettings;
   final CodexRunSettings? codexRunSettings;
   final CodexRunSettingsChanged? onCodexRunSettingsChanged;
   final FutureOr<void> Function()? onCodexRunSettingsOpened;
@@ -152,6 +165,7 @@ class ChatInputArea extends StatefulWidget {
     this.contextUsageRatio,
     this.contextUsageTooltipMessage,
     this.onLongPressContextUsageRing,
+    this.modelPickerSettings,
     this.codexRunSettings,
     this.onCodexRunSettingsChanged,
     this.onCodexRunSettingsOpened,
@@ -634,7 +648,8 @@ abstract class _ChatInputAreaStateBase extends State<ChatInputArea>
     if (oldWidget.attachments != widget.attachments ||
         oldWidget.useLargeComposerStyle != widget.useLargeComposerStyle ||
         oldWidget.useFrostedGlass != widget.useFrostedGlass ||
-        oldWidget.selectedModelOverrideId != widget.selectedModelOverrideId) {
+        oldWidget.selectedModelOverrideId != widget.selectedModelOverrideId ||
+        oldWidget.modelPickerSettings != widget.modelPickerSettings) {
       _reportInputHeightAfterBuild();
     }
   }

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
@@ -44,6 +44,9 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
   final GlobalKey _codexRunSettingsButtonKey = GlobalKey(
     debugLabel: 'codex-run-settings-button',
   );
+  final GlobalKey _modelPickerButtonKey = GlobalKey(
+    debugLabel: 'chat-model-picker-button',
+  );
   final GlobalKey _codexPermissionButtonKey = GlobalKey(
     debugLabel: 'codex-permission-button',
   );
@@ -195,6 +198,10 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
       ],
       if (_shouldShowCodexRunSettingsSelector) ...[
         _buildCodexRunSettingsButton(compact: false),
+        const SizedBox(width: 4),
+      ],
+      if (_shouldShowModelPicker) ...[
+        _buildModelPickerButton(compact: false),
         const SizedBox(width: 4),
       ],
       if (_shouldShowCodexPermissionSelector) ...[
@@ -712,6 +719,10 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
           _buildCodexRunSettingsButton(compact: true),
           const SizedBox(width: 2),
         ],
+        if (_shouldShowModelPicker) ...[
+          _buildModelPickerButton(compact: true),
+          const SizedBox(width: 2),
+        ],
         if (_shouldShowCodexPermissionSelector) ...[
           SizedBox(
             width: 24,
@@ -740,6 +751,83 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
       widget.codexRunSettings != null &&
       widget.onCodexRunSettingsChanged != null;
 
+  bool get _shouldShowModelPicker => widget.modelPickerSettings != null;
+
+  Widget _buildModelPickerButton({required bool compact}) {
+    final settings = widget.modelPickerSettings!;
+    final palette = context.omniPalette;
+    final modelId = settings.modelId.trim();
+    final english = Localizations.localeOf(context).languageCode == 'en';
+    final selectedColor = palette.accentPrimary;
+    final enabled = settings.hasSelectableModels;
+    final displayText = modelId.isEmpty
+        ? (english ? 'Model' : '模型')
+        : _shortModelLabel(modelId, maxLength: compact ? 14 : 16);
+
+    Future<void> openPicker() async {
+      final anchorContext = _modelPickerButtonKey.currentContext;
+      if (anchorContext == null || !enabled) {
+        return;
+      }
+      await Future<void>.sync(() => settings.onOpen(anchorContext));
+    }
+
+    return SizedBox(
+      key: _modelPickerButtonKey,
+      width: compact ? 92 : 118,
+      height: compact ? 24 : 28,
+      child: Tooltip(
+        message: modelId.isEmpty
+            ? (english ? 'Select model' : '选择模型')
+            : modelId,
+        waitDuration: const Duration(milliseconds: 400),
+        child: InkWell(
+          key: const ValueKey('chat-input-model-picker-button'),
+          borderRadius: BorderRadius.circular(8),
+          onTap: enabled ? openPicker : null,
+          child: AnimatedContainer(
+            duration: _buttonAnimationDuration,
+            curve: _buttonAnimationCurve,
+            height: compact ? 24 : 28,
+            padding: EdgeInsets.only(
+              left: compact ? 4 : 6,
+              right: compact ? 2 : 4,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Expanded(
+                  child: Text(
+                    displayText,
+                    textAlign: TextAlign.right,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: enabled
+                          ? selectedColor
+                          : palette.textTertiary.withValues(alpha: 0.82),
+                      fontSize: compact ? 11 : 12,
+                      height: 1.1,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 2),
+                Icon(
+                  Icons.expand_more_rounded,
+                  size: compact ? 14 : 16,
+                  color: enabled
+                      ? selectedColor
+                      : palette.textTertiary.withValues(alpha: 0.82),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildCodexRunSettingsButton({required bool compact}) {
     final settings = widget.codexRunSettings!;
     final palette = context.omniPalette;
@@ -750,7 +838,7 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
         ? (settings.isLoadingModels
               ? (english ? 'Loading' : '加载中')
               : (english ? 'Model' : '模型'))
-        : _shortCodexModelLabel(modelId);
+        : _shortModelLabel(modelId);
     final displayEffort = effort.isEmpty
         ? ''
         : _codexReasoningEffortLabel(effort, compact: true);
@@ -894,19 +982,22 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
     };
   }
 
-  String _shortCodexModelLabel(String modelId) {
+  String _shortModelLabel(String modelId, {int maxLength = 22}) {
     final normalized = modelId.trim();
-    if (normalized.length <= 22) {
+    if (normalized.length <= maxLength) {
       return normalized;
     }
     final parts = normalized.split(RegExp(r'[-_/]'));
     if (parts.length >= 3) {
       final compact = parts.take(4).join('-');
-      if (compact.length <= 22) {
+      if (compact.length <= maxLength) {
         return compact;
       }
     }
-    return '${normalized.substring(0, 19)}...';
+    final prefix = normalized
+        .substring(0, math.max(1, maxLength - 3))
+        .replaceFirst(RegExp(r'[-_/]+$'), '');
+    return '$prefix...';
   }
 
   List<String> _codexRunSettingsOptions({
@@ -1275,7 +1366,6 @@ class _CodexPermissionOptionData {
   final String label;
   final String iconAsset;
 }
-
 
 class _CodexPermissionGlassMenuContent extends StatefulWidget {
   const _CodexPermissionGlassMenuContent({

--- a/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
+++ b/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
@@ -950,14 +950,6 @@ extension _HomeDrawerConversationList on HomeDrawerState {
                 ? palette.surfaceSecondary
                 : Colors.white,
             shape: BoxShape.circle,
-            boxShadow: [
-              if (!isPrimary && !context.isDarkTheme)
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.05),
-                  blurRadius: 4,
-                  offset: const Offset(0, 2),
-                ),
-            ],
           ),
           padding: const EdgeInsets.all(8),
           child: SvgPicture.asset(

--- a/ui/lib/features/home/widgets/home_drawer_header_footer.dart
+++ b/ui/lib/features/home/widgets/home_drawer_header_footer.dart
@@ -99,15 +99,6 @@ extension _HomeDrawerHeaderFooter on HomeDrawerState {
                 decoration: BoxDecoration(
                   color: circleColor,
                   shape: BoxShape.circle,
-                  boxShadow: context.isDarkTheme
-                      ? const []
-                      : [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.04),
-                            blurRadius: 10,
-                            offset: const Offset(0, 3),
-                          ),
-                        ],
                 ),
                 alignment: Alignment.center,
                 child: icon,

--- a/ui/lib/features/home/widgets/home_drawer_search_field.dart
+++ b/ui/lib/features/home/widgets/home_drawer_search_field.dart
@@ -44,29 +44,6 @@ class HomeDrawerSearchField extends StatelessWidget {
       decoration: BoxDecoration(
         color: backgroundColor,
         borderRadius: BorderRadius.circular(18),
-        boxShadow: context.isDarkTheme
-            ? [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: hasFocus ? 0.18 : 0.12),
-                  blurRadius: hasFocus ? 14 : 10,
-                  offset: const Offset(0, 4),
-                ),
-                if (hasFocus)
-                  BoxShadow(
-                    color: palette.accentPrimary.withValues(alpha: 0.12),
-                    blurRadius: 12,
-                    spreadRadius: -2,
-                  ),
-              ]
-            : [
-                BoxShadow(
-                  color: palette.shadowColor.withValues(
-                    alpha: hasFocus ? 0.18 : 0.08,
-                  ),
-                  blurRadius: hasFocus ? 14 : 10,
-                  offset: const Offset(0, 3),
-                ),
-              ],
       ),
       child: TextField(
         controller: controller,

--- a/ui/lib/widgets/app_update_dialog.dart
+++ b/ui/lib/widgets/app_update_dialog.dart
@@ -162,6 +162,9 @@ class _InfoRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final palette = context.omniPalette;
+    final labelColor = context.isDarkTheme
+        ? palette.textTertiary
+        : const Color(0xFF5F6F89);
     return Row(
       children: [
         SizedBox(
@@ -170,7 +173,7 @@ class _InfoRow extends StatelessWidget {
             label,
             style: TextStyle(
               fontSize: 12,
-              color: palette.textTertiary,
+              color: labelColor,
               fontWeight: FontWeight.w500,
             ),
           ),

--- a/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
+++ b/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
@@ -1842,10 +1842,17 @@ void main() {
     final reused = coordinator.ensureRuntime(
       conversationId: conversationId,
       mode: kChatRuntimeModeNormal,
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.model,
+      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.tools,
     );
 
     expect(identical(runtime, reused), isTrue);
     expect(reused.chatIslandDisplayLayer, ChatIslandDisplayLayer.mode);
+  });
+
+  test('maps legacy model island layer wire value to tools', () {
+    expect(
+      ChatIslandDisplayLayer.fromWireName('model'),
+      ChatIslandDisplayLayer.tools,
+    );
   });
 }

--- a/ui/test/features/home/pages/chat/widgets/chat_app_bar_test.dart
+++ b/ui/test/features/home/pages/chat/widgets/chat_app_bar_test.dart
@@ -1,8 +1,6 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -31,17 +29,20 @@ class _SvgTestAssetBundle extends CachingAssetBundle {
 }
 
 class _ChatAppBarHarness extends StatefulWidget {
-  const _ChatAppBarHarness();
+  const _ChatAppBarHarness({this.showSurfaceSwitcher = true});
+
+  final bool showSurfaceSwitcher;
 
   @override
   State<_ChatAppBarHarness> createState() => _ChatAppBarHarnessState();
 }
 
 class _ChatAppBarHarnessState extends State<_ChatAppBarHarness> {
-  ChatIslandDisplayLayer _displayLayer = ChatIslandDisplayLayer.model;
+  ChatIslandDisplayLayer _displayLayer = ChatIslandDisplayLayer.mode;
   ChatSurfaceMode _activeMode = ChatSurfaceMode.normal;
   int _browserTapCount = 0;
   int _envTapCount = 0;
+  int _terminalTapCount = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -60,7 +61,6 @@ class _ChatAppBarHarnessState extends State<_ChatAppBarHarness> {
                     _activeMode = value;
                   });
                 },
-                activeModelId: 'gpt-5.4',
                 displayLayer: _displayLayer,
                 onDisplayLayerChanged: (value) {
                   setState(() {
@@ -72,7 +72,11 @@ class _ChatAppBarHarnessState extends State<_ChatAppBarHarness> {
                     _envTapCount += 1;
                   });
                 },
-                onTerminalTap: () {},
+                onTerminalTap: () {
+                  setState(() {
+                    _terminalTapCount += 1;
+                  });
+                },
                 onBrowserTap: () {
                   setState(() {
                     _browserTapCount += 1;
@@ -81,10 +85,13 @@ class _ChatAppBarHarnessState extends State<_ChatAppBarHarness> {
                 hasTerminalEnvironment: true,
                 isBrowserEnabled: false,
                 activeToolType: null,
+                showSurfaceSwitcher: widget.showSurfaceSwitcher,
               ),
+              Text('active:${_activeMode.name}'),
               Text('layer:${_displayLayer.wireName}'),
               Text('browserTaps:$_browserTapCount'),
               Text('envTaps:$_envTapCount'),
+              Text('terminalTaps:$_terminalTapCount'),
             ],
           ),
         ),
@@ -146,8 +153,7 @@ class _PureChatToggleHarnessState extends State<_PureChatToggleHarness> {
                 onCompanionTap: () {},
                 activeMode: ChatSurfaceMode.normal,
                 onModeChanged: (_) {},
-                activeModelId: 'gpt-5.4',
-                displayLayer: ChatIslandDisplayLayer.model,
+                displayLayer: ChatIslandDisplayLayer.mode,
                 onDisplayLayerChanged: (_) {},
                 onTerminalEnvironmentTap: (_) {},
                 onTerminalTap: () {},
@@ -182,19 +188,12 @@ class _SurfaceTransitionHarness extends StatefulWidget {
 }
 
 class _SurfaceTransitionHarnessState extends State<_SurfaceTransitionHarness> {
-  static const Duration _revealDelay = Duration(milliseconds: 1700);
-
   late final PageController _pageController = PageController(
     initialPage: _pageIndexForSurface(ChatSurfaceMode.openclaw),
   );
   ChatSurfaceMode _activeMode = ChatSurfaceMode.openclaw;
-  ChatIslandDisplayLayer _normalDisplayLayer = ChatIslandDisplayLayer.model;
-  Timer? _revealTimer;
-  bool _revealInterrupted = false;
-  bool _isSurfacePageScrolling = false;
+  ChatIslandDisplayLayer _normalDisplayLayer = ChatIslandDisplayLayer.mode;
   int _surfaceSwitchRequestId = 0;
-  int? _pageGesturePointerId;
-  double _pageVerticalDragDelta = 0;
 
   int _pageIndexForSurface(ChatSurfaceMode mode) => switch (mode) {
     ChatSurfaceMode.normal => 0,
@@ -208,149 +207,24 @@ class _SurfaceTransitionHarnessState extends State<_SurfaceTransitionHarness> {
     _ => ChatSurfaceMode.normal,
   };
 
-  void _cancelReveal() {
-    _revealTimer?.cancel();
-    _revealTimer = null;
-  }
-
-  void _interruptReveal() {
-    _cancelReveal();
-    _revealInterrupted = true;
-  }
-
-  void _forceNormalModeLayer() {
-    _normalDisplayLayer = ChatIslandDisplayLayer.mode;
-  }
-
-  bool _canRevealModel() {
-    return _activeMode == ChatSurfaceMode.normal &&
-        !_isSurfacePageScrolling &&
-        !_revealInterrupted &&
-        _normalDisplayLayer == ChatIslandDisplayLayer.mode;
-  }
-
-  void _scheduleReveal() {
-    _cancelReveal();
-    if (!_canRevealModel()) {
-      return;
-    }
-    _revealTimer = Timer(_revealDelay, () {
-      _revealTimer = null;
-      if (!mounted || !_canRevealModel()) {
-        return;
-      }
-      setState(() {
-        _normalDisplayLayer = ChatIslandDisplayLayer.model;
-      });
-    });
-  }
-
-  void _handleSurfaceScrollStart() {
-    _cancelReveal();
-    if (!mounted) {
-      _isSurfacePageScrolling = true;
-      _forceNormalModeLayer();
-      return;
-    }
-    if (_isSurfacePageScrolling &&
-        _normalDisplayLayer == ChatIslandDisplayLayer.mode) {
-      return;
-    }
-    setState(() {
-      _isSurfacePageScrolling = true;
-      _forceNormalModeLayer();
-    });
-  }
-
-  void _handleSurfaceScrollSettled(ChatSurfaceMode mode) {
-    _cancelReveal();
-    if (!mounted) {
-      _isSurfacePageScrolling = false;
-      if (mode == ChatSurfaceMode.normal) {
-        _revealInterrupted = false;
-        _forceNormalModeLayer();
-      }
-      return;
-    }
-    final shouldSetState =
-        _isSurfacePageScrolling ||
-        (mode == ChatSurfaceMode.normal &&
-            _normalDisplayLayer != ChatIslandDisplayLayer.mode);
-    if (shouldSetState) {
-      setState(() {
-        _isSurfacePageScrolling = false;
-        if (mode == ChatSurfaceMode.normal) {
-          _revealInterrupted = false;
-          _forceNormalModeLayer();
-        }
-      });
-    } else {
-      _isSurfacePageScrolling = false;
-      if (mode == ChatSurfaceMode.normal) {
-        _revealInterrupted = false;
-      }
-    }
-    if (mode == ChatSurfaceMode.normal) {
-      _scheduleReveal();
-    }
-  }
-
-  bool _handleScrollNotification(ScrollNotification notification) {
-    if (notification.depth != 0 ||
-        notification.metrics.axis != Axis.horizontal) {
-      return false;
-    }
-    if (notification is ScrollStartNotification) {
-      _handleSurfaceScrollStart();
-      return false;
-    }
-    if (notification is UserScrollNotification) {
-      final direction = notification.direction;
-      if (direction == ScrollDirection.forward ||
-          direction == ScrollDirection.reverse) {
-        _handleSurfaceScrollStart();
-      }
-      return false;
-    }
-    if (notification is ScrollEndNotification) {
-      final pageMetrics = notification.metrics;
-      final rawPage = pageMetrics is PageMetrics
-          ? pageMetrics.page
-          : (_pageController.hasClients ? _pageController.page : null);
-      final settledIndex =
-          (rawPage ?? _pageIndexForSurface(_activeMode).toDouble()).round();
-      _handleSurfaceScrollSettled(_surfaceForPageIndex(settledIndex));
-    }
-    return false;
-  }
-
   Future<void> _switchMode(
     ChatSurfaceMode targetMode, {
     bool syncPage = true,
   }) async {
     final requestId = ++_surfaceSwitchRequestId;
     bool isStaleRequest() => !mounted || requestId != _surfaceSwitchRequestId;
-    if (_activeMode == targetMode) {
-      if (targetMode == ChatSurfaceMode.normal && !syncPage) {
-        _scheduleReveal();
-      }
-      return;
-    }
+    if (_activeMode == targetMode) return;
 
-    _cancelReveal();
     final delay = widget.applyDelayByMode[targetMode] ?? Duration.zero;
     if (delay > Duration.zero) {
       await Future<void>.delayed(delay);
     }
-    if (isStaleRequest()) {
-      return;
-    }
+    if (isStaleRequest()) return;
 
     setState(() {
       _activeMode = targetMode;
-      if (targetMode == ChatSurfaceMode.normal) {
-        _revealInterrupted = false;
-        _forceNormalModeLayer();
+      if (targetMode == ChatSurfaceMode.workspace) {
+        _normalDisplayLayer = ChatIslandDisplayLayer.mode;
       }
     });
     if (syncPage) {
@@ -359,64 +233,20 @@ class _SurfaceTransitionHarnessState extends State<_SurfaceTransitionHarness> {
         duration: const Duration(milliseconds: 240),
         curve: Curves.easeOutCubic,
       );
-      return;
-    }
-    if (targetMode == ChatSurfaceMode.normal && !_isSurfacePageScrolling) {
-      _scheduleReveal();
     }
   }
 
   @override
   void dispose() {
-    _cancelReveal();
     _pageController.dispose();
     super.dispose();
   }
 
-  void _handlePagePointerDown(PointerDownEvent event) {
-    _pageGesturePointerId = event.pointer;
-    _pageVerticalDragDelta = 0;
-  }
-
-  void _handlePagePointerMove(PointerMoveEvent event) {
-    if (event.pointer != _pageGesturePointerId ||
-        _activeMode != ChatSurfaceMode.normal) {
-      return;
-    }
-    _pageVerticalDragDelta += event.delta.dy;
-    if (_revealTimer != null &&
-        !_revealInterrupted &&
-        _pageVerticalDragDelta.abs() >= 6) {
-      _interruptReveal();
-    }
-  }
-
-  void _handlePagePointerUp(PointerUpEvent event) {
-    if (event.pointer != _pageGesturePointerId) {
-      return;
-    }
-    if (_activeMode == ChatSurfaceMode.normal &&
-        _pageVerticalDragDelta.abs() >= 18) {
-      setState(() {
-        _normalDisplayLayer = _pageVerticalDragDelta > 0
-            ? ChatIslandDisplayLayer.tools
-            : ChatIslandDisplayLayer.model;
-      });
-    }
-    _pageGesturePointerId = null;
-    _pageVerticalDragDelta = 0;
-  }
-
-  void _handlePagePointerCancel(PointerCancelEvent event) {
-    if (event.pointer != _pageGesturePointerId) {
-      return;
-    }
-    _pageGesturePointerId = null;
-    _pageVerticalDragDelta = 0;
-  }
-
   @override
   Widget build(BuildContext context) {
+    final displayLayer = _activeMode == ChatSurfaceMode.normal
+        ? _normalDisplayLayer
+        : ChatIslandDisplayLayer.mode;
     return MaterialApp(
       home: DefaultAssetBundle(
         bundle: _SvgTestAssetBundle(),
@@ -430,13 +260,8 @@ class _SurfaceTransitionHarnessState extends State<_SurfaceTransitionHarness> {
                 onModeChanged: (value) {
                   _switchMode(value);
                 },
-                activeModelId: 'gpt-5.4',
-                displayLayer: _activeMode == ChatSurfaceMode.normal
-                    ? _normalDisplayLayer
-                    : ChatIslandDisplayLayer.mode,
-                onInteracted: _cancelReveal,
+                displayLayer: displayLayer,
                 onDisplayLayerChanged: (value) {
-                  _cancelReveal();
                   setState(() {
                     _normalDisplayLayer = value;
                   });
@@ -449,7 +274,7 @@ class _SurfaceTransitionHarnessState extends State<_SurfaceTransitionHarness> {
                 activeToolType: null,
               ),
               Text('active:${_activeMode.name}'),
-              Text('layer:${_normalDisplayLayer.wireName}'),
+              Text('layer:${displayLayer.wireName}'),
               TextButton(
                 key: const ValueKey('request-normal'),
                 onPressed: () {
@@ -465,169 +290,55 @@ class _SurfaceTransitionHarnessState extends State<_SurfaceTransitionHarness> {
                 child: const Text('request-openclaw'),
               ),
               TextButton(
-                key: const ValueKey('simulate-page-scroll'),
+                key: const ValueKey('request-workspace'),
                 onPressed: () {
-                  _interruptReveal();
+                  _switchMode(ChatSurfaceMode.workspace, syncPage: false);
                 },
-                child: const Text('simulate-page-scroll'),
+                child: const Text('request-workspace'),
               ),
               Expanded(
-                child: Listener(
-                  behavior: HitTestBehavior.translucent,
-                  onPointerDown: _handlePagePointerDown,
-                  onPointerMove: _handlePagePointerMove,
-                  onPointerUp: _handlePagePointerUp,
-                  onPointerCancel: _handlePagePointerCancel,
-                  child: NotificationListener<ScrollNotification>(
-                    onNotification: _handleScrollNotification,
-                    child: PageView(
-                      controller: _pageController,
-                      onPageChanged: (pageIndex) {
-                        _switchMode(
-                          _surfaceForPageIndex(pageIndex),
-                          syncPage: false,
-                        );
-                      },
-                      children: const [
-                        ColoredBox(color: Colors.white),
-                        ColoredBox(color: Colors.white),
-                        ColoredBox(color: Colors.white),
-                      ],
-                    ),
+                child: NotificationListener<ScrollNotification>(
+                  onNotification: (notification) {
+                    if (notification.depth != 0 ||
+                        notification.metrics.axis != Axis.horizontal) {
+                      return false;
+                    }
+                    if (notification is ScrollEndNotification) {
+                      final pageMetrics = notification.metrics;
+                      final rawPage = pageMetrics is PageMetrics
+                          ? pageMetrics.page
+                          : (_pageController.hasClients
+                                ? _pageController.page
+                                : null);
+                      final settledIndex =
+                          (rawPage ??
+                                  _pageIndexForSurface(_activeMode).toDouble())
+                              .round();
+                      _switchMode(
+                        _surfaceForPageIndex(settledIndex),
+                        syncPage: false,
+                      );
+                    }
+                    return false;
+                  },
+                  child: PageView(
+                    controller: _pageController,
+                    onPageChanged: (pageIndex) {
+                      _switchMode(
+                        _surfaceForPageIndex(pageIndex),
+                        syncPage: false,
+                      );
+                    },
+                    children: const [
+                      ColoredBox(color: Colors.white),
+                      ColoredBox(color: Colors.white),
+                      ColoredBox(color: Colors.white),
+                    ],
                   ),
                 ),
               ),
             ],
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _FloatingPanelGestureExclusionHarness extends StatefulWidget {
-  const _FloatingPanelGestureExclusionHarness();
-
-  @override
-  State<_FloatingPanelGestureExclusionHarness> createState() =>
-      _FloatingPanelGestureExclusionHarnessState();
-}
-
-class _FloatingPanelGestureExclusionHarnessState
-    extends State<_FloatingPanelGestureExclusionHarness> {
-  final GlobalKey _panelKey = GlobalKey();
-  ChatIslandDisplayLayer _displayLayer = ChatIslandDisplayLayer.model;
-  int? _pageGesturePointerId;
-  double _pageVerticalDragDelta = 0;
-
-  bool _isPointerInside(GlobalKey key, Offset position) {
-    final context = key.currentContext;
-    if (context == null) {
-      return false;
-    }
-    final renderBox = context.findRenderObject() as RenderBox?;
-    if (renderBox == null || !renderBox.hasSize) {
-      return false;
-    }
-    final rect = renderBox.localToGlobal(Offset.zero) & renderBox.size;
-    return rect.contains(position);
-  }
-
-  void _handlePagePointerDown(PointerDownEvent event) {
-    if (_isPointerInside(_panelKey, event.position)) {
-      _pageGesturePointerId = null;
-      _pageVerticalDragDelta = 0;
-      return;
-    }
-    _pageGesturePointerId = event.pointer;
-    _pageVerticalDragDelta = 0;
-  }
-
-  void _handlePagePointerMove(PointerMoveEvent event) {
-    if (event.pointer != _pageGesturePointerId) {
-      return;
-    }
-    _pageVerticalDragDelta += event.delta.dy;
-  }
-
-  void _handlePagePointerUp(PointerUpEvent event) {
-    if (event.pointer != _pageGesturePointerId) {
-      return;
-    }
-    if (_pageVerticalDragDelta.abs() >= 18) {
-      setState(() {
-        _displayLayer = _pageVerticalDragDelta > 0
-            ? ChatIslandDisplayLayer.tools
-            : ChatIslandDisplayLayer.model;
-      });
-    }
-    _pageGesturePointerId = null;
-    _pageVerticalDragDelta = 0;
-  }
-
-  void _handlePagePointerCancel(PointerCancelEvent event) {
-    if (event.pointer != _pageGesturePointerId) {
-      return;
-    }
-    _pageGesturePointerId = null;
-    _pageVerticalDragDelta = 0;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Column(
-          children: [
-            Text('layer:${_displayLayer.wireName}'),
-            Expanded(
-              child: Listener(
-                behavior: HitTestBehavior.translucent,
-                onPointerDown: _handlePagePointerDown,
-                onPointerMove: _handlePagePointerMove,
-                onPointerUp: _handlePagePointerUp,
-                onPointerCancel: _handlePagePointerCancel,
-                child: Stack(
-                  children: [
-                    Positioned.fill(
-                      child: ColoredBox(
-                        key: const ValueKey('floating-background'),
-                        color: const Color(0xFFF5F7FB),
-                      ),
-                    ),
-                    Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: 32),
-                        child: Material(
-                          key: _panelKey,
-                          elevation: 4,
-                          borderRadius: BorderRadius.circular(16),
-                          color: Colors.white,
-                          child: SizedBox(
-                            width: 240,
-                            height: 180,
-                            child: ListView.builder(
-                              key: const ValueKey('floating-panel'),
-                              padding: const EdgeInsets.symmetric(vertical: 8),
-                              physics: const ClampingScrollPhysics(),
-                              itemCount: 12,
-                              itemBuilder: (context, index) {
-                                return ListTile(
-                                  dense: true,
-                                  title: Text('model-$index'),
-                                );
-                              },
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
         ),
       ),
     );
@@ -649,19 +360,26 @@ Future<void> _pumpSurfaceSwitch(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 260));
 }
 
+Finder _hitTestableIslandToolButton(String key) =>
+    find.byKey(ValueKey<String>(key)).hitTestable();
+
 void _setTestViewport(WidgetTester tester, Size size) {
   tester.view.devicePixelRatio = 1;
   tester.view.physicalSize = size;
 }
 
 void main() {
-  testWidgets('keeps model layer visible by default in normal chat', (
+  testWidgets('keeps dynamic island free of model text in normal chat', (
     tester,
   ) async {
     await tester.pumpWidget(const _ChatAppBarHarness());
 
-    expect(find.text('layer:model'), findsOneWidget);
-    expect(find.text('gpt-5.4'), findsOneWidget);
+    expect(find.text('layer:mode'), findsOneWidget);
+    expect(find.text('gpt-5.4'), findsNothing);
+    expect(
+      _hitTestableIslandToolButton('chat-island-terminal-button'),
+      findsNothing,
+    );
   });
 
   testWidgets('swaps companion shortcut left and mode menu right', (
@@ -693,27 +411,7 @@ void main() {
   testWidgets('uses page background when surface switcher is visible', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: DefaultAssetBundle(
-          bundle: _SvgTestAssetBundle(),
-          child: Scaffold(
-            body: ChatAppBar(
-              onMenuTap: () {},
-              onCompanionTap: () {},
-              activeMode: ChatSurfaceMode.normal,
-              onModeChanged: (_) {},
-              activeModelId: 'gpt-5.4',
-              displayLayer: ChatIslandDisplayLayer.model,
-              onDisplayLayerChanged: (_) {},
-              onTerminalEnvironmentTap: (_) {},
-              onTerminalTap: () {},
-              onBrowserTap: () {},
-            ),
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(const _ChatAppBarHarness());
 
     final appBarContext = tester.element(find.byType(ChatAppBar));
     final rootSurface = tester.widget<ColoredBox>(
@@ -737,8 +435,7 @@ void main() {
               onCompanionTap: () {},
               activeMode: ChatSurfaceMode.normal,
               onModeChanged: (_) {},
-              activeModelId: 'gpt-5.4',
-              displayLayer: ChatIslandDisplayLayer.model,
+              displayLayer: ChatIslandDisplayLayer.mode,
               onDisplayLayerChanged: (_) {},
               onTerminalEnvironmentTap: (_) {},
               onTerminalTap: () {},
@@ -944,8 +641,7 @@ void main() {
               onCompanionTap: () {},
               activeMode: ChatSurfaceMode.normal,
               onModeChanged: (_) {},
-              activeModelId: 'gpt-5.4',
-              displayLayer: ChatIslandDisplayLayer.model,
+              displayLayer: ChatIslandDisplayLayer.mode,
               onDisplayLayerChanged: (_) {},
               onTerminalEnvironmentTap: (_) {},
               onTerminalTap: () {},
@@ -1014,8 +710,7 @@ void main() {
               onCompanionTap: () {},
               activeMode: ChatSurfaceMode.normal,
               onModeChanged: (_) {},
-              activeModelId: 'gpt-5.4',
-              displayLayer: ChatIslandDisplayLayer.model,
+              displayLayer: ChatIslandDisplayLayer.mode,
               onDisplayLayerChanged: (_) {},
               onTerminalEnvironmentTap: (_) {},
               onTerminalTap: () {},
@@ -1044,8 +739,7 @@ void main() {
               onCompanionTap: () {},
               activeMode: ChatSurfaceMode.normal,
               onModeChanged: (_) {},
-              activeModelId: 'gpt-5.4',
-              displayLayer: ChatIslandDisplayLayer.model,
+              displayLayer: ChatIslandDisplayLayer.mode,
               onDisplayLayerChanged: (_) {},
               onTerminalEnvironmentTap: (_) {},
               onTerminalTap: () {},
@@ -1089,7 +783,6 @@ void main() {
                 onCompanionTap: () {},
                 activeMode: ChatSurfaceMode.normal,
                 onModeChanged: (_) {},
-                activeModelId: 'gpt-5.4',
                 displayLayer: ChatIslandDisplayLayer.mode,
                 onDisplayLayerChanged: (_) {},
                 onTerminalEnvironmentTap: (_) {},
@@ -1123,18 +816,15 @@ void main() {
     expect(primaryIconAsset(), contains('assets/home/chat/pure_chat.svg'));
   });
 
-  testWidgets('supports direct island swipe between model and tools layers', (
+  testWidgets('switches island directly between mode and tools layers', (
     tester,
   ) async {
     await tester.pumpWidget(const _ChatAppBarHarness());
 
-    await tester.drag(find.text('gpt-5.4'), const Offset(0, -42));
-    await tester.pumpAndSettle();
-
-    expect(find.text('layer:model'), findsOneWidget);
-    expect(find.text('gpt-5.4'), findsOneWidget);
-
-    await tester.drag(find.text('gpt-5.4'), const Offset(0, 42));
+    await tester.drag(
+      find.byKey(const ValueKey('chat-app-bar-island')),
+      const Offset(0, 42),
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('layer:tools'), findsOneWidget);
@@ -1180,72 +870,55 @@ void main() {
 
     expect(find.text('envTaps:1'), findsOneWidget);
 
+    await tester.tap(find.byKey(const ValueKey('chat-island-terminal-button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('terminalTaps:1'), findsOneWidget);
+
     await tester.tap(find.byKey(const ValueKey('chat-island-browser-button')));
     await tester.pumpAndSettle();
 
     expect(find.text('browserTaps:0'), findsOneWidget);
 
     await tester.drag(
-      find.byKey(const ValueKey('chat-island-terminal-button')),
+      find.byKey(const ValueKey('chat-app-bar-island')),
       const Offset(0, -42),
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('layer:model'), findsOneWidget);
+    expect(find.text('layer:mode'), findsOneWidget);
   });
 
-  testWidgets('ignores floating panel drags for island layer switching', (
+  testWidgets('hides surface switcher without forcing tools layer', (
     tester,
   ) async {
-    await tester.pumpWidget(const _FloatingPanelGestureExclusionHarness());
+    await tester.pumpWidget(
+      const _ChatAppBarHarness(showSurfaceSwitcher: false),
+    );
 
-    expect(find.text('layer:model'), findsOneWidget);
+    expect(find.byType(ChatModeSlider), findsNothing);
+    expect(find.text('layer:mode'), findsOneWidget);
+    expect(find.text('gpt-5.4'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('chat-island-single-mode-icon')),
+      findsOneWidget,
+    );
+    expect(
+      _hitTestableIslandToolButton('chat-island-terminal-button'),
+      findsNothing,
+    );
 
     await tester.drag(
-      find.byKey(const ValueKey('floating-panel')),
-      const Offset(0, 64),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('layer:model'), findsOneWidget);
-
-    final background = find.byKey(const ValueKey('floating-background'));
-    await tester.dragFrom(
-      tester.getTopLeft(background) + const Offset(40, 40),
-      const Offset(0, 64),
+      find.byKey(const ValueKey('chat-app-bar-island')),
+      const Offset(0, 42),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('layer:tools'), findsOneWidget);
-  });
-
-  testWidgets('hides surface switcher when disabled', (tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: DefaultAssetBundle(
-          bundle: _SvgTestAssetBundle(),
-          child: Scaffold(
-            body: ChatAppBar(
-              onMenuTap: () {},
-              onCompanionTap: () {},
-              activeMode: ChatSurfaceMode.normal,
-              onModeChanged: (_) {},
-              activeModelId: 'gpt-5.4',
-              displayLayer: ChatIslandDisplayLayer.mode,
-              onDisplayLayerChanged: (_) {},
-              onTerminalEnvironmentTap: (_) {},
-              onTerminalTap: () {},
-              onBrowserTap: () {},
-              showMenuButton: false,
-              showSurfaceSwitcher: false,
-            ),
-          ),
-        ),
-      ),
+    expect(
+      _hitTestableIslandToolButton('chat-island-terminal-button'),
+      findsOneWidget,
     );
-
-    expect(find.byType(ChatModeSlider), findsNothing);
-    expect(find.text('gpt-5.4'), findsOneWidget);
 
     final appBarContext = tester.element(find.byType(ChatAppBar));
     final rootSurface = tester.widget<ColoredBox>(
@@ -1255,56 +928,25 @@ void main() {
     expect(rootSurface.color, appBarContext.omniPalette.surfacePrimary);
   });
 
-  testWidgets(
-    'reveals model only after normal surface settles and stays idle',
-    (tester) async {
-      await tester.pumpWidget(const _SurfaceTransitionHarness());
-
-      expect(find.text('active:openclaw'), findsOneWidget);
-
-      await _tapModeSegment(tester, 0);
-      await _pumpSurfaceSwitch(tester);
-
-      expect(find.text('active:normal'), findsOneWidget);
-      expect(find.text('layer:mode'), findsOneWidget);
-
-      await tester.pump(const Duration(milliseconds: 1699));
-      expect(find.text('layer:mode'), findsOneWidget);
-
-      await tester.pump(const Duration(milliseconds: 1));
-      expect(find.text('layer:model'), findsOneWidget);
-    },
-  );
-
-  testWidgets('resets reveal delay after repeated surface switches', (
+  testWidgets('normal surface preserves island layer while idle', (
     tester,
   ) async {
     await tester.pumpWidget(const _SurfaceTransitionHarness());
 
-    await tester.tap(find.byKey(const ValueKey('request-normal')));
-    await tester.pump();
-    expect(find.text('active:normal'), findsOneWidget);
-    expect(find.text('layer:mode'), findsOneWidget);
-
-    await tester.pump(const Duration(milliseconds: 1000));
-
-    await tester.tap(find.byKey(const ValueKey('request-openclaw')));
-    await tester.pump();
     expect(find.text('active:openclaw'), findsOneWidget);
 
-    await tester.tap(find.byKey(const ValueKey('request-normal')));
-    await tester.pump();
+    await _tapModeSegment(tester, 0);
+    await _pumpSurfaceSwitch(tester);
+
     expect(find.text('active:normal'), findsOneWidget);
     expect(find.text('layer:mode'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 1699));
-    expect(find.text('layer:mode'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 2500));
 
-    await tester.pump(const Duration(milliseconds: 1));
-    expect(find.text('layer:model'), findsOneWidget);
+    expect(find.text('layer:mode'), findsOneWidget);
   });
 
-  testWidgets('interrupts delayed reveal when page scroll happens in time', (
+  testWidgets('workspace visit resets tool-triggered island layer', (
     tester,
   ) async {
     await tester.pumpWidget(const _SurfaceTransitionHarness());
@@ -1314,13 +956,38 @@ void main() {
     expect(find.text('active:normal'), findsOneWidget);
     expect(find.text('layer:mode'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 600));
-    await tester.tap(find.byKey(const ValueKey('simulate-page-scroll')));
-    await tester.pump();
+    await tester.drag(
+      find.byKey(const ValueKey('chat-app-bar-island')),
+      const Offset(0, 42),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('layer:tools'), findsOneWidget);
 
+    await tester.fling(find.byType(PageView), const Offset(-640, 0), 1200);
+    await tester.pumpAndSettle();
+    expect(find.text('active:workspace'), findsOneWidget);
     expect(find.text('layer:mode'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 2000));
+    await tester.fling(find.byType(PageView), const Offset(640, 0), 1200);
+    await tester.pumpAndSettle();
+    expect(find.text('active:normal'), findsOneWidget);
+    expect(find.text('layer:mode'), findsOneWidget);
+
+    await tester.drag(
+      find.byKey(const ValueKey('chat-app-bar-island')),
+      const Offset(0, 42),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('layer:tools'), findsOneWidget);
+
+    await tester.fling(find.byType(PageView), const Offset(-640, 0), 1200);
+    await tester.pumpAndSettle();
+    expect(find.text('active:workspace'), findsOneWidget);
+    expect(find.text('layer:mode'), findsOneWidget);
+
+    await tester.fling(find.byType(PageView), const Offset(640, 0), 1200);
+    await tester.pumpAndSettle();
+    expect(find.text('active:normal'), findsOneWidget);
     expect(find.text('layer:mode'), findsOneWidget);
   });
 
@@ -1339,6 +1006,6 @@ void main() {
     await tester.pump(const Duration(milliseconds: 140));
 
     expect(find.text('active:openclaw'), findsOneWidget);
-    expect(find.text('layer:model'), findsOneWidget);
+    expect(find.text('layer:mode'), findsOneWidget);
   });
 }

--- a/ui/test/features/home/pages/command_overlay/widgets/chat_input_area_test.dart
+++ b/ui/test/features/home/pages/command_overlay/widgets/chat_input_area_test.dart
@@ -208,7 +208,7 @@ void main() {
     await tester.tap(
       find.byKey(
         const ValueKey(
-          'chat-input-codex-run-settings-model-option-gpt-5.1-codex',
+          'chat-input-codex-run-settings-option-model-gpt-5.1-codex',
         ),
       ),
     );
@@ -221,11 +221,73 @@ void main() {
 
     await tester.tap(
       find.byKey(
-        const ValueKey('chat-input-codex-run-settings-effort-option-xhigh'),
+        const ValueKey('chat-input-codex-run-settings-option-effort-xhigh'),
       ),
     );
     await tester.pump(const Duration(milliseconds: 300));
     expect(selectedEffort, 'xhigh');
+  });
+
+  testWidgets('normal chat model picker renders inside input actions', (
+    tester,
+  ) async {
+    var opened = false;
+    await tester.pumpWidget(
+      _buildTestApp(
+        contextUsageRatio: null,
+        useLargeComposerStyle: true,
+        modelPickerSettings: ChatModelPickerSettings(
+          modelId: 'gpt-5.4-chat-preview',
+          hasSelectableModels: true,
+          onOpen: (_) {
+            opened = true;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final modelButton = find.byKey(
+      const ValueKey('chat-input-model-picker-button'),
+    );
+    expect(modelButton, findsOneWidget);
+    expect(find.text('gpt-5.4-chat-preview'), findsNothing);
+    expect(find.text('gpt-5.4-chat...'), findsOneWidget);
+
+    await tester.tap(modelButton);
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(opened, isTrue);
+  });
+
+  testWidgets('disabled normal chat model picker does not open', (
+    tester,
+  ) async {
+    var opened = false;
+    await tester.pumpWidget(
+      _buildTestApp(
+        contextUsageRatio: null,
+        useLargeComposerStyle: true,
+        modelPickerSettings: ChatModelPickerSettings(
+          modelId: 'gpt-5.4',
+          hasSelectableModels: false,
+          onOpen: (_) {
+            opened = true;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final modelButton = find.byKey(
+      const ValueKey('chat-input-model-picker-button'),
+    );
+    expect(modelButton, findsOneWidget);
+
+    await tester.tap(modelButton);
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(opened, isFalse);
   });
 
   testWidgets('large composer codex controls fit on narrow screens', (
@@ -395,6 +457,7 @@ Widget _buildTestApp({
   ValueChanged<CodexPermissionMode>? onCodexPermissionModeChanged,
   CodexRunSettings? codexRunSettings,
   CodexRunSettingsChanged? onCodexRunSettingsChanged,
+  ChatModelPickerSettings? modelPickerSettings,
   String initialText = '',
   FocusNode? focusNode,
 }) {
@@ -412,6 +475,7 @@ Widget _buildTestApp({
           contextUsageRatio: contextUsageRatio,
           onLongPressContextUsageRing: onLongPressContextUsageRing,
           onTriggerSlashCommand: onTriggerSlashCommand,
+          modelPickerSettings: modelPickerSettings,
           codexRunSettings: codexRunSettings,
           onCodexRunSettingsChanged: onCodexRunSettingsChanged,
           codexPermissionMode: codexPermissionMode,

--- a/ui/test/widgets/app_update_dialog_test.dart
+++ b/ui/test/widgets/app_update_dialog_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/services/app_update_service.dart';
+import 'package:ui/theme/app_theme.dart';
+import 'package:ui/theme/omni_theme_palette.dart';
+import 'package:ui/widgets/app_update_dialog.dart';
+
+void main() {
+  const status = AppUpdateStatus(
+    currentVersion: '1.0.0',
+    latestVersion: '1.0.1',
+    hasUpdate: true,
+    checkedAt: 1,
+    publishedAt: 1717200000000,
+    releaseUrl: 'https://example.com/release',
+    releaseNotes: 'Bug fixes and improvements.',
+    apkName: 'OpenOmniBot-v1.0.1.apk',
+    apkDownloadUrl: '',
+  );
+
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    required ThemeMode themeMode,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        darkTheme: AppTheme.darkTheme,
+        themeMode: themeMode,
+        locale: const Locale('en'),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => showAppUpdateDialog(context, status),
+              child: const Text('Open dialog'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open dialog'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('uses higher contrast labels in light mode', (tester) async {
+    await pumpDialog(tester, themeMode: ThemeMode.light);
+
+    expect(_textColor(tester, 'Current version'), const Color(0xFF5F6F89));
+    expect(_textColor(tester, 'Latest version'), const Color(0xFF5F6F89));
+    expect(_textColor(tester, 'Published at'), const Color(0xFF5F6F89));
+  });
+
+  testWidgets('keeps update labels unchanged in dark mode', (tester) async {
+    await pumpDialog(tester, themeMode: ThemeMode.dark);
+
+    expect(
+      _textColor(tester, 'Current version'),
+      OmniThemePalette.dark.textTertiary,
+    );
+    expect(
+      _textColor(tester, 'Latest version'),
+      OmniThemePalette.dark.textTertiary,
+    );
+    expect(
+      _textColor(tester, 'Published at'),
+      OmniThemePalette.dark.textTertiary,
+    );
+  });
+}
+
+Color? _textColor(WidgetTester tester, String text) {
+  final widget = tester.widget<Text>(find.text(text));
+  return widget.style?.color;
+}


### PR DESCRIPTION
移除了聊天页面中自动显示模型层的相关代码，包括定时器、滚动中断逻辑
和相关的状态管理。统一了正常模式下的默认显示层为mode，移除了model
枚举值，并重构了显示层切换逻辑以提高代码可读性。

BREAKING CHANGE: 移除了ChatIslandDisplayLayer.model枚举值，相关API 需要适配新的显示层逻辑

## 变更摘要

<!-- 用 1-3 句话描述本次改动解决了什么问题 -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
