### PR TITLE
fix:支持 max/xhigh 思考强度透传，并为 DeepSeek Agent 补默认 max

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -29,6 +29,7 @@ import cn.com.omnimind.baselib.llm.ChatCompletionMessage
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionTool
 import cn.com.omnimind.baselib.llm.AiRequestLogStore
+import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.llm.ModelProviderConfig
 import cn.com.omnimind.baselib.llm.ModelProviderProfile
 import cn.com.omnimind.baselib.llm.ModelProviderConfigStore
@@ -187,9 +188,33 @@ internal fun resolveChatTaskModelOverride(
 internal fun normalizeReasoningEffort(raw: String?): String? {
     val normalized = raw?.trim()?.lowercase().orEmpty()
     return when (normalized) {
-        "no", "low", "high" -> normalized
+        "no", "low", "high", "xhigh", "max" -> normalized
         else -> null
     }
+}
+
+internal fun resolveAgentReasoningEffort(
+    reasoningEffort: String?,
+    modelOverride: AgentModelOverride?,
+    fallbackProfile: ModelProviderProfile? = runCatching {
+        ModelProviderConfigStore.getEditingProfile()
+    }.getOrNull()
+): String? {
+    if (!reasoningEffort.isNullOrBlank()) {
+        return reasoningEffort
+    }
+    val useOfficialDeepSeekDefault = if (modelOverride != null) {
+        DeepSeekProvider.shouldUseOfficialAdapter(
+            protocolType = modelOverride.protocolType,
+            apiBase = modelOverride.apiBase
+        )
+    } else {
+        DeepSeekProvider.shouldUseOfficialAdapter(
+            protocolType = fallbackProfile?.protocolType,
+            apiBase = fallbackProfile?.baseUrl
+        )
+    }
+    return if (useOfficialDeepSeekDefault) "max" else null
 }
 
 internal data class AgentFinalErrorResolution(
@@ -4013,8 +4038,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val modelOverride = resolveAgentModelOverride(
             call.argument<Map<String, Any?>>("modelOverride")
         )
-        val reasoningEffort = normalizeReasoningEffort(
-            call.argument<String>("reasoningEffort")
+        val reasoningEffort = resolveAgentReasoningEffort(
+            normalizeReasoningEffort(
+                call.argument<String>("reasoningEffort")
+            ),
+            modelOverride
         )
         val terminalEnvironment = parseTerminalEnvironmentMap(
             call.argument<Map<String, Any?>>("terminalEnvironment")
@@ -5828,8 +5856,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val modelOverride = resolveAgentModelOverride(
             call.argument<Map<String, Any?>>("modelOverride")
         )
-        val reasoningEffort = normalizeReasoningEffort(
-            call.argument<String>("reasoningEffort")
+        val reasoningEffort = resolveAgentReasoningEffort(
+            normalizeReasoningEffort(
+                call.argument<String>("reasoningEffort")
+            ),
+            modelOverride
         )
         workJob.launch {
             try {

--- a/ui/lib/features/home/pages/chat/chat_page_openclaw.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_openclaw.dart
@@ -237,7 +237,7 @@ mixin _ChatPageOpenClawMixin on _ChatPageStateBase {
         trimmed.substring('/effort'.length).trimLeft(),
       );
       if (effort == null) {
-        _showSnackBar('可用思考强度：no、low、high');
+        _showSnackBar('可用思考强度：no、low、high、max（兼容 xhigh）');
         return true;
       }
       await _applyConversationReasoningEffort(effort);

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -114,15 +114,19 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     if (route == _SlashCommandPanelRoute.effort &&
         _supportsReasoningEffortCommand) {
       final activeEffort = _activeConversationReasoningEffort;
+      final displayActiveEffort =
+          activeEffort == 'xhigh' ? 'max' : activeEffort;
       final query = _slashCommandRouteQuery(route).toLowerCase();
-      final efforts = <String>['no', 'low', 'high']
+      final efforts = <String>['no', 'low', 'high', 'max']
           .where((effort) {
-            return query.isEmpty || effort.contains(query);
+            return query.isEmpty ||
+                effort.contains(query) ||
+                (effort == 'max' && 'xhigh'.contains(query));
           })
           .toList(growable: false);
       return efforts
           .map((effort) {
-            final isSelected = effort == activeEffort;
+            final isSelected = effort == displayActiveEffort;
             return <String, dynamic>{
               'cardId': 'slash-command-effort-$effort',
               'toolName': effort,
@@ -184,6 +188,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     }
     if (_supportsReasoningEffortCommand) {
       final activeEffort = _activeConversationReasoningEffort;
+      final displayActiveEffort =
+          activeEffort == 'xhigh' ? 'max' : activeEffort;
       commands.add(<String, dynamic>{
         'cardId': 'slash-command-effort',
         'toolName': '/effort',
@@ -191,19 +197,20 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
         'displayName': '/effort',
         'toolType': 'command',
         'toolTypeLabel': LegacyTextLocalizer.isEnglish ? 'Thinking' : '思考',
-        'status': activeEffort == null ? 'running' : 'success',
+        'status': displayActiveEffort == null ? 'running' : 'success',
         'statusLabel':
-            activeEffort ?? (LegacyTextLocalizer.isEnglish ? 'Command' : '命令'),
-        'summary': activeEffort == null
+            displayActiveEffort ??
+            (LegacyTextLocalizer.isEnglish ? 'Command' : '命令'),
+        'summary': displayActiveEffort == null
             ? (LegacyTextLocalizer.isEnglish
                   ? 'Set reasoning effort for this session'
                   : '设置当前会话的思考强度')
             : (LegacyTextLocalizer.isEnglish
-                  ? 'Current effort: $activeEffort'
-                  : '当前思考强度：$activeEffort'),
+                  ? 'Current effort: $displayActiveEffort'
+                  : '当前思考强度：$displayActiveEffort'),
         'progress': LegacyTextLocalizer.isEnglish
-            ? 'Choose no, low or high'
-            : '点击后选择 no、low 或 high',
+            ? 'Choose no, low, high or max'
+            : '点击后选择 no、low、high 或 max',
       });
     }
     if (_isOpenClawSurface) {
@@ -456,6 +463,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
       case 'no':
       case 'low':
       case 'high':
+      case 'xhigh':
+      case 'max':
         unawaited(_applyConversationReasoningEffort(command));
         _messageController.clear();
         _hideSlashCommandPanel();

--- a/ui/lib/services/conversation_model_override_service.dart
+++ b/ui/lib/services/conversation_model_override_service.dart
@@ -94,7 +94,13 @@ class ConversationModelOverrideService {
 class ConversationReasoningEffortService {
   static const String _kConversationReasoningEffortsKey =
       'conversation_reasoning_efforts_v1';
-  static const Set<String> _kSupportedEfforts = {'no', 'low', 'high'};
+  static const Set<String> _kSupportedEfforts = {
+    'no',
+    'low',
+    'high',
+    'xhigh',
+    'max',
+  };
 
   static Future<String?> getEffort(int conversationId) async {
     final map = _readEffortMap();


### PR DESCRIPTION
## 变更摘要

修复 issue363 中 `reasoning_effort` 链路前后不一致的问题。此前 Flutter/native 上游会拦掉 `xhigh/max`，导致 DeepSeek 适配层虽然支持高强度值，但请求无法完整透传；同时official DeepSeek 场景下 Agent 默认思考强度为 max。

## 变更类型

- [x]  Bug 修复

## 关联 Issue

Closes #363

## 主要改动

1. native 侧放宽 `reasoning_effort` 合法值，支持 `no/low/high/xhigh/max`，并新增 Agent 专用 `resolveAgentReasoningEffort()`。
2. Flutter 会话覆盖服务支持保存/恢复 `xhigh/max`，`/effort` UI 补齐 `max` 并兼容历史 `xhigh`。
3. Agent 模式下官方 deepseek 默认使用 max 思考强度。


测试细节：

已在抓包日志中捕捉到Agent模式下 reasoning_effort 出现，且不为 null。用户侧切换会话时也能保持历史思考强度。
<img width="2048" height="127" alt="dddbc1b9-a482-43bf-9ed2-f1a7a9b6a2a6" src="https://github.com/user-attachments/assets/74c455a3-b37d-4d8e-b3fa-817a7c608859" />



## UI 变更（如有）

无明显视觉改版，仅更新 `/effort` 可选项和提示文案：
- 支持 `max`
- 兼容历史 `xhigh`

## 风险与回滚

无