### PR TITLE
fix(chat): 修复输入框随软键盘回落后的底部弹动

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -58,6 +58,7 @@ import 'package:ui/features/home/pages/chat/utils/agent_runtime_attachment_paylo
 import 'package:ui/features/home/pages/chat/utils/agent_thinking_card_locator.dart';
 import 'package:ui/features/home/pages/chat/utils/codex_slash_commands.dart';
 import 'package:ui/features/home/pages/chat/utils/deep_thinking_persistence.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart';
 import 'package:ui/features/home/pages/chat/utils/keyboard_inset_motion_tracker.dart';
 import 'package:ui/features/home/pages/codex/codex_remote_directory_picker.dart';
 import 'package:ui/features/home/pages/codex/codex_remote_workspace_browser.dart';
@@ -190,6 +191,8 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   };
   final KeyboardInsetMotionTracker _emptyGreetingKeyboardLiftTracker =
       KeyboardInsetMotionTracker();
+  final ComposerKeyboardMetricsTracker _composerKeyboardMetricsTracker =
+      ComposerKeyboardMetricsTracker();
   final Map<ChatPageMode, ChatIslandDisplayLayer>
   _chatIslandDisplayLayerByMode = {
     ChatPageMode.normal: ChatIslandDisplayLayer.mode,

--- a/ui/lib/features/home/pages/chat/chat_page_models.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_models.dart
@@ -1115,6 +1115,44 @@ class HdPadPaneLayout {
 const double kHdPadMinShortestSide = 600;
 const double kHdPadMinLandscapeWidth = 960;
 const double kChatKeyboardComposerClearance = 10.0;
+const double kChatComposerEdgeInset = 24.0;
+
+/// Resolves the composer's bottom padding inside the page-level [SafeArea].
+///
+/// While the soft keyboard still covers the system navigation area, the
+/// ancestor SafeArea's bottom padding (`max(0, viewPadding - viewInsets)`)
+/// has not been restored yet. When the composer is not lifted for the
+/// keyboard (e.g. focus was cleared before the IME finished hiding), the
+/// missing SafeArea padding is compensated here so the composer rests at its
+/// final position immediately, instead of settling too low and visibly
+/// popping up once the IME hide animation ends.
+double resolveChatComposerInputBottomPadding({
+  required bool shouldLiftComposerForKeyboard,
+  required double bottomInset,
+  required double viewPaddingBottom,
+  required double safeAreaBottomPadding,
+  double edgeInset = kChatComposerEdgeInset,
+}) {
+  final normalizedBottomInset = bottomInset.isFinite
+      ? math.max(0.0, bottomInset)
+      : 0.0;
+  final normalizedViewPadding = viewPaddingBottom.isFinite
+      ? math.max(0.0, viewPaddingBottom)
+      : 0.0;
+  final normalizedEdgeInset = edgeInset.isFinite
+      ? math.max(0.0, edgeInset)
+      : 0.0;
+  if (shouldLiftComposerForKeyboard) {
+    return (normalizedViewPadding + normalizedEdgeInset - normalizedBottomInset)
+        .clamp(0.0, normalizedEdgeInset)
+        .toDouble();
+  }
+  final normalizedSafeAreaPadding = safeAreaBottomPadding.isFinite
+      ? safeAreaBottomPadding.clamp(0.0, normalizedViewPadding).toDouble()
+      : 0.0;
+  final safeAreaShortfall = normalizedViewPadding - normalizedSafeAreaPadding;
+  return normalizedEdgeInset + safeAreaShortfall;
+}
 
 double resolveChatComposerKeyboardSpacer({
   required bool shouldLiftComposerForKeyboard,

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1745,24 +1745,20 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
 
   @override
   Widget build(BuildContext context) {
-    const edgeInset = 24.0;
     final mediaQuery = MediaQuery.of(context);
     final isHdPadLandscape = _isHdPadLandscapeForMediaQuery(mediaQuery);
     final bottomInset = mediaQuery.viewInsets.bottom;
     final viewPaddingBottom = mediaQuery.viewPadding.bottom;
     final shouldLiftComposerForKeyboard =
         _inputFocusNode.hasFocus || _editingUserMessageId != null;
-    final composerKeyboardLift = shouldLiftComposerForKeyboard
-        ? bottomInset
-        : 0.0;
-    final inputBottomPadding =
-        (viewPaddingBottom + edgeInset - composerKeyboardLift)
-            .clamp(0.0, edgeInset)
-            .toDouble();
-    final keyboardSpacer = resolveChatComposerKeyboardSpacer(
+    final composerKeyboardMetrics = _composerKeyboardMetricsTracker.update(
       shouldLiftComposerForKeyboard: shouldLiftComposerForKeyboard,
       bottomInset: bottomInset,
+      viewPaddingBottom: viewPaddingBottom,
+      safeAreaBottomPadding: mediaQuery.padding.bottom,
     );
+    final inputBottomPadding = composerKeyboardMetrics.inputBottomPadding;
+    final keyboardSpacer = composerKeyboardMetrics.keyboardSpacer;
     final commandPanelBottomOffset =
         (_popupMenuBottomOffset() + inputBottomPadding + keyboardSpacer + 6)
             .toDouble();

--- a/ui/lib/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart
+++ b/ui/lib/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart
@@ -1,0 +1,202 @@
+import 'dart:math' as math;
+
+import 'package:ui/features/home/pages/chat/chat_page_models.dart';
+
+/// Resolved composer metrics for one frame.
+class ComposerKeyboardMetrics {
+  const ComposerKeyboardMetrics({
+    required this.inputBottomPadding,
+    required this.keyboardSpacer,
+  });
+
+  final double inputBottomPadding;
+  final double keyboardSpacer;
+}
+
+/// Resolves the chat composer's bottom padding and keyboard spacer from raw
+/// per-frame window metrics, keeping the composer's absolute screen position
+/// monotone while the soft keyboard hides and perfectly still once settled.
+///
+/// Raw metrics are not trustworthy frame-by-frame on every device:
+/// - `viewPadding.bottom` can momentarily report 0 or a stale value while
+///   the IME animates or the navigation mode changes (observed on ColorOS),
+///   which makes any formula based on the live value settle the composer too
+///   low and visibly pop it up when the hide animation ends.
+/// - `viewInsets.bottom` can emit a short non-zero blip right after the hide
+///   animation has settled at 0, which re-engages the keyboard spacer for a
+///   frame and bounces the composer.
+///
+/// Guards 1-3 are provably inert on healthy signals; guard 4 reshapes only
+/// the tail of the hide trajectory:
+/// 1. Rest latch: `viewPadding.bottom` is latched while the keyboard is
+///    fully closed and the latched value anchors the rest position during
+///    keyboard motion.
+/// 2. Rest floor: the composer's total distance from the physical screen
+///    bottom (SafeArea padding + bottom padding + spacer) never drops below
+///    the latched rest position. The healthy lifted trajectory always stays
+///    at or above it, so the floor only engages on degraded signals and on
+///    unfocused dismissals (where it pins the composer exactly at rest for
+///    the whole hide animation).
+/// 3. Settle debounce: when the inset rises right after settling, the lift
+///    is deferred by one frame so single-frame inset blips are swallowed. A
+///    real keyboard open only loses its first sub-perceptual frame (~2dp).
+/// 4. Continuous landing: while the keyboard is closing, the total is
+///    capped at `max(rest, inset + clearance)`. The raw formulas would hold
+///    the composer clearance-height above rest for the last stretch of the
+///    hide (a flat shelf) and only drop the final ~10dp in the very last
+///    frames — which reads as a small bottom bounce after an apparent
+///    landing. With the cap the composer rides the keyboard down in one
+///    continuous motion, lands exactly at rest slightly before the keyboard
+///    finishes, and never moves again. The opening trajectory is untouched.
+class ComposerKeyboardMetricsTracker {
+  ComposerKeyboardMetricsTracker({
+    this.edgeInset = kChatComposerEdgeInset,
+    this.keyboardClearance = kChatKeyboardComposerClearance,
+    this.settleInsetThreshold = 0.5,
+    this.motionEpsilon = 1.0,
+  });
+
+  final double edgeInset;
+  final double keyboardClearance;
+  final double settleInsetThreshold;
+  final double motionEpsilon;
+
+  double? _restViewPadding;
+  bool _settled = true;
+  bool _liftDeferredOnce = false;
+  bool _closing = false;
+  double? _lastEngagedInset;
+
+  double? _lastInset;
+  double? _lastViewPadding;
+  double? _lastSafeAreaPadding;
+  bool? _lastShouldLift;
+  ComposerKeyboardMetrics _lastMetrics = const ComposerKeyboardMetrics(
+    inputBottomPadding: kChatComposerEdgeInset,
+    keyboardSpacer: 0,
+  );
+
+  /// Latched rest-time bottom view padding, exposed for diagnostics/tests.
+  double? get restViewPadding => _restViewPadding;
+
+  ComposerKeyboardMetrics update({
+    required bool shouldLiftComposerForKeyboard,
+    required double bottomInset,
+    required double viewPaddingBottom,
+    required double safeAreaBottomPadding,
+  }) {
+    final inset = bottomInset.isFinite ? math.max(0.0, bottomInset) : 0.0;
+    final viewPadding = viewPaddingBottom.isFinite
+        ? math.max(0.0, viewPaddingBottom)
+        : 0.0;
+    final safeAreaPadding = safeAreaBottomPadding.isFinite
+        ? math.max(0.0, safeAreaBottomPadding)
+        : 0.0;
+
+    // Rebuilds happen for many reasons besides metrics changes; only advance
+    // the settle/debounce state machine when the raw samples change.
+    final inputsUnchanged =
+        _lastInset == inset &&
+        _lastViewPadding == viewPadding &&
+        _lastSafeAreaPadding == safeAreaPadding &&
+        _lastShouldLift == shouldLiftComposerForKeyboard;
+    if (inputsUnchanged) {
+      return _lastMetrics;
+    }
+    _lastInset = inset;
+    _lastViewPadding = viewPadding;
+    _lastSafeAreaPadding = safeAreaPadding;
+    _lastShouldLift = shouldLiftComposerForKeyboard;
+
+    // Guard 1: latch the rest anchor while the keyboard is fully closed.
+    // The settle frame itself (motion -> rest transition) may still carry a
+    // degraded viewPadding (observed as 0 on ColorOS), so it may only raise
+    // or hold the latch; a later rest -> rest sample is trusted to lower it
+    // (legitimate navigation-mode changes happen with the keyboard closed).
+    if (inset <= settleInsetThreshold) {
+      final previous = _restViewPadding;
+      _restViewPadding = (previous == null || _settled)
+          ? viewPadding
+          : math.max(previous, viewPadding);
+    }
+    final restAnchor = math.max(viewPadding, _restViewPadding ?? viewPadding);
+
+    // Guard 3: defer re-engaging the lift by one frame after settling.
+    var effectiveInset = inset;
+    var deferred = false;
+    if (inset <= settleInsetThreshold) {
+      // Settle dead zone: sub-threshold residues are treated as fully
+      // closed so the composer pins exactly at rest.
+      effectiveInset = 0.0;
+      _settled = true;
+      _liftDeferredOnce = false;
+      _closing = false;
+      _lastEngagedInset = null;
+    } else if (_settled) {
+      if (!_liftDeferredOnce) {
+        _liftDeferredOnce = true;
+        effectiveInset = 0.0;
+        deferred = true;
+      } else {
+        _settled = false;
+        _liftDeferredOnce = false;
+      }
+    }
+
+    // Guard 4 phase detection: the keyboard is closing once the engaged
+    // inset shrinks; a clear rise (reopen) releases the cap again.
+    if (!deferred && inset > settleInsetThreshold) {
+      final lastEngaged = _lastEngagedInset;
+      if (lastEngaged != null) {
+        if (inset < lastEngaged - motionEpsilon) {
+          _closing = true;
+        } else if (inset > lastEngaged + motionEpsilon) {
+          _closing = false;
+        }
+      }
+      _lastEngagedInset = inset;
+    }
+
+    var inputBottomPadding = resolveChatComposerInputBottomPadding(
+      shouldLiftComposerForKeyboard: shouldLiftComposerForKeyboard,
+      bottomInset: effectiveInset,
+      viewPaddingBottom: viewPadding,
+      safeAreaBottomPadding: safeAreaPadding,
+      edgeInset: edgeInset,
+    );
+    var keyboardSpacer = resolveChatComposerKeyboardSpacer(
+      shouldLiftComposerForKeyboard: shouldLiftComposerForKeyboard,
+      bottomInset: effectiveInset,
+    );
+
+    // Guard 2: never let the composer rest below its settled position.
+    final restTotal = restAnchor + edgeInset;
+    var total = safeAreaPadding + inputBottomPadding + keyboardSpacer;
+    if (total < restTotal) {
+      inputBottomPadding += restTotal - total;
+      total = restTotal;
+    }
+
+    // Guard 4: while closing, ride the keyboard down in one continuous
+    // motion instead of shelving clearance-height above rest and dropping
+    // the final stretch in the last frames.
+    if (_closing && shouldLiftComposerForKeyboard) {
+      final capped = math.max(restTotal, effectiveInset + keyboardClearance);
+      var reduction = total - capped;
+      if (reduction > 0) {
+        final fromBottomPadding = math.min(reduction, inputBottomPadding);
+        inputBottomPadding -= fromBottomPadding;
+        reduction -= fromBottomPadding;
+        if (reduction > 0) {
+          keyboardSpacer = math.max(0.0, keyboardSpacer - reduction);
+        }
+      }
+    }
+
+    _lastMetrics = ComposerKeyboardMetrics(
+      inputBottomPadding: inputBottomPadding,
+      keyboardSpacer: keyboardSpacer,
+    );
+    return _lastMetrics;
+  }
+}

--- a/ui/test/features/home/pages/chat/chat_hd_pad_layout_test.dart
+++ b/ui/test/features/home/pages/chat/chat_hd_pad_layout_test.dart
@@ -164,6 +164,95 @@ void main() {
     );
   });
 
+  test('keeps the lifted composer bottom padding clamped to the edge '
+      'inset', () {
+    expect(
+      resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: true,
+        bottomInset: 320,
+        viewPaddingBottom: 24,
+        safeAreaBottomPadding: 0,
+      ),
+      0,
+    );
+    expect(
+      resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: true,
+        bottomInset: 30,
+        viewPaddingBottom: 24,
+        safeAreaBottomPadding: 0,
+      ),
+      18,
+    );
+    expect(
+      resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: true,
+        bottomInset: 0,
+        viewPaddingBottom: 24,
+        safeAreaBottomPadding: 24,
+      ),
+      kChatComposerEdgeInset,
+    );
+  });
+
+  test('compensates pending SafeArea padding while the keyboard hides '
+      'without focus', () {
+    // Mid-hide: SafeArea bottom padding is still consumed by the keyboard
+    // inset, so the unlifted composer padding makes up the difference.
+    expect(
+      resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: false,
+        bottomInset: 300,
+        viewPaddingBottom: 24,
+        safeAreaBottomPadding: 0,
+      ),
+      kChatComposerEdgeInset + 24,
+    );
+    // Fully hidden: SafeArea padding restored, no compensation left.
+    expect(
+      resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: false,
+        bottomInset: 0,
+        viewPaddingBottom: 24,
+        safeAreaBottomPadding: 24,
+      ),
+      kChatComposerEdgeInset,
+    );
+  });
+
+  test('unlifted composer keeps a constant screen-anchored rest position '
+      'through the whole keyboard hide animation', () {
+    const viewPaddingBottom = 24.0;
+    for (final bottomInset in const [300.0, 24.0, 12.0, 3.0, 0.5, 0.0]) {
+      final safeAreaBottomPadding = bottomInset >= viewPaddingBottom
+          ? 0.0
+          : viewPaddingBottom - bottomInset;
+      final padding = resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: false,
+        bottomInset: bottomInset,
+        viewPaddingBottom: viewPaddingBottom,
+        safeAreaBottomPadding: safeAreaBottomPadding,
+      );
+      expect(
+        safeAreaBottomPadding + padding,
+        viewPaddingBottom + kChatComposerEdgeInset,
+        reason: 'bottomInset $bottomInset should not move the settled composer',
+      );
+    }
+  });
+
+  test('SafeArea compensation is a no-op without bottom view padding', () {
+    expect(
+      resolveChatComposerInputBottomPadding(
+        shouldLiftComposerForKeyboard: false,
+        bottomInset: 200,
+        viewPaddingBottom: 0,
+        safeAreaBottomPadding: 0,
+      ),
+      kChatComposerEdgeInset,
+    );
+  });
+
   test('clamps overlay anchor when keyboard spacing exceeds viewport', () {
     final geometry = resolveChatPaneOverlayAnchorGeometry(
       viewportSize: const Size(420, 300),

--- a/ui/test/features/home/pages/chat/composer_keyboard_metrics_tracker_test.dart
+++ b/ui/test/features/home/pages/chat/composer_keyboard_metrics_tracker_test.dart
@@ -1,0 +1,400 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/chat/chat_page_models.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart';
+
+/// One raw metrics sample as reported by the platform for a frame.
+class _Sample {
+  const _Sample(this.inset, this.viewPadding, this.padding, this.lift);
+
+  final double inset;
+  final double viewPadding;
+  final double padding;
+  final bool lift;
+}
+
+/// Frame-by-frame keyboard hide captured on a OnePlus PJD110 (gesture nav,
+/// viewPadding.bottom = 16) while the composer kept focus (back-key
+/// dismissal). padding.bottom == max(0, viewPadding - inset).
+const List<_Sample> _focusRetainedHideTrace = [
+  _Sample(304.00, 16, 0.00, true),
+  _Sample(239.33, 16, 0.00, true),
+  _Sample(150.67, 16, 0.00, true),
+  _Sample(87.67, 16, 0.00, true),
+  _Sample(58.67, 16, 0.00, true),
+  _Sample(33.33, 16, 0.00, true),
+  _Sample(20.33, 16, 0.00, true),
+  _Sample(14.33, 16, 1.67, true),
+  _Sample(7.00, 16, 9.00, true),
+  _Sample(4.00, 16, 12.00, true),
+  _Sample(2.00, 16, 14.00, true),
+  _Sample(0.33, 16, 15.67, true),
+  _Sample(0.00, 16, 16.00, true),
+];
+
+/// Same device, send-path dismissal: focus is cleared while the keyboard is
+/// still at full height, then the keyboard animates away.
+const List<_Sample> _unfocusedHideTrace = [
+  _Sample(301.00, 16, 0.00, false),
+  _Sample(298.33, 16, 0.00, false),
+  _Sample(174.00, 16, 0.00, false),
+  _Sample(113.67, 16, 0.00, false),
+  _Sample(75.67, 16, 0.00, false),
+  _Sample(50.67, 16, 0.00, false),
+  _Sample(28.00, 16, 0.00, false),
+  _Sample(17.00, 16, 0.00, false),
+  _Sample(9.33, 16, 6.67, false),
+  _Sample(2.00, 16, 14.00, false),
+  _Sample(0.00, 16, 16.00, false),
+];
+
+/// Same device, keyboard open after tapping the focused composer.
+const List<_Sample> _openTrace = [
+  _Sample(0.00, 16, 16.00, true),
+  _Sample(2.33, 16, 13.67, true),
+  _Sample(126.67, 16, 0.00, true),
+  _Sample(171.00, 16, 0.00, true),
+  _Sample(225.00, 16, 0.00, true),
+  _Sample(268.00, 16, 0.00, true),
+  _Sample(289.33, 16, 0.00, true),
+  _Sample(298.67, 16, 0.00, true),
+  _Sample(301.00, 16, 0.00, true),
+];
+
+double _legacyInputBottomPadding(_Sample s) =>
+    resolveChatComposerInputBottomPadding(
+      shouldLiftComposerForKeyboard: s.lift,
+      bottomInset: s.inset,
+      viewPaddingBottom: s.viewPadding,
+      safeAreaBottomPadding: s.padding,
+    );
+
+double _legacySpacer(_Sample s) => resolveChatComposerKeyboardSpacer(
+  shouldLiftComposerForKeyboard: s.lift,
+  bottomInset: s.inset,
+);
+
+/// The composer's distance from the physical screen bottom for a frame:
+/// the SafeArea contribution plus the in-tree padding.
+double _screenBottomDistance(_Sample s, ComposerKeyboardMetrics m) =>
+    s.padding + m.inputBottomPadding + m.keyboardSpacer;
+
+void main() {
+  ComposerKeyboardMetricsTracker primedTracker() {
+    final tracker = ComposerKeyboardMetricsTracker();
+    // Prime the rest latch with one settled frame, as happens in production
+    // builds long before any keyboard motion.
+    tracker.update(
+      shouldLiftComposerForKeyboard: false,
+      bottomInset: 0,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 16,
+    );
+    return tracker;
+  }
+
+  ComposerKeyboardMetricsTracker trackerAtOpenKeyboard() {
+    final tracker = primedTracker();
+    for (final sample in _openTrace) {
+      tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+    }
+    return tracker;
+  }
+
+  test('rides the keyboard down with clearance and lands continuously at '
+      'rest on a real focus-retained hide trace', () {
+    final tracker = trackerAtOpenKeyboard();
+    for (final sample in _focusRetainedHideTrace) {
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      // One closed form for the whole hide: keyboard top + clearance until
+      // that reaches the rest position, then rest — no shelf above rest and
+      // no late final step (the perceived settle bounce).
+      final expectedTotal = math.max(
+        16 + kChatComposerEdgeInset,
+        sample.inset + kChatKeyboardComposerClearance,
+      );
+      expect(
+        _screenBottomDistance(sample, metrics),
+        closeTo(expectedTotal, 1e-9),
+        reason: 'trajectory diverged at inset ${sample.inset}',
+      );
+    }
+  });
+
+  test('hide trajectory has no shelf: strictly falling until rest, then '
+      'frozen', () {
+    final tracker = trackerAtOpenKeyboard();
+    const restTotal = 16 + kChatComposerEdgeInset;
+    var reachedRest = false;
+    double? previous;
+    for (final sample in _focusRetainedHideTrace) {
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      final distance = _screenBottomDistance(sample, metrics);
+      if (reachedRest) {
+        expect(
+          distance,
+          closeTo(restTotal, 1e-9),
+          reason: 'composer moved after landing at inset ${sample.inset}',
+        );
+      } else if (previous != null) {
+        expect(
+          distance,
+          lessThan(previous),
+          reason: 'composer stalled above rest at inset ${sample.inset}',
+        );
+      }
+      if ((distance - restTotal).abs() < 1e-9) {
+        reachedRest = true;
+      }
+      previous = distance;
+    }
+    expect(reachedRest, isTrue);
+  });
+
+  test('reopening mid-hide releases the landing cap and restores the legacy '
+      'lift trajectory', () {
+    final tracker = trackerAtOpenKeyboard();
+    // Close partially...
+    const partialHide = [
+      _Sample(304.00, 16, 0.00, true),
+      _Sample(150.67, 16, 0.00, true),
+      _Sample(58.67, 16, 0.00, true),
+    ];
+    for (final sample in partialHide) {
+      tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+    }
+    // ...then the keyboard comes back up: legacy formulas again.
+    const reopen = [
+      _Sample(120.00, 16, 0.00, true),
+      _Sample(250.00, 16, 0.00, true),
+    ];
+    for (final sample in reopen) {
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      expect(
+        metrics.inputBottomPadding,
+        closeTo(_legacyInputBottomPadding(sample), 1e-9),
+      );
+      expect(metrics.keyboardSpacer, closeTo(_legacySpacer(sample), 1e-9));
+    }
+  });
+
+  test('keyboard open trace only defers the first sub-perceptual frame', () {
+    final tracker = primedTracker();
+    for (var i = 0; i < _openTrace.length; i++) {
+      final sample = _openTrace[i];
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      if (i == 1) {
+        // First rising frame (2.33dp) is deferred: composer stays at rest.
+        expect(_screenBottomDistance(sample, metrics), closeTo(40, 1e-9));
+        continue;
+      }
+      expect(
+        metrics.inputBottomPadding,
+        closeTo(_legacyInputBottomPadding(sample), 1e-9),
+        reason: 'inputBottomPadding diverged at inset ${sample.inset}',
+      );
+      expect(
+        metrics.keyboardSpacer,
+        closeTo(_legacySpacer(sample), 1e-9),
+        reason: 'keyboardSpacer diverged at inset ${sample.inset}',
+      );
+    }
+  });
+
+  test('composer screen position is monotone non-increasing and settles at '
+      'rest on the focus-retained hide trace', () {
+    final tracker = trackerAtOpenKeyboard();
+    double? previous;
+    late double last;
+    for (final sample in _focusRetainedHideTrace) {
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      final distance = _screenBottomDistance(sample, metrics);
+      if (previous != null) {
+        expect(
+          distance,
+          lessThanOrEqualTo(previous + 1e-9),
+          reason: 'composer rose mid-hide at inset ${sample.inset}',
+        );
+      }
+      previous = distance;
+      last = distance;
+    }
+    expect(last, closeTo(16 + kChatComposerEdgeInset, 1e-9));
+  });
+
+  test('composer holds its rest position for the entire unfocused hide', () {
+    final tracker = trackerAtOpenKeyboard();
+    for (final sample in _unfocusedHideTrace) {
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      expect(
+        _screenBottomDistance(sample, metrics),
+        closeTo(16 + kChatComposerEdgeInset, 1e-9),
+        reason: 'composer moved at inset ${sample.inset}',
+      );
+    }
+  });
+
+  test('swallows a single-frame inset blip after settling', () {
+    final tracker = trackerAtOpenKeyboard();
+    // Settled with focus retained (back-key dismissal already finished).
+    for (final sample in _focusRetainedHideTrace) {
+      tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+    }
+    // Late engine blip: inset pops to 8dp for one frame, then returns to 0.
+    final blip = tracker.update(
+      shouldLiftComposerForKeyboard: true,
+      bottomInset: 8,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 8,
+    );
+    expect(
+      8 + blip.inputBottomPadding + blip.keyboardSpacer,
+      closeTo(16 + kChatComposerEdgeInset, 1e-9),
+      reason: 'blip frame must keep the composer at rest',
+    );
+    final settled = tracker.update(
+      shouldLiftComposerForKeyboard: true,
+      bottomInset: 0,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 16,
+    );
+    expect(
+      16 + settled.inputBottomPadding + settled.keyboardSpacer,
+      closeTo(16 + kChatComposerEdgeInset, 1e-9),
+    );
+  });
+
+  test('rest latch keeps the composer anchored when viewPadding collapses '
+      'mid-hide (degraded OEM signal)', () {
+    final tracker = primedTracker();
+    // Keyboard fully open, healthy signal.
+    tracker.update(
+      shouldLiftComposerForKeyboard: true,
+      bottomInset: 300,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 0,
+    );
+    // Hide animation during which the platform wrongly reports
+    // viewPadding.bottom = 0 (observed on ColorOS nav-mode transitions).
+    const degraded = [
+      _Sample(150.0, 0, 0, true),
+      _Sample(50.0, 0, 0, true),
+      _Sample(20.0, 0, 0, true),
+      _Sample(5.0, 0, 0, true),
+      _Sample(0.0, 0, 0, true),
+    ];
+    double? previous;
+    for (final sample in degraded) {
+      final metrics = tracker.update(
+        shouldLiftComposerForKeyboard: sample.lift,
+        bottomInset: sample.inset,
+        viewPaddingBottom: sample.viewPadding,
+        safeAreaBottomPadding: sample.padding,
+      );
+      final distance = _screenBottomDistance(sample, metrics);
+      expect(
+        distance,
+        greaterThanOrEqualTo(16 + kChatComposerEdgeInset - 1e-9),
+        reason: 'composer dipped below rest at inset ${sample.inset}',
+      );
+      if (previous != null) {
+        expect(distance, lessThanOrEqualTo(previous + 1e-9));
+      }
+      previous = distance;
+    }
+    // When the real padding is finally restored at the end of the
+    // animation, the composer must not move.
+    final restored = tracker.update(
+      shouldLiftComposerForKeyboard: true,
+      bottomInset: 0,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 16,
+    );
+    expect(
+      16 + restored.inputBottomPadding + restored.keyboardSpacer,
+      closeTo(16 + kChatComposerEdgeInset, 1e-9),
+      reason: 'late padding restoration must not pop the composer',
+    );
+  });
+
+  test('repeated identical samples return cached metrics without advancing '
+      'the debounce state', () {
+    final tracker = primedTracker();
+    final first = tracker.update(
+      shouldLiftComposerForKeyboard: true,
+      bottomInset: 300,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 0,
+    );
+    final second = tracker.update(
+      shouldLiftComposerForKeyboard: true,
+      bottomInset: 300,
+      viewPaddingBottom: 16,
+      safeAreaBottomPadding: 0,
+    );
+    expect(identical(first, second), isTrue);
+  });
+
+  test('latch refreshes at rest so a legitimately smaller nav inset is '
+      'adopted', () {
+    final tracker = primedTracker();
+    // Device switches to a smaller bottom inset (e.g. nav mode change while
+    // the keyboard is closed) — the new rest must win, not the old latch.
+    final metrics = tracker.update(
+      shouldLiftComposerForKeyboard: false,
+      bottomInset: 0,
+      viewPaddingBottom: 0,
+      safeAreaBottomPadding: 0,
+    );
+    expect(
+      0 + metrics.inputBottomPadding + metrics.keyboardSpacer,
+      closeTo(kChatComposerEdgeInset, 1e-9),
+    );
+  });
+}


### PR DESCRIPTION
引入 ComposerKeyboardMetricsTracker 统一解析输入框底部留白与键盘间隔, 不再逐帧信任原始窗口指标:
- 静止锁存:键盘关闭时锁存 viewPadding 作为静止锚点,规避 OEM 在动画 期间 viewPadding 归零/失真导致的落定后上弹
- 地板钳制:输入框到屏幕底边的总距离永不低于静止位,unfocus 收起全程 钉在静止位,消除 SafeArea padding 迟到恢复造成的上顶
- 落定防抖:落定后单帧 inset 毛刺延迟一帧响应
- 连续着陆:收起阶段总距离钳到 max(静止位, inset + clearance),消除 clearance 渐出造成的"悬停搁板 + 末段补落"底部弹动

弹起轨迹与骑行下落速度逐帧不变,单元测试以真机抓取的逐帧轨迹回放断言。

## 变更摘要

<!-- 用 1-3 句话描述本次改动解决了什么问题 -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
