### PR TITLE
feature:支持 OpenAI v1/responses 接口并修复对应格式下流式工具调用映射与回复重复问题

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/config/AgentAiCapabilityConfigSync.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/config/AgentAiCapabilityConfigSync.kt
@@ -5,6 +5,7 @@ import android.os.FileObserver
 import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.llm.ModelProviderConfigStore
 import cn.com.omnimind.baselib.llm.ModelProviderProfile
+import cn.com.omnimind.baselib.llm.OpenAiWireApi
 import cn.com.omnimind.baselib.llm.SceneModelBindingEntry
 import cn.com.omnimind.baselib.llm.SceneModelBindingStore
 import cn.com.omnimind.baselib.llm.SceneVoiceConfig
@@ -33,7 +34,8 @@ private data class AgentAiCapabilityProviderSnapshot(
     val name: String = "",
     val baseUrl: String = "",
     val apiKey: String = "",
-    val protocolType: String = "openai_compatible"
+    val protocolType: String = "openai_compatible",
+    val wireApi: String = "chat_completions"
 )
 
 private data class AgentAiCapabilitySceneModelSnapshot(
@@ -70,7 +72,8 @@ private data class AgentAiCapabilityProviderPartial(
     val name: String? = null,
     val baseUrl: String? = null,
     val apiKey: String? = null,
-    val protocolType: String? = null
+    val protocolType: String? = null,
+    val wireApi: String? = null
 )
 
 class AgentAiCapabilityConfigSync private constructor(
@@ -279,7 +282,8 @@ class AgentAiCapabilityConfigSync private constructor(
                     name = profile.name,
                     baseUrl = profile.baseUrl,
                     apiKey = profile.apiKey,
-                    protocolType = profile.protocolType
+                    protocolType = profile.protocolType,
+                    wireApi = profile.wireApi
                 )
             }
         val sceneModels = linkedMapOf<String, AgentAiCapabilitySceneModelSnapshot>()
@@ -314,7 +318,8 @@ class AgentAiCapabilityConfigSync private constructor(
                     name = provider.name.trim(),
                     baseUrl = provider.baseUrl.trim(),
                     apiKey = provider.apiKey.trim(),
-                    protocolType = normalizeProtocolType(provider.protocolType)
+                    protocolType = normalizeProtocolType(provider.protocolType),
+                    wireApi = OpenAiWireApi.normalize(provider.wireApi)
                 )
             },
             editingProfileId = snapshot.currentProviderId
@@ -386,7 +391,8 @@ class AgentAiCapabilityConfigSync private constructor(
                     name = provider.name?.trim().orEmpty(),
                     baseUrl = provider.baseUrl?.trim().orEmpty(),
                     apiKey = provider.apiKey?.trim().orEmpty(),
-                    protocolType = normalizeProtocolType(provider.protocolType)
+                    protocolType = normalizeProtocolType(provider.protocolType),
+                    wireApi = OpenAiWireApi.normalize(provider.wireApi)
                 )
             } ?: fallback.providers,
             sceneModels = sceneModels,

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationContextCompactor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationContextCompactor.kt
@@ -367,6 +367,7 @@ Do NOT translate or alter code snippets, file paths, identifiers, or error messa
                 explicitApiKey = modelOverride?.apiKey,
                 explicitModel = modelOverride?.modelId,
                 explicitProtocolType = modelOverride?.protocolType,
+                explicitWireApi = modelOverride?.wireApi,
                 reasoningEffort = reasoningEffort
             )
             result.await()

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -61,8 +61,9 @@ class HttpAgentLlmClient(
         explicitApiKey: String?,
         explicitModel: String?,
         explicitProtocolType: String?,
+        explicitWireApi: String?,
         forceHttp1: Boolean
-    ) -> EventSource = { model, requestBodyJson, event, explicitApiBase, explicitApiKey, explicitModel, explicitProtocolType, forceHttp1 ->
+    ) -> EventSource = { model, requestBodyJson, event, explicitApiBase, explicitApiKey, explicitModel, explicitProtocolType, explicitWireApi, forceHttp1 ->
         HttpController.postChatCompletionsStreamRequest(
             model = model,
             requestBodyJson = requestBodyJson,
@@ -71,6 +72,7 @@ class HttpAgentLlmClient(
             explicitApiKey = explicitApiKey,
             explicitModel = explicitModel,
             explicitProtocolType = explicitProtocolType,
+            explicitWireApi = explicitWireApi,
             forceHttp1 = forceHttp1
         )
     },
@@ -79,14 +81,16 @@ class HttpAgentLlmClient(
         explicitApiBase: String?,
         explicitApiKey: String?,
         explicitModel: String?,
-        explicitProtocolType: String?
-    ) -> HttpController.ChatCompletionRouteInfo = { modelOrScene, explicitApiBase, explicitApiKey, explicitModel, explicitProtocolType ->
+        explicitProtocolType: String?,
+        explicitWireApi: String?
+    ) -> HttpController.ChatCompletionRouteInfo = { modelOrScene, explicitApiBase, explicitApiKey, explicitModel, explicitProtocolType, explicitWireApi ->
         HttpController.resolveChatCompletionRouteInfo(
             modelOrScene = modelOrScene,
             explicitApiBase = explicitApiBase,
             explicitApiKey = explicitApiKey,
             explicitModel = explicitModel,
-            explicitProtocolType = explicitProtocolType
+            explicitProtocolType = explicitProtocolType,
+            explicitWireApi = explicitWireApi
         )
     },
     private val streamIdleWatchdogMs: Long = 0L,
@@ -127,7 +131,8 @@ class HttpAgentLlmClient(
                 modelOverride?.apiBase,
                 modelOverride?.apiKey,
                 modelOverride?.modelId,
-                modelOverride?.protocolType
+                modelOverride?.protocolType,
+                modelOverride?.wireApi
             )
             val variants = buildRequestVariants(sanitizedRequest, routeInfo)
             for (variantIndex in variants.indices) {
@@ -242,7 +247,8 @@ class HttpAgentLlmClient(
             modelOverride?.apiBase,
             modelOverride?.apiKey,
             modelOverride?.modelId,
-            modelOverride?.protocolType
+            modelOverride?.protocolType,
+            modelOverride?.wireApi
         )
         val accumulator = AgentLlmStreamAccumulator(
             json = json,
@@ -471,6 +477,7 @@ class HttpAgentLlmClient(
                 modelOverride?.apiKey,
                 modelOverride?.modelId,
                 modelOverride?.protocolType,
+                modelOverride?.wireApi,
                 forceHttp1
             )
             scheduleWatchdog()
@@ -544,7 +551,7 @@ class HttpAgentLlmClient(
         )
 
         val legacyFunctions = request.tools.map { it.function }
-        if (legacyFunctions.isNotEmpty()) {
+        if (legacyFunctions.isNotEmpty() && !routeInfo.wireApi.equals("responses", ignoreCase = true)) {
             add(
                 "legacy_functions",
                 request.copy(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeModels.kt
@@ -19,7 +19,8 @@ data class AgentModelOverride(
     val modelId: String,
     val apiBase: String,
     val apiKey: String,
-    val protocolType: String = "openai_compatible"
+    val protocolType: String = "openai_compatible",
+    val wireApi: String = "chat_completions"
 )
 
 data class ArtifactAction(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
@@ -150,7 +150,8 @@ class OmniAgentExecutor(
                         explicitApiBase = modelOverride?.apiBase,
                         explicitApiKey = modelOverride?.apiKey,
                         explicitModel = modelOverride?.modelId,
-                        explicitProtocolType = modelOverride?.protocolType
+                        explicitProtocolType = modelOverride?.protocolType,
+                        explicitWireApi = modelOverride?.wireApi
                     )
                 )
             }.getOrDefault(AgentToolImageContinuationPolicy.DEFAULT)

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -181,7 +181,8 @@ internal fun resolveChatTaskModelOverride(
         modelId = modelId,
         apiBase = providerProfile.baseUrl,
         apiKey = providerProfile.apiKey,
-        protocolType = providerProfile.protocolType.ifEmpty { "openai_compatible" }
+        protocolType = providerProfile.protocolType.ifEmpty { "openai_compatible" },
+        wireApi = providerProfile.wireApi
     )
 }
 
@@ -410,7 +411,8 @@ internal fun chatModelOverrideToAgentModelOverride(
         modelId = modelOverride.modelId,
         apiBase = modelOverride.apiBase,
         apiKey = modelOverride.apiKey,
-        protocolType = modelOverride.protocolType.ifEmpty { "openai_compatible" }
+        protocolType = modelOverride.protocolType.ifEmpty { "openai_compatible" },
+        wireApi = modelOverride.wireApi
     )
 }
 
@@ -865,7 +867,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             "baseUrl" to baseUrl,
             "apiKey" to apiKey,
             "source" to source,
-            "configured" to isConfigured()
+            "configured" to isConfigured(),
+            "wireApi" to wireApi
         )
     }
 
@@ -876,7 +879,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             "baseUrl" to baseUrl,
             "apiKey" to apiKey,
             "configured" to isConfigured(),
-            "protocolType" to protocolType
+            "protocolType" to protocolType,
+            "wireApi" to wireApi
         )
     }
 
@@ -2896,6 +2900,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val baseUrl = call.argument<String>("baseUrl")?.trim().orEmpty()
         val apiKey = call.argument<String>("apiKey")?.trim().orEmpty()
         val protocolType = call.argument<String>("protocolType")?.trim() ?: "openai_compatible"
+        val wireApi = call.argument<String>("wireApi")?.trim().orEmpty()
 
         workJob.launch {
             try {
@@ -2904,7 +2909,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     name = name,
                     baseUrl = baseUrl,
                     apiKey = apiKey,
-                    protocolType = protocolType
+                    protocolType = protocolType,
+                    wireApi = wireApi
                 )
                 syncAgentAiCapabilityConfigFile()
                 withContext(Dispatchers.Main) {
@@ -3035,7 +3041,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     val apiKey = if (baseUrlArg.isNotEmpty()) apiKeyArg else currentConfig.apiKey
                     val profile = profileId?.let(ModelProviderConfigStore::getProfile)
                         ?: ModelProviderConfigStore.getEditingProfile()
-                    HttpController.fetchProviderModels(apiBase, apiKey, profile.protocolType)
+                    HttpController.fetchProviderModels(
+                        apiBase = apiBase,
+                        apiKey = apiKey,
+                        protocolType = profile.protocolType,
+                        wireApi = profile.wireApi
+                    )
                 }
                 withContext(Dispatchers.Main) {
                     result.success(models.map { it.toMap() })
@@ -3076,10 +3087,13 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 } else {
                     val apiBase = if (baseUrlArg.isNotEmpty()) baseUrlArg else currentConfig.baseUrl
                     val apiKey = if (baseUrlArg.isNotEmpty()) apiKeyArg else currentConfig.apiKey
+                    val profile = profileId?.let(ModelProviderConfigStore::getProfile)
+                        ?: ModelProviderConfigStore.getEditingProfile()
                     HttpController.checkProviderModelAvailability(
                         model = model,
                         apiBase = apiBase,
-                        apiKey = apiKey
+                        apiKey = apiKey,
+                        wireApi = profile.wireApi
                     )
                 }
 
@@ -3997,7 +4011,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             modelId = modelId,
             apiBase = providerProfile.baseUrl,
             apiKey = providerProfile.apiKey,
-            protocolType = providerProfile.protocolType.ifEmpty { "openai_compatible" }
+            protocolType = providerProfile.protocolType.ifEmpty { "openai_compatible" },
+            wireApi = providerProfile.wireApi
         )
     }
 

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
@@ -32,7 +32,7 @@ class HttpAgentLlmClientTest {
             val client = HttpAgentLlmClient(
                 scope = scope,
                 modelOverride = testOverride(),
-                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                streamRequestOp = { _, _, listener, _, _, _, _, _, _ ->
                     val source = dummyEventSource()
                     listener.onOpen(source, okResponse())
                     listener.onEvent(
@@ -68,7 +68,7 @@ class HttpAgentLlmClientTest {
             val client = HttpAgentLlmClient(
                 scope = scope,
                 modelOverride = testOverride(),
-                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                streamRequestOp = { _, _, listener, _, _, _, _, _, _ ->
                     val source = dummyEventSource()
                     listener.onOpen(source, okResponse())
                     listener.onEvent(
@@ -101,7 +101,7 @@ class HttpAgentLlmClientTest {
             val client = HttpAgentLlmClient(
                 scope = scope,
                 modelOverride = testOverride(),
-                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                streamRequestOp = { _, _, listener, _, _, _, _, _, _ ->
                     val source = dummyEventSource()
                     listener.onOpen(source, okResponse())
                     listener.onEvent(
@@ -132,7 +132,7 @@ class HttpAgentLlmClientTest {
             val client = HttpAgentLlmClient(
                 scope = scope,
                 modelOverride = testOverride(),
-                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                resolveRouteInfoOp = { model, _, _, _, protocolType, _ ->
                     routeInfo(
                         requestedModel = model,
                         resolvedModel = "deepseek-v4-flash",
@@ -140,7 +140,7 @@ class HttpAgentLlmClientTest {
                         requiresReasoningEcho = true
                     )
                 },
-                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                streamRequestOp = { _, _, listener, _, _, _, _, _, _ ->
                     val source = dummyEventSource()
                     listener.onOpen(source, okResponse())
                     listener.onEvent(
@@ -172,7 +172,7 @@ class HttpAgentLlmClientTest {
             val client = HttpAgentLlmClient(
                 scope = scope,
                 modelOverride = testOverride(),
-                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                resolveRouteInfoOp = { model, _, _, _, protocolType, _ ->
                     routeInfo(
                         requestedModel = model,
                         resolvedModel = "qwen-plus",
@@ -180,7 +180,7 @@ class HttpAgentLlmClientTest {
                         requiresReasoningEcho = false
                     )
                 },
-                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                streamRequestOp = { _, _, listener, _, _, _, _, _, _ ->
                     val source = dummyEventSource()
                     listener.onOpen(source, okResponse())
                     listener.onEvent(
@@ -268,7 +268,7 @@ class HttpAgentLlmClientTest {
             val client = HttpAgentLlmClient(
                 scope = scope,
                 modelOverride = testOverride(),
-                resolveRouteInfoOp = { model, _, _, _, protocolType ->
+                resolveRouteInfoOp = { model, _, _, _, protocolType, _ ->
                     routeInfo(
                         requestedModel = model,
                         resolvedModel = "qwen3.6-plus",
@@ -276,7 +276,7 @@ class HttpAgentLlmClientTest {
                         requiresReasoningEcho = false
                     )
                 },
-                streamRequestOp = { _, _, listener, _, _, _, _, _ ->
+                streamRequestOp = { _, _, listener, _, _, _, _, _, _ ->
                     val source = dummyEventSource()
                     listener.onOpen(source, okResponse())
                     listener.onEvent(

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerResponsesTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerResponsesTest.kt
@@ -1,0 +1,288 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.assists.controller.http.HttpController
+import cn.com.omnimind.baselib.llm.contentText
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Request
+import okhttp3.sse.EventSource
+import okhttp3.sse.EventSourceListener
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HttpControllerResponsesTest {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `responses request body maps chat history to instructions input and function call output`() {
+        val method = HttpController::class.java.getDeclaredMethod(
+            "buildOpenAIResponsesRequestBody",
+            String::class.java,
+            String::class.java
+        )
+        method.isAccessible = true
+        val payload = method.invoke(
+            HttpController,
+            """
+                {
+                  "model": "gpt-4.1",
+                  "stream": true,
+                  "max_completion_tokens": 256,
+                  "tool_choice": "required",
+                  "tools": [
+                    {
+                      "type": "function",
+                      "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {"type":"object","properties":{"city":{"type":"string"}}}
+                      }
+                    }
+                  ],
+                  "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Weather in Shanghai?"},
+                    {
+                      "role": "assistant",
+                      "tool_calls": [
+                        {
+                          "id": "call_1",
+                          "type": "function",
+                          "function": {"name": "get_weather", "arguments": "{\"city\":\"Shanghai\"}"}
+                        }
+                      ]
+                    },
+                    {"role": "tool", "tool_call_id": "call_1", "content": "{\"temp\":28}"}
+                  ]
+                }
+            """.trimIndent(),
+            "gpt-4.1-mini"
+        ) as String
+
+        val root = json.parseToJsonElement(payload).jsonObject
+        assertEquals("gpt-4.1-mini", root["model"]?.jsonPrimitive?.content)
+        assertEquals("You are helpful.", root["instructions"]?.jsonPrimitive?.content)
+        assertEquals("required", root["tool_choice"]?.jsonPrimitive?.content)
+        assertEquals("256", root["max_output_tokens"]?.jsonPrimitive?.content)
+
+        val input = root["input"]!!.jsonArray
+        assertEquals("user", input[0].jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals(
+            "Weather in Shanghai?",
+            input[0].jsonObject["content"]!!.jsonArray[0].jsonObject["text"]?.jsonPrimitive?.content
+        )
+        assertEquals("function_call", input[1].jsonObject["type"]?.jsonPrimitive?.content)
+        assertEquals("call_1", input[1].jsonObject["call_id"]?.jsonPrimitive?.content)
+        assertEquals("function_call_output", input[2].jsonObject["type"]?.jsonPrimitive?.content)
+        assertEquals("{\"temp\":28}", input[2].jsonObject["output"]?.jsonPrimitive?.content)
+
+        val tools = root["tools"]!!.jsonArray
+        assertEquals("function", tools[0].jsonObject["type"]?.jsonPrimitive?.content)
+        assertEquals("get_weather", tools[0].jsonObject["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `responses stream adapter converts output text events into chat chunks`() {
+        val chunks = mutableListOf<String>()
+        val wrapped = HttpController.wrapResponsesListener(
+            object : EventSourceListener() {
+                override fun onEvent(
+                    eventSource: EventSource,
+                    id: String?,
+                    type: String?,
+                    data: String
+                ) {
+                    chunks += data
+                }
+            }
+        )
+
+        val source = dummyEventSource()
+        wrapped.onEvent(
+            source,
+            null,
+            "response.output_text.delta",
+            """{"type":"response.output_text.delta","delta":"Hello"}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.completed",
+            """{"type":"response.completed","response":{"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}}"""
+        )
+
+        val accumulator = AgentLlmStreamAccumulator(json)
+        chunks.forEach(accumulator::consume)
+        val turn = accumulator.buildTurn()
+
+        assertEquals("Hello", turn.message.contentText())
+        assertEquals(4, turn.usage?.promptTokens)
+    }
+
+    @Test
+    fun `responses stream adapter converts function call events into tool calls`() {
+        val chunks = mutableListOf<String>()
+        val wrapped = HttpController.wrapResponsesListener(
+            object : EventSourceListener() {
+                override fun onEvent(
+                    eventSource: EventSource,
+                    id: String?,
+                    type: String?,
+                    data: String
+                ) {
+                    chunks += data
+                }
+            }
+        )
+
+        val source = dummyEventSource()
+        wrapped.onEvent(
+            source,
+            null,
+            "response.output_item.added",
+            """{"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_7","name":"get_weather","arguments":"{\"city\":\"Shanghai\"}"}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.completed",
+            """{"type":"response.completed","response":{"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}}"""
+        )
+
+        val accumulator = AgentLlmStreamAccumulator(json)
+        chunks.forEach(accumulator::consume)
+        val turn = accumulator.buildTurn()
+
+        assertEquals(1, turn.message.toolCalls?.size)
+        assertEquals("get_weather", turn.message.toolCalls?.first()?.function?.name)
+        assertTrue(turn.message.toolCalls?.first()?.function?.arguments?.contains("Shanghai") == true)
+        assertEquals("tool_calls", turn.finishReason)
+    }
+
+    @Test
+    fun `responses stream adapter keeps item_id argument deltas on original tool call`() {
+        val chunks = mutableListOf<String>()
+        val wrapped = HttpController.wrapResponsesListener(
+            object : EventSourceListener() {
+                override fun onEvent(
+                    eventSource: EventSource,
+                    id: String?,
+                    type: String?,
+                    data: String
+                ) {
+                    chunks += data
+                }
+            }
+        )
+
+        val source = dummyEventSource()
+        wrapped.onEvent(
+            source,
+            null,
+            "response.output_item.added",
+            """{"type":"response.output_item.added","item":{"type":"function_call","id":"msg_tool_1","call_id":"call_7","name":"get_weather","arguments":"","status":"in_progress"}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.function_call_arguments.delta",
+            """{"type":"response.function_call_arguments.delta","item_id":"msg_tool_1","delta":"{\"city\":\"Shanghai\"}","output_index":1}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.function_call_arguments.done",
+            """{"type":"response.function_call_arguments.done","item_id":"msg_tool_1","name":"get_weather","arguments":"{\"city\":\"Shanghai\"}","output_index":1}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.completed",
+            """{"type":"response.completed","response":{"usage":{"prompt_tokens":4,"completion_tokens":1,"total_tokens":5}}}"""
+        )
+
+        val accumulator = AgentLlmStreamAccumulator(json)
+        chunks.forEach(accumulator::consume)
+        val turn = accumulator.buildTurn()
+
+        assertEquals(1, turn.message.toolCalls?.size)
+        assertEquals("call_7", turn.message.toolCalls?.first()?.id)
+        assertEquals("get_weather", turn.message.toolCalls?.first()?.function?.name)
+        assertEquals("""{"city":"Shanghai"}""", turn.message.toolCalls?.first()?.function?.arguments)
+        assertEquals("tool_calls", turn.finishReason)
+    }
+
+    @Test
+    fun `responses stream adapter deduplicates final assistant text snapshots`() {
+        val chunks = mutableListOf<String>()
+        val wrapped = HttpController.wrapResponsesListener(
+            object : EventSourceListener() {
+                override fun onEvent(
+                    eventSource: EventSource,
+                    id: String?,
+                    type: String?,
+                    data: String
+                ) {
+                    chunks += data
+                }
+            }
+        )
+
+        val source = dummyEventSource()
+        wrapped.onEvent(
+            source,
+            null,
+            "response.output_text.delta",
+            """{"type":"response.output_text.delta","delta":"Hello "}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.output_text.delta",
+            """{"type":"response.output_text.delta","delta":"world"}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.content_part.done",
+            """{"type":"response.content_part.done","part":{"type":"output_text","text":"Hello world"}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.output_item.done",
+            """{"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"Hello world"}]}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "response.completed",
+            """{"type":"response.completed","response":{"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}}"""
+        )
+
+        val accumulator = AgentLlmStreamAccumulator(json)
+        chunks.forEach(accumulator::consume)
+        val turn = accumulator.buildTurn()
+
+        assertEquals("Hello world", turn.message.contentText())
+        assertEquals("stop", turn.finishReason)
+        assertEquals(2, turn.usage?.completionTokens)
+    }
+
+    private fun dummyEventSource(): EventSource {
+        return object : EventSource {
+            override fun request(): Request =
+                Request.Builder().url("https://example.com").build()
+
+            override fun cancel() = Unit
+        }
+    }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/manager/AssistsCoreManagerChatOnlyTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/manager/AssistsCoreManagerChatOnlyTest.kt
@@ -2,6 +2,7 @@ package cn.com.omnimind.bot.manager
 
 import cn.com.omnimind.baselib.llm.ModelProviderProfile
 import cn.com.omnimind.assists.api.bean.TaskParams
+import cn.com.omnimind.bot.agent.AgentModelOverride
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -205,7 +206,59 @@ class AssistsCoreManagerChatOnlyTest {
         assertEquals("no", normalizeReasoningEffort(" NO "))
         assertEquals("low", normalizeReasoningEffort(" low "))
         assertEquals("high", normalizeReasoningEffort("HIGH"))
+        assertEquals("xhigh", normalizeReasoningEffort(" xhigh "))
+        assertEquals("max", normalizeReasoningEffort("MAX"))
         assertNull(normalizeReasoningEffort("medium"))
         assertNull(normalizeReasoningEffort(""))
+    }
+
+    @Test
+    fun `resolveAgentReasoningEffort defaults to max only for official deepseek targets`() {
+        val officialDeepSeekOverride = AgentModelOverride(
+            providerProfileId = "deepseek-official",
+            providerProfileName = "DeepSeek",
+            modelId = "deepseek-reasoner",
+            apiBase = "https://api.deepseek.com/v1",
+            apiKey = "secret",
+            protocolType = "deepseek"
+        )
+        val nonDeepSeekProfile = ModelProviderProfile(
+            id = "provider-1",
+            name = "Provider One",
+            baseUrl = "https://example.com/v1",
+            apiKey = "secret",
+            protocolType = "openai_compatible"
+        )
+
+        assertEquals("max", resolveAgentReasoningEffort(null, officialDeepSeekOverride))
+        assertEquals(
+            "max",
+            resolveAgentReasoningEffort(
+                reasoningEffort = null,
+                modelOverride = null,
+                fallbackProfile = ModelProviderProfile(
+                    id = "deepseek-official",
+                    name = "DeepSeek",
+                    baseUrl = "https://api.deepseek.com",
+                    apiKey = "secret",
+                    protocolType = "deepseek"
+                )
+            )
+        )
+        assertEquals(
+            "low",
+            resolveAgentReasoningEffort("low", officialDeepSeekOverride)
+        )
+        assertEquals(
+            "no",
+            resolveAgentReasoningEffort("no", officialDeepSeekOverride)
+        )
+        assertNull(
+            resolveAgentReasoningEffort(
+                reasoningEffort = null,
+                modelOverride = null,
+                fallbackProfile = nonDeepSeekProfile
+            )
+        )
     }
 }

--- a/assists/src/main/java/cn/com/omnimind/assists/api/bean/TaskParams.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/api/bean/TaskParams.kt
@@ -16,7 +16,8 @@ sealed class TaskParams {
         val modelId: String,
         val apiBase: String,
         val apiKey: String,
-        val protocolType: String = "openai_compatible"
+        val protocolType: String = "openai_compatible",
+        val wireApi: String = "chat_completions"
     )
     //陪伴任务参数
     data class CompanionTaskParams(

--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -19,8 +19,11 @@ import cn.com.omnimind.baselib.llm.ModelProviderConfig
 import cn.com.omnimind.baselib.llm.ModelProviderConfigStore
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.baselib.llm.ModelSceneRegistry
+import cn.com.omnimind.baselib.llm.OpenAiWireApi
+import cn.com.omnimind.baselib.llm.OpenAIResponsesRequest
 import cn.com.omnimind.baselib.llm.ProviderModelOption
 import cn.com.omnimind.baselib.llm.SceneModelBindingStore
+import cn.com.omnimind.baselib.llm.contentText
 import cn.com.omnimind.omniintelligence.models.AgentRequest.Payload
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -71,6 +74,7 @@ object HttpController {
         val bindingProfileMissing: Boolean,
         val overrideApplied: Boolean,
         val protocolType: String = "openai_compatible",
+        val wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS,
         val requiresReasoningEcho: Boolean = false
     )
 
@@ -90,7 +94,8 @@ object HttpController {
         val bindingProfileMissing: Boolean,
         val overrideApplied: Boolean,
         val overrideModel: String?,
-        val protocolType: String = "openai_compatible"
+        val protocolType: String = "openai_compatible",
+        val wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
     )
 
     private data class AiRequestLogSeed(
@@ -103,6 +108,13 @@ object HttpController {
         val requestJson: String
     )
 
+            private data class ResponseToolCallState(
+                var index: Int = -1,
+                var id: String = "",
+                var name: String = "",
+                val arguments: StringBuilder = StringBuilder()
+            )
+
     data class ModelAvailabilityCheckResult(
         val available: Boolean,
         val code: Int? = null,
@@ -114,14 +126,16 @@ object HttpController {
         explicitApiBase: String? = null,
         explicitApiKey: String? = null,
         explicitModel: String? = null,
-        explicitProtocolType: String? = null
+        explicitProtocolType: String? = null,
+        explicitWireApi: String? = null
     ): ChatCompletionRouteInfo {
         return resolveSceneRequest(
             modelOrScene = modelOrScene,
             explicitApiBase = explicitApiBase,
             explicitApiKey = explicitApiKey,
             explicitModel = explicitModel,
-            explicitProtocolType = explicitProtocolType
+            explicitProtocolType = explicitProtocolType,
+            explicitWireApi = explicitWireApi
         ).toRouteInfo()
     }
 
@@ -244,6 +258,13 @@ object HttpController {
         return runCatching {
             val json = JSONObject(trimmed)
             when {
+                json.optString("type") == "response.output_text.delta" -> json.optString("delta")
+                json.optString("type") == "response.reasoning_summary_text.delta" -> json.optString("delta")
+                json.optString("type") == "response.reasoning.delta" -> json.optString("delta")
+                json.has("output_text") -> json.optString("output_text")
+                json.has("output") -> extractResponsesOutputText(json).ifBlank {
+                    extractResponsesReasoningText(json)
+                }
                 json.has("text") -> json.optString("text")
                 json.has("message") && json.opt("message") is String -> json.optString("message")
                 json.has("choices") -> {
@@ -440,6 +461,7 @@ object HttpController {
             bindingProfileMissing = bindingProfileMissing,
             overrideApplied = overrideApplied,
             protocolType = protocolType,
+            wireApi = wireApi,
             requiresReasoningEcho = DeepSeekProvider.shouldUseOfficialAdapter(
                 protocolType = protocolType,
                 apiBase = apiBase
@@ -453,6 +475,7 @@ object HttpController {
         explicitApiKey: String? = null,
         explicitModel: String? = null,
         explicitProtocolType: String? = null,
+        explicitWireApi: String? = null,
         @Suppress("UNUSED_PARAMETER") defaultTransport: ModelSceneRegistry.SceneTransport = ModelSceneRegistry.SceneTransport.OPENAI_COMPATIBLE
     ): ResolvedSceneRequest {
         val requestedModel = modelOrScene.trim()
@@ -472,6 +495,7 @@ object HttpController {
         val explicitResolvedModel = explicitModel?.trim()?.takeIf { it.isNotEmpty() }
         val explicitProtocol = explicitProtocolType
             ?.let(DeepSeekProvider::normalizeProtocolType)
+        val explicitWire = explicitWireApi?.let(OpenAiWireApi::normalize)
         val providerConfig = if (explicitBase == null) {
             ModelProviderConfigStore.getConfig()
         } else {
@@ -515,6 +539,12 @@ object HttpController {
             bindingApplied -> boundProfile?.protocolType?.ifEmpty { "openai_compatible" } ?: "openai_compatible"
             else -> ModelProviderConfigStore.getEditingProfile().protocolType.ifEmpty { "openai_compatible" }
         }
+        val wireApi = when {
+            explicitWire != null -> explicitWire
+            bindingApplied -> boundProfile?.wireApi ?: OpenAiWireApi.CHAT_COMPLETIONS
+            providerBase != null -> providerConfig.wireApi
+            else -> ModelProviderConfigStore.getEditingProfile().wireApi
+        }
         val effectiveTransport = sceneProfile?.transport ?: defaultTransport
         val responseParser = sceneProfile?.responseParser ?: when (effectiveTransport) {
             ModelSceneRegistry.SceneTransport.OPENAI_COMPATIBLE,
@@ -549,7 +579,8 @@ object HttpController {
             bindingProfileMissing = bindingProfileMissing,
             overrideApplied = overrideApplied,
             overrideModel = overrideModel,
-            protocolType = protocolType
+            protocolType = protocolType,
+            wireApi = wireApi
         )
     }
 
@@ -566,6 +597,26 @@ object HttpController {
             "$base/chat/completions"
         } else {
             "$base/v1/chat/completions"
+        }
+    }
+
+    private fun buildOpenAIResponsesUrl(apiBase: String): String {
+        val base = ModelProviderConfigStore.stripDirectRequestUrlMarker(apiBase)
+        if (ModelProviderConfigStore.hasDirectRequestUrlMarker(apiBase)) {
+            return base
+        }
+        return if (base.endsWith("/v1", ignoreCase = true)) {
+            "$base/responses"
+        } else {
+            "$base/v1/responses"
+        }
+    }
+
+    private fun buildOpenAIInferenceUrl(apiBase: String, wireApi: String): String {
+        return if (OpenAiWireApi.isResponses(wireApi)) {
+            buildOpenAIResponsesUrl(apiBase)
+        } else {
+            buildOpenAIChatCompletionsUrl(apiBase)
         }
     }
 
@@ -993,6 +1044,341 @@ object HttpController {
      * 包装一个 EventSourceListener，将 Anthropic SSE 事件实时翻译为 OpenAI-style chunks
      * 后转发给 outer，使上层 AgentLlmStreamAccumulator 无需修改。
      */
+    fun wrapResponsesListener(outer: EventSourceListener): EventSourceListener {
+        return object : EventSourceListener() {
+            private val toolCalls = linkedMapOf<String, ResponseToolCallState>()
+            private val toolCallAliases = linkedMapOf<String, String>()
+            private val assistantText = StringBuilder()
+            private var nextToolIndex = 0
+            private var sawToolCall = false
+
+            override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {
+                outer.onOpen(eventSource, response)
+            }
+
+            override fun onEvent(
+                eventSource: EventSource,
+                id: String?,
+                type: String?,
+                data: String
+            ) {
+                if (data == "[DONE]") {
+                    outer.onEvent(eventSource, id, type, "[DONE]")
+                    return
+                }
+                val json = runCatching {
+                    completionJson.parseToJsonElement(data) as? KxJsonObject
+                }.getOrNull() ?: return
+                val eventType = type?.trim()?.takeIf { it.isNotEmpty() }
+                    ?: json.string("type").trim().takeIf { it.isNotEmpty() }
+                    ?: return
+                when (eventType) {
+                    "response.output_text.delta" -> {
+                        emitAssistantText(
+                            eventSource = eventSource,
+                            id = id,
+                            type = type,
+                            incoming = json.string("delta"),
+                            isSnapshot = false
+                        )
+                    }
+                    "response.output_text.done" -> {
+                        emitAssistantText(
+                            eventSource = eventSource,
+                            id = id,
+                            type = type,
+                            incoming = json.string("text"),
+                            isSnapshot = true
+                        )
+                    }
+                    "response.content_part.added",
+                    "response.content_part.done" -> {
+                        val part = json.obj("part") ?: return
+                        if (part.string("type") != "output_text") return
+                        emitAssistantText(
+                            eventSource = eventSource,
+                            id = id,
+                            type = type,
+                            incoming = part.string("text"),
+                            isSnapshot = true
+                        )
+                    }
+                    "response.reasoning_summary_text.delta",
+                    "response.reasoning.delta" -> {
+                        val delta = json.string("delta")
+                        if (delta.isNotEmpty()) {
+                            outer.onEvent(
+                                eventSource,
+                                id,
+                                type,
+                                buildOpenAIChunk(buildSingleFieldDelta("reasoning_content", delta), null)
+                            )
+                        }
+                    }
+                    "response.output_item.added",
+                    "response.output_item.done" -> {
+                        val item = json.obj("item") ?: return
+                        when (item.string("type")) {
+                            "function_call" -> {
+                                sawToolCall = true
+                                val state = getOrCreateResponsesToolCallState(item)
+                                registerResponsesToolCallAlias(item, state.id)
+                                state.name = item.string("name").ifBlank { state.name }
+                                val arguments = item.string("arguments")
+                                val emittedArguments = updateResponsesArguments(state, arguments)
+                                outer.onEvent(
+                                    eventSource,
+                                    id,
+                                    type,
+                                    buildOpenAIToolCallChunk(
+                                        state = state,
+                                        finishReason = if (eventType.endsWith(".done")) "tool_calls" else null,
+                                        argumentsDelta = emittedArguments
+                                    )
+                                )
+                            }
+                            "message" -> {
+                                val content = item.array("content") ?: return
+                                content.forEach { blockElement ->
+                                    val block = blockElement as? KxJsonObject ?: return@forEach
+                                    emitAssistantText(
+                                        eventSource = eventSource,
+                                        id = id,
+                                        type = type,
+                                        incoming = block.string("text"),
+                                        isSnapshot = true
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    "response.function_call_arguments.delta",
+                    "response.function_call_arguments.done" -> {
+                        sawToolCall = true
+                        val state = getOrCreateResponsesToolCallState(json)
+                        val delta = if (eventType.endsWith(".done")) {
+                            json.string("arguments")
+                        } else {
+                            json.string("delta")
+                        }
+                        val emittedArguments = updateResponsesArguments(state, delta)
+                        outer.onEvent(
+                            eventSource,
+                            id,
+                            type,
+                            buildOpenAIToolCallChunk(
+                                state = state,
+                                finishReason = if (eventType.endsWith(".done")) "tool_calls" else null,
+                                argumentsDelta = emittedArguments
+                            )
+                        )
+                    }
+                    "response.completed" -> {
+                        val responseObj = json.obj("response") ?: json
+                        val usage = responseObj.obj("usage")
+                        outer.onEvent(
+                            eventSource,
+                            id,
+                            type,
+                            buildOpenAIChunk(
+                            deltaJson = "{}",
+                                finishReason = if (sawToolCall) "tool_calls" else "stop",
+                                usage = usage
+                            )
+                        )
+                        outer.onEvent(eventSource, id, type, "[DONE]")
+                    }
+                    else -> {
+                        if (json.containsKey("error")) {
+                            outer.onEvent(eventSource, id, type, data)
+                        }
+                    }
+                }
+            }
+
+            override fun onClosed(eventSource: EventSource) {
+                outer.onClosed(eventSource)
+            }
+
+            override fun onFailure(
+                eventSource: EventSource,
+                t: Throwable?,
+                response: okhttp3.Response?
+            ) {
+                outer.onFailure(eventSource, t, response)
+            }
+
+            private fun getOrCreateResponsesToolCallState(raw: KxJsonObject): ResponseToolCallState {
+                val callId = resolveResponsesToolCallId(raw)
+                return toolCalls.getOrPut(callId) {
+                    ResponseToolCallState(
+                        index = nextToolIndex++,
+                        id = callId,
+                        name = raw.string("name")
+                    )
+                }
+            }
+
+            private fun resolveResponsesToolCallId(raw: KxJsonObject): String {
+                val candidates = listOf(
+                    raw.string("call_id"),
+                    raw.string("id"),
+                    raw.string("item_id")
+                )
+                for (candidate in candidates) {
+                    if (candidate.isBlank()) continue
+                    val alias = toolCallAliases[candidate]
+                    if (!alias.isNullOrBlank()) {
+                        return alias
+                    }
+                }
+                return candidates.firstOrNull { it.isNotBlank() }
+                    ?: "tool_${nextToolIndex}"
+            }
+
+            private fun registerResponsesToolCallAlias(
+                raw: KxJsonObject,
+                canonicalId: String
+            ) {
+                listOf(
+                    raw.string("call_id"),
+                    raw.string("id"),
+                    raw.string("item_id")
+                ).forEach { candidate ->
+                    if (candidate.isNotBlank()) {
+                        toolCallAliases[candidate] = canonicalId
+                    }
+                }
+            }
+
+            private fun KxJsonObject.string(name: String): String {
+                return (this[name] as? JsonPrimitive)?.contentOrNull.orEmpty()
+            }
+
+            private fun KxJsonObject.obj(name: String): KxJsonObject? {
+                return this[name] as? KxJsonObject
+            }
+
+            private fun KxJsonObject.array(name: String): KxJsonArray? {
+                return this[name] as? KxJsonArray
+            }
+
+            private fun buildOpenAIToolCallChunk(
+                state: ResponseToolCallState,
+                finishReason: String?,
+                argumentsDelta: String? = null
+            ): String {
+                val emittedArguments = argumentsDelta ?: state.arguments.toString()
+                return buildOpenAIChunk(
+                    deltaJson = buildString {
+                        append("{\"tool_calls\":[{")
+                        append("\"index\":")
+                        append(state.index)
+                        append(",\"id\":")
+                        append(completionJson.encodeToString(state.id))
+                        append(",\"type\":\"function\"")
+                        append(",\"function\":{")
+                        append("\"name\":")
+                        append(completionJson.encodeToString(state.name))
+                        append(",\"arguments\":")
+                        append(completionJson.encodeToString(emittedArguments))
+                        append("}}]}")
+                    },
+                    finishReason = finishReason
+                )
+            }
+
+            private fun updateResponsesArguments(
+                state: ResponseToolCallState,
+                incoming: String
+            ): String? {
+                if (incoming.isEmpty()) {
+                    return null
+                }
+                val current = state.arguments.toString()
+                val emitted = when {
+                    current.isEmpty() -> incoming
+                    incoming == current -> ""
+                    incoming.startsWith(current) -> incoming.substring(current.length)
+                    current.startsWith(incoming) -> ""
+                    else -> incoming
+                }
+                if (incoming != current) {
+                    state.arguments.setLength(0)
+                    state.arguments.append(incoming)
+                }
+                return emitted
+            }
+
+            private fun emitAssistantText(
+                eventSource: EventSource,
+                id: String?,
+                type: String?,
+                incoming: String,
+                isSnapshot: Boolean
+            ) {
+                val emitted = updateAssistantText(incoming, isSnapshot) ?: return
+                outer.onEvent(
+                    eventSource,
+                    id,
+                    type,
+                    buildOpenAIChunk(buildSingleFieldDelta("content", emitted), null)
+                )
+            }
+
+            private fun updateAssistantText(
+                incoming: String,
+                isSnapshot: Boolean
+            ): String? {
+                if (incoming.isEmpty()) {
+                    return null
+                }
+                if (!isSnapshot) {
+                    assistantText.append(incoming)
+                    return incoming
+                }
+                val current = assistantText.toString()
+                val emitted = when {
+                    current.isEmpty() -> incoming
+                    incoming == current -> ""
+                    incoming.startsWith(current) -> incoming.substring(current.length)
+                    current.startsWith(incoming) -> ""
+                    else -> incoming
+                }
+                if (incoming != current) {
+                    assistantText.setLength(0)
+                    assistantText.append(incoming)
+                }
+                return emitted.ifEmpty { null }
+            }
+
+            private fun buildSingleFieldDelta(field: String, value: String): String {
+                return "{\"$field\":${completionJson.encodeToString(value)}}"
+            }
+
+            private fun buildOpenAIChunk(
+                deltaJson: String,
+                finishReason: String?,
+                usage: KxJsonObject? = null
+            ): String {
+                val finishReasonPart = finishReason?.let {
+                    ",\"finish_reason\":${completionJson.encodeToString(it)}"
+                }.orEmpty()
+                val usagePart = usage?.let {
+                    ",\"usage\":${it.toString()}"
+                }.orEmpty()
+                return buildString {
+                    append("{\"choices\":[{\"delta\":")
+                    append(deltaJson.toString())
+                    append(finishReasonPart)
+                    append("}]")
+                    append(usagePart)
+                    append("}")
+                }
+            }
+        }
+    }
+
     fun wrapAnthropicListener(outer: EventSourceListener): EventSourceListener {
         return object : EventSourceListener() {
             // per-stream state
@@ -1553,6 +1939,139 @@ object HttpController {
         return stripAnthropicOnlyFieldsForOpenAiCompatible(protocolReadyBody)
     }
 
+    private fun buildOpenAIResponsesRequestBody(
+        requestBodyJson: String,
+        resolvedModel: String
+    ): String {
+        val parsedRequest = completionJson.decodeFromString<ChatCompletionRequest>(requestBodyJson)
+            .copy(model = resolvedModel)
+        val systemInstructions = parsedRequest.messages
+            .filter { it.role == "system" }
+            .mapNotNull { it.contentText().trim().takeIf { text -> text.isNotEmpty() } }
+            .joinToString(separator = "\n\n")
+            .trim()
+            .ifEmpty { null }
+        val payload = OpenAIResponsesRequest(
+            model = parsedRequest.model,
+            input = buildResponsesInputItems(parsedRequest.messages.filter { it.role != "system" }),
+            instructions = systemInstructions,
+            maxOutputTokens = parsedRequest.maxCompletionTokens ?: parsedRequest.maxTokens,
+            stream = parsedRequest.stream,
+            tools = buildResponsesTools(parsedRequest),
+            toolChoice = buildResponsesToolChoice(parsedRequest.toolChoice),
+            reasoning = buildResponsesReasoning(parsedRequest)
+        )
+        return stripAnthropicOnlyFieldsForOpenAiCompatible(
+            completionJson.encodeToString(payload)
+        )
+    }
+
+    private fun buildResponsesInputItems(messages: List<ChatCompletionMessage>): List<JsonElement> {
+        val items = mutableListOf<JsonElement>()
+        messages.forEach { message ->
+            when (message.role) {
+                "tool" -> {
+                    items += buildJsonObject {
+                        put("type", "function_call_output")
+                        put("call_id", message.toolCallId.orEmpty())
+                        put("output", message.contentText())
+                    }
+                }
+                "assistant" -> {
+                    val visibleText = buildList {
+                        message.reasoningContent?.trim()?.takeIf { it.isNotEmpty() }?.let { add(it) }
+                        message.contentText().trim().takeIf { it.isNotEmpty() }?.let { add(it) }
+                    }.joinToString(separator = "\n\n").trim()
+                    if (visibleText.isNotEmpty()) {
+                        items += buildResponsesMessageItem("assistant", visibleText)
+                    }
+                    message.toolCalls.orEmpty().forEach { toolCall ->
+                        items += buildJsonObject {
+                            put("type", "function_call")
+                            put("call_id", toolCall.id)
+                            put("name", toolCall.function.name)
+                            put("arguments", toolCall.function.arguments)
+                        }
+                    }
+                }
+                else -> {
+                    val text = message.contentText()
+                    if (text.isNotBlank()) {
+                        items += buildResponsesMessageItem(message.role.ifBlank { "user" }, text)
+                    }
+                }
+            }
+        }
+        return items
+    }
+
+    private fun buildResponsesMessageItem(role: String, text: String): JsonElement {
+        return buildJsonObject {
+            put("role", role)
+            put(
+                "content",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("type", "input_text")
+                            put("text", text)
+                        }
+                    )
+                }
+            )
+        }
+    }
+
+    private fun buildResponsesTools(request: ChatCompletionRequest): List<JsonElement> {
+        return request.tools.map { tool ->
+            buildJsonObject {
+                put("type", "function")
+                put("name", tool.function.name)
+                if (tool.function.description.isNotBlank()) {
+                    put("description", tool.function.description)
+                }
+                put("parameters", tool.function.parameters)
+            }
+        }
+    }
+
+    private fun buildResponsesToolChoice(toolChoice: JsonElement?): JsonElement? {
+        return when (toolChoice) {
+            null -> null
+            is JsonPrimitive -> {
+                val normalized = toolChoice.contentOrNull?.trim().orEmpty()
+                normalized.takeIf { it.isNotEmpty() }?.let(::JsonPrimitive)
+            }
+            is KxJsonObject -> {
+                val functionName = toolChoice["function"]?.let { raw ->
+                    (raw as? KxJsonObject)?.get("name")?.jsonPrimitive?.contentOrNull
+                }?.trim().orEmpty()
+                if (functionName.isEmpty()) {
+                    JsonPrimitive("auto")
+                } else {
+                    buildJsonObject {
+                        put("type", "function")
+                        put("name", functionName)
+                    }
+                }
+            }
+            else -> null
+        }
+    }
+
+    private fun buildResponsesReasoning(request: ChatCompletionRequest): JsonElement? {
+        if (request.enableThinking == false || request.thinking?.type == "disabled") {
+            return null
+        }
+        val normalizedEffort = request.reasoningEffort?.trim()?.lowercase()
+        val effort = when (normalizedEffort) {
+            "low", "medium", "high" -> normalizedEffort
+            "xhigh", "max" -> "high"
+            else -> null
+        } ?: return null
+        return buildJsonObject { put("effort", effort) }
+    }
+
     private fun applyLocalBackendMaxCompletionTokens(
         requestBodyJson: String,
         apiBase: String?
@@ -1644,7 +2163,8 @@ object HttpController {
         apiKey: String?,
         event: EventSourceListener,
         routeTag: String? = null,
-        protocolType: String = "openai_compatible"
+        protocolType: String = "openai_compatible",
+        wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
     ): EventSource = withContext(Dispatchers.IO) {
         if (protocolType == "anthropic") {
             val resolved = ResolvedSceneRequest(
@@ -1670,31 +2190,49 @@ object HttpController {
         }
         val base = normalizeApiBase(apiBase ?: "")
             ?: throw IllegalArgumentException("Invalid apiBase")
-        val requestJson = buildOpenAICompatibleRequestBody(
-            requestBodyJson = completionJson.encodeToString(chatRequest.copy(stream = true)),
-            resolvedModel = chatRequest.model,
-            includeLegacyMirrors = false,
-            protocolType = protocolType,
-            apiBase = base
-        )
+        val normalizedWireApi = OpenAiWireApi.normalize(wireApi)
+        val requestJson = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+            buildOpenAIResponsesRequestBody(
+                requestBodyJson = completionJson.encodeToString(chatRequest.copy(stream = true)),
+                resolvedModel = chatRequest.model
+            )
+        } else {
+            buildOpenAICompatibleRequestBody(
+                requestBodyJson = completionJson.encodeToString(chatRequest.copy(stream = true)),
+                resolvedModel = chatRequest.model,
+                includeLegacyMirrors = false,
+                protocolType = protocolType,
+                apiBase = base
+            )
+        }
         val requestBody = requestJson.toRequestBody("application/json".toMediaType())
+        val url = buildOpenAIInferenceUrl(base, normalizedWireApi)
         val request = buildOpenAIRequestBuilder(
-            url = buildOpenAIChatCompletionsUrl(base),
+            url = url,
             requestBody = requestBody,
             apiKey = apiKey
         )
             .addHeader("Accept", "text/event-stream")
             .build()
+        val delegate = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+            wrapResponsesListener(event)
+        } else {
+            event
+        }
         EventSources.createFactory(openAIStreamClient()).newEventSource(
             request,
             createLoggingEventListener(
                 "[openai_compatible stream model=${chatRequest.model} route=${routeTag.orEmpty()}]",
-                event,
+                delegate,
                 requestLogSeed = AiRequestLogSeed(
-                    label = "openai/chat.completions.stream",
+                    label = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                        "openai/responses.stream"
+                    } else {
+                        "openai/chat.completions.stream"
+                    },
                     model = chatRequest.model,
                     protocolType = protocolType,
-                    url = buildOpenAIChatCompletionsUrl(base),
+                    url = url,
                     stream = true,
                     requestJson = requestJson
                 )
@@ -1722,32 +2260,50 @@ object HttpController {
         }
         val base = normalizeApiBase(resolved.apiBase ?: "")
             ?: throw IllegalArgumentException("Invalid apiBase")
-        val preparedRequestJson = buildOpenAICompatibleRequestBody(
-            requestBodyJson = requestBodyJson,
-            resolvedModel = resolved.resolvedModel,
-            includeLegacyMirrors = false,
-            mirrorLegacyTokenFields = false,
-            protocolType = resolved.protocolType,
-            apiBase = base
-        )
+        val normalizedWireApi = OpenAiWireApi.normalize(resolved.wireApi)
+        val preparedRequestJson = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+            buildOpenAIResponsesRequestBody(
+                requestBodyJson = requestBodyJson,
+                resolvedModel = resolved.resolvedModel
+            )
+        } else {
+            buildOpenAICompatibleRequestBody(
+                requestBodyJson = requestBodyJson,
+                resolvedModel = resolved.resolvedModel,
+                includeLegacyMirrors = false,
+                mirrorLegacyTokenFields = false,
+                protocolType = resolved.protocolType,
+                apiBase = base
+            )
+        }
         val requestBody = preparedRequestJson.toRequestBody("application/json".toMediaType())
+        val url = buildOpenAIInferenceUrl(base, normalizedWireApi)
         val request = buildOpenAIRequestBuilder(
-            url = buildOpenAIChatCompletionsUrl(base),
+            url = url,
             requestBody = requestBody,
             apiKey = resolved.apiKey
         )
             .addHeader("Accept", "text/event-stream")
             .build()
+        val delegate = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+            wrapResponsesListener(event)
+        } else {
+            event
+        }
         EventSources.createFactory(openAIStreamClient(forceHttp1)).newEventSource(
             request,
             createLoggingEventListener(
                 "[openai_compatible chat-completions model=${resolved.resolvedModel}]",
-                event,
+                delegate,
                 requestLogSeed = AiRequestLogSeed(
-                    label = "openai/chat.completions.stream",
+                    label = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                        "openai/responses.stream"
+                    } else {
+                        "openai/chat.completions.stream"
+                    },
                     model = resolved.resolvedModel,
                     protocolType = resolved.protocolType,
-                    url = buildOpenAIChatCompletionsUrl(base),
+                    url = url,
                     stream = true,
                     requestJson = preparedRequestJson
                 )
@@ -1811,7 +2367,8 @@ object HttpController {
             apiKey = resolved.apiKey,
             event = event,
             routeTag = resolved.routeTag,
-            protocolType = resolved.protocolType
+            protocolType = resolved.protocolType,
+            wireApi = resolved.wireApi
         )
     }
 
@@ -1832,6 +2389,7 @@ object HttpController {
         explicitApiKey: String? = null,
         explicitModel: String? = null,
         explicitProtocolType: String? = null,
+        explicitWireApi: String? = null,
         reasoningEffort: String? = null
     ): EventSource {
         val resolved = resolveSceneRequest(
@@ -1839,7 +2397,8 @@ object HttpController {
             explicitApiBase = explicitApiBase,
             explicitApiKey = explicitApiKey,
             explicitModel = explicitModel,
-            explicitProtocolType = explicitProtocolType
+            explicitProtocolType = explicitProtocolType,
+            explicitWireApi = explicitWireApi
         )
         logSceneProfile(resolved)
         prepareLocalProviderIfNeeded(resolved)
@@ -1854,7 +2413,8 @@ object HttpController {
             apiKey = resolved.apiKey,
             event = event,
             routeTag = resolved.routeTag,
-            protocolType = resolved.protocolType
+            protocolType = resolved.protocolType,
+            wireApi = resolved.wireApi
         )
     }
 
@@ -1872,6 +2432,7 @@ object HttpController {
         explicitApiKey: String? = null,
         explicitModel: String? = null,
         explicitProtocolType: String? = null,
+        explicitWireApi: String? = null,
         forceHttp1: Boolean = false
     ): EventSource {
         val resolved = resolveSceneRequest(
@@ -1879,7 +2440,8 @@ object HttpController {
             explicitApiBase = explicitApiBase,
             explicitApiKey = explicitApiKey,
             explicitModel = explicitModel,
-            explicitProtocolType = explicitProtocolType
+            explicitProtocolType = explicitProtocolType,
+            explicitWireApi = explicitWireApi
         )
         logSceneProfile(resolved)
         return postOpenAIChatCompletionsStreamRequest(
@@ -2034,7 +2596,8 @@ object HttpController {
             apiBase = resolved.apiBase,
             apiKey = resolved.apiKey,
             event = event,
-            routeTag = resolved.routeTag
+            routeTag = resolved.routeTag,
+            wireApi = resolved.wireApi
         )
     }
 
@@ -2056,7 +2619,8 @@ object HttpController {
             apiBase = resolved.apiBase,
             apiKey = resolved.apiKey,
             event = event,
-            routeTag = resolved.routeTag
+            routeTag = resolved.routeTag,
+            wireApi = resolved.wireApi
         )
     }
 
@@ -2180,7 +2744,8 @@ object HttpController {
             )
         }
 
-        val url = buildOpenAIChatCompletionsUrl(base)
+        val normalizedWireApi = OpenAiWireApi.normalize(resolved.wireApi)
+        val url = buildOpenAIInferenceUrl(base, normalizedWireApi)
         val variants = if (retryOnBadRequest) {
             buildSceneRequestVariants(request.copy(model = resolved.resolvedModel, stream = false))
         } else {
@@ -2196,13 +2761,20 @@ object HttpController {
                 )
             }
 
-            val requestJson = buildOpenAICompatibleRequestBody(
-                requestBodyJson = completionJson.encodeToString(variant.request),
-                resolvedModel = variant.request.model,
-                includeLegacyMirrors = false,
-                protocolType = resolved.protocolType,
-                apiBase = base
-            )
+            val requestJson = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                buildOpenAIResponsesRequestBody(
+                    requestBodyJson = completionJson.encodeToString(variant.request),
+                    resolvedModel = variant.request.model
+                )
+            } else {
+                buildOpenAICompatibleRequestBody(
+                    requestBodyJson = completionJson.encodeToString(variant.request),
+                    resolvedModel = variant.request.model,
+                    includeLegacyMirrors = false,
+                    protocolType = resolved.protocolType,
+                    apiBase = base
+                )
+            }
             OmniLog.d(TAG, "=== OpenAI Request Debug ===")
             OmniLog.d(TAG, "URL: $url")
             OmniLog.d(TAG, "Model: ${variant.request.model}, hasApiKey=${!resolved.apiKey.isNullOrBlank()}, variant=${variant.name}")
@@ -2222,7 +2794,11 @@ object HttpController {
             logResponseBody("[openai_compatible model=${variant.request.model}]", responseBody)
             persistAiRequestLog(
                 seed = AiRequestLogSeed(
-                    label = "openai/chat.completions",
+                    label = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                        "openai/responses"
+                    } else {
+                        "openai/chat.completions"
+                    },
                     model = variant.request.model,
                     protocolType = resolved.protocolType,
                     url = url,
@@ -2251,10 +2827,11 @@ object HttpController {
                 return@withContext failure
             }
 
-            return@withContext parseStructuredSceneResponse(
+            return@withContext parseOpenAiStructuredSceneResponse(
                 response = responseBody,
                 parser = resolved.responseParser,
-                routeTag = resolved.routeTag
+                routeTag = resolved.routeTag,
+                wireApi = normalizedWireApi
             )
         }
 
@@ -2272,7 +2849,8 @@ object HttpController {
     suspend fun checkVlmModelAvailability(
         model: String,
         apiBase: String,
-        apiKey: String?
+        apiKey: String?,
+        wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
     ): ModelAvailabilityCheckResult = withContext(Dispatchers.IO) {
         val normalizedModel = model.trim()
         if (normalizedModel.isEmpty()) {
@@ -2289,7 +2867,8 @@ object HttpController {
                 code = null,
                 message = "URL 非法，请输入 http(s) 地址"
             )
-        val url = buildOpenAIChatCompletionsUrl(normalizedApiBase)
+        val normalizedWireApi = OpenAiWireApi.normalize(wireApi)
+        val url = buildOpenAIInferenceUrl(normalizedApiBase, normalizedWireApi)
 
         return@withContext try {
             val isOfficialDeepSeek = DeepSeekProvider.isOfficialBaseUrl(normalizedApiBase)
@@ -2312,13 +2891,20 @@ object HttpController {
                     )
                 )
             }
-            val requestJson = buildOpenAICompatibleRequestBody(
-                requestBodyJson = baseRequestJson.toString(),
-                resolvedModel = normalizedModel,
-                includeLegacyMirrors = false,
-                protocolType = DeepSeekProvider.normalizeProtocolType(null),
-                apiBase = normalizedApiBase
-            )
+            val requestJson = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                buildOpenAIResponsesRequestBody(
+                    requestBodyJson = baseRequestJson.toString(),
+                    resolvedModel = normalizedModel
+                )
+            } else {
+                buildOpenAICompatibleRequestBody(
+                    requestBodyJson = baseRequestJson.toString(),
+                    resolvedModel = normalizedModel,
+                    includeLegacyMirrors = false,
+                    protocolType = DeepSeekProvider.normalizeProtocolType(null),
+                    apiBase = normalizedApiBase
+                )
+            }
 
             val requestBody = requestJson.toRequestBody("application/json".toMediaType())
             val response = OkHttpClient().newCall(
@@ -2333,15 +2919,19 @@ object HttpController {
                 )
             }
 
-            val hasChoices = try {
+            val hasExpectedShape = try {
                 val json = JSONObject(responseBody ?: "{}")
-                val choices = json.optJSONArray("choices")
-                choices != null && choices.length() > 0
+                if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                    json.has("output") || json.has("output_text")
+                } else {
+                    val choices = json.optJSONArray("choices")
+                    choices != null && choices.length() > 0
+                }
             } catch (_: Exception) {
                 false
             }
 
-            if (hasChoices) {
+            if (hasExpectedShape) {
                 ModelAvailabilityCheckResult(
                     available = true,
                     code = response.code,
@@ -2351,7 +2941,11 @@ object HttpController {
                 ModelAvailabilityCheckResult(
                     available = false,
                     code = response.code,
-                    message = "响应不符合 OpenAI 结构（缺少 choices）"
+                    message = if (OpenAiWireApi.isResponses(normalizedWireApi)) {
+                        "响应不符合 Responses 结构（缺少 output）"
+                    } else {
+                        "响应不符合 OpenAI 结构（缺少 choices）"
+                    }
                 )
             }
         } catch (e: Exception) {
@@ -2366,15 +2960,17 @@ object HttpController {
     suspend fun checkProviderModelAvailability(
         model: String,
         apiBase: String,
-        apiKey: String?
+        apiKey: String?,
+        wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
     ): ModelAvailabilityCheckResult {
-        return checkVlmModelAvailability(model, apiBase, apiKey)
+        return checkVlmModelAvailability(model, apiBase, apiKey, wireApi)
     }
 
     suspend fun fetchProviderModels(
         apiBase: String,
         apiKey: String?,
-        protocolType: String = "openai_compatible"
+        protocolType: String = "openai_compatible",
+        @Suppress("UNUSED_PARAMETER") wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
     ): List<ProviderModelOption> = withContext(Dispatchers.IO) {
         val normalizedApiBase = normalizeApiBase(apiBase)
             ?: return@withContext emptyList()
@@ -2467,11 +3063,15 @@ object HttpController {
         )
     }
 
-    private fun parseStructuredSceneResponse(
+    private fun parseOpenAiStructuredSceneResponse(
         response: String?,
         parser: ModelSceneRegistry.ResponseParser,
-        routeTag: String?
+        routeTag: String?,
+        wireApi: String
     ): SceneChatCompletionResponse {
+        if (OpenAiWireApi.isResponses(wireApi)) {
+            return parseResponsesSceneResponse(response, parser, routeTag)
+        }
         return try {
             val jsonObject = JSONObject(response ?: "{}")
             val choices = jsonObject.optJSONArray("choices")
@@ -2537,6 +3137,125 @@ object HttpController {
                 rawResponseBody = response
             )
         }
+    }
+
+    private fun parseResponsesSceneResponse(
+        response: String?,
+        parser: ModelSceneRegistry.ResponseParser,
+        routeTag: String?
+    ): SceneChatCompletionResponse {
+        return try {
+            val jsonObject = JSONObject(response ?: "{}")
+            val content = extractResponsesOutputText(jsonObject)
+            val reasoning = extractResponsesReasoningText(jsonObject)
+            val toolCalls = extractResponsesToolCalls(jsonObject)
+            val finishReason = jsonObject.optString("status").trim().takeIf { it.isNotEmpty() }
+            if (content.isBlank() && toolCalls.isEmpty()) {
+                return buildFailureSceneResponse(
+                    code = "500",
+                    message = "响应不符合 Responses 结构（缺少 output）",
+                    parser = parser,
+                    routeTag = routeTag,
+                    rawResponseBody = response
+                )
+            }
+            SceneChatCompletionResponse(
+                success = true,
+                code = "200",
+                message = "success",
+                parser = parser,
+                route = routeTag,
+                content = content,
+                reasoning = reasoning,
+                finishReason = finishReason,
+                toolCalls = toolCalls,
+                rawResponseBody = response
+            )
+        } catch (e: Exception) {
+            safeLogError("Failed to parse responses output: ${e.message}")
+            buildFailureSceneResponse(
+                code = "500",
+                message = "Responses parse error: ${e.message}",
+                parser = parser,
+                routeTag = routeTag,
+                rawResponseBody = response
+            )
+        }
+    }
+
+    private fun extractResponsesOutputText(root: JSONObject): String {
+        val direct = root.optString("output_text").trim()
+        if (direct.isNotEmpty()) {
+            return direct
+        }
+        val output = root.optJSONArray("output") ?: return ""
+        val buffer = StringBuilder()
+        for (i in 0 until output.length()) {
+            val item = output.optJSONObject(i) ?: continue
+            when (item.optString("type")) {
+                "message" -> {
+                    val content = item.optJSONArray("content") ?: continue
+                    for (j in 0 until content.length()) {
+                        val block = content.optJSONObject(j) ?: continue
+                        when (block.optString("type")) {
+                            "output_text", "text", "input_text" -> {
+                                buffer.append(
+                                    block.optString("text").ifEmpty {
+                                        block.optString("content")
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+                "output_text", "text" -> {
+                    buffer.append(
+                        item.optString("text").ifEmpty {
+                            item.optString("content")
+                        }
+                    )
+                }
+            }
+        }
+        return buffer.toString()
+    }
+
+    private fun extractResponsesReasoningText(root: JSONObject): String {
+        val output = root.optJSONArray("output") ?: return ""
+        val buffer = StringBuilder()
+        for (i in 0 until output.length()) {
+            val item = output.optJSONObject(i) ?: continue
+            if (item.optString("type") != "reasoning") continue
+            val summary = item.optJSONArray("summary")
+            if (summary != null) {
+                for (j in 0 until summary.length()) {
+                    val block = summary.optJSONObject(j) ?: continue
+                    buffer.append(block.optString("text"))
+                }
+            } else {
+                buffer.append(item.optString("text"))
+            }
+        }
+        return buffer.toString()
+    }
+
+    private fun extractResponsesToolCalls(root: JSONObject): List<AssistantToolCall> {
+        val output = root.optJSONArray("output") ?: return emptyList()
+        val parsed = mutableListOf<AssistantToolCall>()
+        for (i in 0 until output.length()) {
+            val item = output.optJSONObject(i) ?: continue
+            if (item.optString("type") != "function_call") continue
+            val name = item.optString("name").trim()
+            if (name.isEmpty()) continue
+            parsed += AssistantToolCall(
+                id = item.optString("call_id").ifBlank { item.optString("id", "tool_$i") },
+                function = AssistantToolCallFunction(
+                    name = name,
+                    arguments = item.optString("arguments", "{}")
+                )
+            )
+        }
+        return parsed
     }
 
     private fun parseToolCalls(

--- a/assists/src/main/java/cn/com/omnimind/assists/task/ChatTask.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/task/ChatTask.kt
@@ -172,6 +172,7 @@ class ChatTask(override val taskChangeListener: TaskChangeListener,
                         explicitApiKey = modelOverride?.apiKey,
                         explicitModel = modelOverride?.modelId,
                         explicitProtocolType = modelOverride?.protocolType,
+                        explicitWireApi = modelOverride?.wireApi,
                         reasoningEffort = this@ChatTask.reasoningEffort
                     )
                 }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/MnnLocalProviderStateStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/MnnLocalProviderStateStore.kt
@@ -62,7 +62,8 @@ object MnnLocalProviderStateStore {
             providerType = profile.sourceType,
             readOnly = profile.readOnly,
             ready = profile.ready,
-            statusText = profile.statusText
+            statusText = profile.statusText,
+            wireApi = profile.wireApi
         )
     }
 }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderConfigStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderConfigStore.kt
@@ -28,6 +28,8 @@ object ModelProviderConfigStore {
     private val canonicalEndpointSuffixes = listOf(
         "/v1/chat/completions",
         "/chat/completions",
+        "/v1/responses",
+        "/responses",
         "/v1/images/generations",
         "/images/generations",
         "/v1/models",
@@ -108,7 +110,8 @@ object ModelProviderConfigStore {
                         ),
                         baseUrl = normalizeBaseUrl(profile.baseUrl).orEmpty(),
                         apiKey = profile.apiKey.trim(),
-                        protocolType = normalizeProtocolType(profile.protocolType)
+                        protocolType = normalizeProtocolType(profile.protocolType),
+                        wireApi = normalizeWireApi(profile.wireApi)
                     )
                 )
             }
@@ -137,17 +140,24 @@ object ModelProviderConfigStore {
         name: String,
         baseUrl: String,
         apiKey: String,
-        protocolType: String = "openai_compatible"
+        protocolType: String = "openai_compatible",
+        wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
     ): ModelProviderProfile {
         ModelProviderMigration.ensureMigrated()
         require(!MnnLocalProviderStateStore.isBuiltinProfileId(id)) { "builtin provider is read only" }
         val normalizedProtocolType = normalizeProtocolType(protocolType)
+        val normalizedWireApi = resolveWireApiForSave(
+            baseUrl = baseUrl,
+            protocolType = normalizedProtocolType,
+            wireApi = wireApi
+        )
         val mmkv = MMKV.defaultMMKV() ?: return ModelProviderProfile(
             id = id?.trim().orEmpty().ifEmpty { DEFAULT_PROFILE_ID },
             name = name.trim().ifEmpty { DEFAULT_PROFILE_NAME },
             baseUrl = normalizeBaseUrl(baseUrl).orEmpty(),
             apiKey = apiKey.trim(),
-            protocolType = normalizedProtocolType
+            protocolType = normalizedProtocolType,
+            wireApi = normalizedWireApi
         )
 
         val current = readProfiles(mmkv).toMutableList().ifEmpty {
@@ -165,7 +175,8 @@ object ModelProviderConfigStore {
             name = sanitizedName,
             baseUrl = normalizeBaseUrl(baseUrl).orEmpty(),
             apiKey = apiKey.trim(),
-            protocolType = normalizedProtocolType
+            protocolType = normalizedProtocolType,
+            wireApi = normalizedWireApi
         )
 
         if (currentIndex >= 0) {
@@ -215,7 +226,8 @@ object ModelProviderConfigStore {
             providerType = profile.sourceType,
             readOnly = profile.readOnly,
             ready = profile.ready,
-            statusText = profile.statusText
+            statusText = profile.statusText,
+            wireApi = profile.wireApi
         )
     }
 
@@ -227,7 +239,8 @@ object ModelProviderConfigStore {
             name = current.name,
             baseUrl = baseUrl,
             apiKey = apiKey,
-            protocolType = current.protocolType
+            protocolType = current.protocolType,
+            wireApi = current.wireApi
         )
     }
 
@@ -239,7 +252,8 @@ object ModelProviderConfigStore {
             name = current.name,
             baseUrl = "",
             apiKey = "",
-            protocolType = current.protocolType
+            protocolType = current.protocolType,
+            wireApi = current.wireApi
         )
     }
 
@@ -382,6 +396,35 @@ object ModelProviderConfigStore {
         return DeepSeekProvider.normalizeProtocolType(value)
     }
 
+    private fun normalizeWireApi(value: String?): String {
+        return OpenAiWireApi.normalize(value)
+    }
+
+    private fun resolveWireApiForSave(
+        baseUrl: String,
+        protocolType: String,
+        wireApi: String?
+    ): String {
+        val normalizedWireApi = wireApi?.trim()?.lowercase().orEmpty()
+        if (normalizedWireApi == OpenAiWireApi.RESPONSES ||
+            normalizedWireApi == OpenAiWireApi.CHAT_COMPLETIONS
+        ) {
+            return normalizedWireApi
+        }
+        if (protocolType != "openai_compatible") {
+            return OpenAiWireApi.CHAT_COMPLETIONS
+        }
+        val rawBaseUrl = stripDirectRequestUrlMarker(baseUrl).lowercase()
+        return if (
+            rawBaseUrl.endsWith("/v1/responses") ||
+            rawBaseUrl.endsWith("/responses")
+        ) {
+            OpenAiWireApi.RESPONSES
+        } else {
+            OpenAiWireApi.CHAT_COMPLETIONS
+        }
+    }
+
     private fun ensureOfficialDeepSeekProfileSeeded(
         mmkv: MMKV,
         profiles: List<ModelProviderProfile>
@@ -454,7 +497,8 @@ object ModelProviderConfigStore {
                     name = profile.name.trim().ifEmpty { DEFAULT_PROFILE_NAME },
                     baseUrl = normalizeBaseUrl(profile.baseUrl).orEmpty(),
                     apiKey = profile.apiKey.trim(),
-                    protocolType = normalizeProtocolType(profile.protocolType)
+                    protocolType = normalizeProtocolType(profile.protocolType),
+                    wireApi = normalizeWireApi(profile.wireApi)
                 )
             }
         } catch (t: Throwable) {
@@ -475,7 +519,8 @@ object ModelProviderConfigStore {
                 name = profile.name.trim().ifEmpty { "Provider ${index + 1}" },
                 baseUrl = normalizeBaseUrl(profile.baseUrl).orEmpty(),
                 apiKey = profile.apiKey.trim(),
-                protocolType = normalizeProtocolType(profile.protocolType)
+                protocolType = normalizeProtocolType(profile.protocolType),
+                wireApi = normalizeWireApi(profile.wireApi)
             )
         }
         mmkv.encode(KEY_PROVIDER_PROFILES, gson.toJson(normalized))

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderModels.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderModels.kt
@@ -9,7 +9,8 @@ data class ModelProviderConfig(
     val providerType: String = "custom",
     val readOnly: Boolean = false,
     val ready: Boolean = true,
-    val statusText: String? = null
+    val statusText: String? = null,
+    val wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
 ) {
     fun isConfigured(): Boolean = baseUrl.isNotBlank()
 }
@@ -23,7 +24,8 @@ data class ModelProviderProfile(
     val readOnly: Boolean = false,
     val ready: Boolean = true,
     val statusText: String? = null,
-    val protocolType: String = "openai_compatible"
+    val protocolType: String = "openai_compatible",
+    val wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS
 ) {
     fun isConfigured(): Boolean = baseUrl.isNotBlank()
 }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAIResponsesModels.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAIResponsesModels.kt
@@ -1,0 +1,19 @@
+package cn.com.omnimind.baselib.llm
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+@Serializable
+data class OpenAIResponsesRequest(
+    val model: String,
+    val input: List<JsonElement> = emptyList(),
+    val instructions: String? = null,
+    @SerialName("max_output_tokens")
+    val maxOutputTokens: Int? = null,
+    val stream: Boolean = false,
+    val tools: List<JsonElement> = emptyList(),
+    @SerialName("tool_choice")
+    val toolChoice: JsonElement? = null,
+    val reasoning: JsonElement? = null
+)

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAiWireApi.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAiWireApi.kt
@@ -1,0 +1,18 @@
+package cn.com.omnimind.baselib.llm
+
+object OpenAiWireApi {
+    const val CHAT_COMPLETIONS = "chat_completions"
+    const val RESPONSES = "responses"
+
+    fun normalize(value: String?): String {
+        return when (value?.trim()?.lowercase()) {
+            RESPONSES -> RESPONSES
+            "chat-completions",
+            "chat/completions",
+            "chatcompletions" -> CHAT_COMPLETIONS
+            else -> CHAT_COMPLETIONS
+        }
+    }
+
+    fun isResponses(value: String?): Boolean = normalize(value) == RESPONSES
+}

--- a/ui/lib/features/home/pages/vlm_model_setting/vlm_model_setting_page.dart
+++ b/ui/lib/features/home/pages/vlm_model_setting/vlm_model_setting_page.dart
@@ -66,10 +66,22 @@ class _ProtocolTypeOption {
   final String label;
 }
 
+class _WireApiOption {
+  const _WireApiOption({required this.value, required this.label});
+
+  final String value;
+  final String label;
+}
+
 const List<_ProtocolTypeOption> _kProtocolTypeOptions = <_ProtocolTypeOption>[
   _ProtocolTypeOption(value: 'deepseek', label: 'DeepSeek'),
   _ProtocolTypeOption(value: 'openai_compatible', label: 'OpenAI'),
   _ProtocolTypeOption(value: 'anthropic', label: 'Anthropic'),
+];
+
+const List<_WireApiOption> _kWireApiOptions = <_WireApiOption>[
+  _WireApiOption(value: 'chat_completions', label: 'Chat Completions'),
+  _WireApiOption(value: 'responses', label: 'Responses'),
 ];
 
 class _ProviderModelItem {
@@ -113,6 +125,7 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
   bool _saveQueued = false;
   bool _isSwitchingProfile = false;
   String _selectedProtocolType = 'openai_compatible';
+  String _selectedWireApi = 'chat_completions';
 
   Timer? _autoSaveTimer;
   StreamSubscription<AgentAiConfigChangedEvent>? _configChangedSubscription;
@@ -163,6 +176,15 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
       }
     }
     return 'OpenAI';
+  }
+
+  String get _selectedWireApiLabel {
+    for (final option in _kWireApiOptions) {
+      if (option.value == _selectedWireApi) {
+        return option.label;
+      }
+    }
+    return 'Chat Completions';
   }
 
   List<_ProviderModelItem> get _modelItems {
@@ -424,6 +446,7 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
           baseUrl: _baseUrlController.text.trim(),
           apiKey: nextApiKey,
           protocolType: _selectedProtocolType,
+          wireApi: _selectedWireApi,
         );
         if (!mounted) return;
         setState(() {
@@ -501,6 +524,10 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
       _manualModels = manualModels;
       _remoteModels = remoteModels;
       _selectedProtocolType = current.protocolType;
+      _selectedWireApi = _normalizeWireApiForProtocol(
+        current.protocolType,
+        current.wireApi,
+      );
     });
   }
 
@@ -578,7 +605,18 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     if (_selectedProtocolType == 'anthropic') {
       return ModelProviderConfigService.buildAnthropicMessagesRequestUrl(input);
     }
+    if (_selectedProtocolType == 'openai_compatible' &&
+        _selectedWireApi == 'responses') {
+      return ModelProviderConfigService.buildResponsesRequestUrl(input);
+    }
     return ModelProviderConfigService.buildChatCompletionsRequestUrl(input);
+  }
+
+  String _normalizeWireApiForProtocol(String protocolType, String? wireApi) {
+    if (protocolType != 'openai_compatible') {
+      return 'chat_completions';
+    }
+    return wireApi == 'responses' ? 'responses' : 'chat_completions';
   }
 
   Future<void> _switchToProfile(String profileId) async {
@@ -908,7 +946,12 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
       return;
     }
     final previousValue = _selectedProtocolType;
-    setState(() => _selectedProtocolType = value);
+    final previousWireApi = _selectedWireApi;
+    final nextWireApi = _normalizeWireApiForProtocol(value, _selectedWireApi);
+    setState(() {
+      _selectedProtocolType = value;
+      _selectedWireApi = nextWireApi;
+    });
     try {
       final saved = await ModelProviderConfigService.saveProfile(
         id: current.id,
@@ -918,14 +961,63 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
         baseUrl: _baseUrlController.text.trim(),
         apiKey: _apiKeyController.text.trim(),
         protocolType: value,
+        wireApi: nextWireApi,
       );
       if (!mounted) return;
       setState(() {
         _profiles = _profiles.map((p) => p.id == saved.id ? saved : p).toList();
+        _selectedWireApi = _normalizeWireApiForProtocol(
+          saved.protocolType,
+          saved.wireApi,
+        );
       });
     } catch (_) {
       if (!mounted) return;
-      setState(() => _selectedProtocolType = previousValue);
+      setState(() {
+        _selectedProtocolType = previousValue;
+        _selectedWireApi = previousWireApi;
+      });
+    }
+  }
+
+  Future<void> _selectWireApi(String value) async {
+    final normalizedValue = _normalizeWireApiForProtocol(
+      _selectedProtocolType,
+      value,
+    );
+    if (_selectedWireApi == normalizedValue) {
+      return;
+    }
+    final current = _currentProfile;
+    if (current == null ||
+        current.readOnly ||
+        _selectedProtocolType != 'openai_compatible') {
+      return;
+    }
+    final previousValue = _selectedWireApi;
+    setState(() => _selectedWireApi = normalizedValue);
+    try {
+      final saved = await ModelProviderConfigService.saveProfile(
+        id: current.id,
+        name: _nameController.text.trim().isEmpty
+            ? current.name
+            : _nameController.text.trim(),
+        baseUrl: _baseUrlController.text.trim(),
+        apiKey: _apiKeyController.text.trim(),
+        protocolType: _selectedProtocolType,
+        wireApi: normalizedValue,
+      );
+      if (!mounted) return;
+      setState(() {
+        _profiles = _profiles.map((p) => p.id == saved.id ? saved : p).toList();
+        _selectedWireApi = _normalizeWireApiForProtocol(
+          saved.protocolType,
+          saved.wireApi,
+        );
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _selectedWireApi = previousValue);
     }
   }
 
@@ -984,6 +1076,65 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
       return;
     }
     await _selectProtocolType(selected);
+  }
+
+  Future<void> _openWireApiMenu(BuildContext anchorContext) async {
+    final current = _currentProfile;
+    if (current == null ||
+        current.readOnly ||
+        _selectedProtocolType != 'openai_compatible') {
+      return;
+    }
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    final anchorBox = anchorContext.findRenderObject() as RenderBox?;
+    if (overlay == null || anchorBox == null || !anchorBox.hasSize) {
+      return;
+    }
+    final topLeft = anchorBox.localToGlobal(Offset.zero, ancestor: overlay);
+    final bottomRight = anchorBox.localToGlobal(
+      anchorBox.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    );
+    final anchorRect = Rect.fromPoints(topLeft, bottomRight);
+    final popupWidth = anchorRect.width.clamp(180.0, 232.0).toDouble();
+    final estimatedHeight = (_kWireApiOptions.length * 48 + 24)
+        .clamp(120.0, _kProviderSwitchPopupMaxHeight)
+        .toDouble();
+    final position = PopupMenuAnchorPosition.fromAnchorRect(
+      anchorRect: anchorRect,
+      overlaySize: overlay.size,
+      estimatedMenuHeight: estimatedHeight,
+      reservedBottom: MediaQuery.of(context).viewInsets.bottom,
+      verticalGap: 6,
+    );
+    final selected = await showMenu<String>(
+      context: context,
+      color: _cardColor,
+      elevation: _isDarkTheme ? 0 : 8,
+      shadowColor: _isDarkTheme ? context.omniPalette.shadowColor : null,
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: _isDarkTheme
+            ? BorderSide(color: context.omniPalette.borderSubtle)
+            : BorderSide.none,
+      ),
+      constraints: BoxConstraints(minWidth: popupWidth, maxWidth: popupWidth),
+      position: position,
+      items: [
+        _WireApiPopupEntry(
+          width: popupWidth,
+          estimatedHeight: estimatedHeight,
+          options: _kWireApiOptions,
+          selectedValue: _selectedWireApi,
+        ),
+      ],
+    );
+    if (selected == null) {
+      return;
+    }
+    await _selectWireApi(selected);
   }
 
   Widget _buildCard({required Widget child}) {
@@ -1832,6 +1983,49 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     );
   }
 
+  Widget _buildWireApiField() {
+    final current = _currentProfile;
+    final enabled =
+        !(current?.readOnly ?? false) &&
+        _selectedProtocolType == 'openai_compatible';
+    return Builder(
+      builder: (anchorContext) {
+        return InkWell(
+          key: const Key('provider-wire-api-button'),
+          onTap: enabled
+              ? () {
+                  unawaited(_openWireApiMenu(anchorContext));
+                }
+              : null,
+          borderRadius: BorderRadius.circular(12),
+          child: InputDecorator(
+            isEmpty: false,
+            decoration: _buildInputDecoration(
+              label: '接口方式',
+            ).copyWith(
+              enabled: enabled,
+              suffixIcon: Icon(
+                Icons.keyboard_arrow_down_rounded,
+                color: _secondaryTextColor,
+                size: 18,
+              ),
+            ),
+            child: Text(
+              _selectedWireApiLabel,
+              key: const Key('provider-wire-api-text'),
+              style: TextStyle(
+                color: enabled ? _primaryTextColor : _secondaryTextColor,
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                fontFamily: 'PingFang SC',
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final modelItems = _modelItems;
@@ -1949,6 +2143,10 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                             );
                           },
                         ),
+                        if (_selectedProtocolType == 'openai_compatible') ...[
+                          const SizedBox(height: 12),
+                          _buildWireApiField(),
+                        ],
                         const SizedBox(height: 14),
                         TextField(
                           controller: _apiKeyController,
@@ -2302,6 +2500,103 @@ class _ProtocolTypePopupEntryState extends State<_ProtocolTypePopupEntry> {
             itemCount: widget.options.length,
             itemBuilder: (context, index) {
               return _buildProtocolTile(widget.options[index]);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WireApiPopupEntry extends PopupMenuEntry<String> {
+  const _WireApiPopupEntry({
+    required this.width,
+    required this.estimatedHeight,
+    required this.options,
+    required this.selectedValue,
+  });
+
+  final double width;
+  final double estimatedHeight;
+  final List<_WireApiOption> options;
+  final String selectedValue;
+
+  @override
+  double get height => estimatedHeight;
+
+  @override
+  bool represents(String? value) => false;
+
+  @override
+  State<_WireApiPopupEntry> createState() => _WireApiPopupEntryState();
+}
+
+class _WireApiPopupEntryState extends State<_WireApiPopupEntry> {
+  Widget _buildWireApiTile(_WireApiOption option) {
+    final palette = context.omniPalette;
+    final isDark = context.isDarkTheme;
+    final selected = option.value == widget.selectedValue;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(10, 2, 10, 2),
+      child: InkWell(
+        onTap: () => Navigator.of(context).pop(option.value),
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
+          decoration: BoxDecoration(
+            color: selected
+                ? (isDark ? palette.segmentThumb : const Color(0xFFEAF3FF))
+                : (isDark ? palette.surfaceSecondary : const Color(0xFFF8FAFD)),
+            borderRadius: BorderRadius.circular(12),
+            border: isDark ? Border.all(color: palette.borderSubtle) : null,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  option.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: isDark ? palette.textPrimary : AppColors.text,
+                    fontWeight: FontWeight.w500,
+                    fontFamily: 'PingFang SC',
+                  ),
+                ),
+              ),
+              if (selected)
+                Icon(
+                  Icons.check_rounded,
+                  size: 16,
+                  color: isDark
+                      ? palette.accentPrimary
+                      : const Color(0xFF2C7FEB),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final dynamicMaxHeight =
+        (mediaQuery.size.height - mediaQuery.viewInsets.bottom - 96)
+            .clamp(120.0, widget.estimatedHeight)
+            .toDouble();
+    return SizedBox(
+      width: widget.width,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: dynamicMaxHeight),
+        child: Scrollbar(
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: widget.options.length,
+            itemBuilder: (context, index) {
+              return _buildWireApiTile(widget.options[index]);
             },
           ),
         ),

--- a/ui/lib/services/model_provider_config_service.dart
+++ b/ui/lib/services/model_provider_config_service.dart
@@ -16,6 +16,7 @@ class ModelProviderConfig {
   final bool ready;
   final String statusText;
   final bool configured;
+  final String wireApi;
 
   const ModelProviderConfig({
     required this.id,
@@ -28,6 +29,7 @@ class ModelProviderConfig {
     required this.ready,
     required this.statusText,
     required this.configured,
+    required this.wireApi,
   });
 
   factory ModelProviderConfig.empty() {
@@ -42,6 +44,7 @@ class ModelProviderConfig {
       ready: false,
       statusText: '',
       configured: false,
+      wireApi: 'chat_completions',
     );
   }
 
@@ -60,6 +63,7 @@ class ModelProviderConfig {
       ready: map['ready'] == true,
       statusText: (map['statusText'] ?? '').toString(),
       configured: map['configured'] == true,
+      wireApi: (map['wireApi'] ?? 'chat_completions').toString(),
     );
   }
 }
@@ -75,6 +79,7 @@ class ModelProviderProfileSummary {
   final String statusText;
   final bool configured;
   final String protocolType;
+  final String wireApi;
 
   const ModelProviderProfileSummary({
     required this.id,
@@ -87,6 +92,7 @@ class ModelProviderProfileSummary {
     required this.statusText,
     required this.configured,
     this.protocolType = 'openai_compatible',
+    this.wireApi = 'chat_completions',
   });
 
   factory ModelProviderProfileSummary.fromMap(Map<dynamic, dynamic>? map) {
@@ -101,6 +107,7 @@ class ModelProviderProfileSummary {
       statusText: (map?['statusText'] ?? '').toString(),
       configured: map?['configured'] == true,
       protocolType: (map?['protocolType'] ?? 'openai_compatible').toString(),
+      wireApi: (map?['wireApi'] ?? 'chat_completions').toString(),
     );
   }
 
@@ -116,6 +123,7 @@ class ModelProviderProfileSummary {
       ready: ready,
       statusText: statusText,
       configured: configured,
+      wireApi: wireApi,
     );
   }
 }
@@ -331,6 +339,8 @@ class ModelProviderConfigService {
   static const List<String> _kCanonicalEndpointSuffixes = <String>[
     '/v1/chat/completions',
     '/chat/completions',
+    '/v1/responses',
+    '/responses',
     '/v1/models',
     '/models',
     '/v1/messages',
@@ -378,6 +388,7 @@ class ModelProviderConfigService {
         ready: fallback.ready,
         statusText: fallback.statusText,
         configured: fallback.configured,
+        wireApi: fallback.wireApi,
       );
       return ModelProviderProfilesPayload(
         profiles: [profile],
@@ -392,7 +403,13 @@ class ModelProviderConfigService {
     required String baseUrl,
     required String apiKey,
     String protocolType = 'openai_compatible',
+    String? wireApi,
   }) async {
+    final resolvedWireApi = inferWireApi(
+      baseUrl,
+      explicitWireApi: wireApi,
+      protocolType: protocolType,
+    );
     final result = await AssistsMessageService.assistCore
         .invokeMethod<Map<dynamic, dynamic>>('saveModelProviderProfile', {
           if (id != null && id.trim().isNotEmpty) 'id': id.trim(),
@@ -400,6 +417,7 @@ class ModelProviderConfigService {
           'baseUrl': baseUrl,
           'apiKey': apiKey,
           'protocolType': protocolType,
+          'wireApi': resolvedWireApi,
         });
     return ModelProviderProfileSummary.fromMap(result);
   }
@@ -903,6 +921,26 @@ class ModelProviderConfigService {
     return normalizeApiBase(value) != null;
   }
 
+  static String inferWireApi(
+    String baseUrl, {
+    String? explicitWireApi,
+    String protocolType = 'openai_compatible',
+  }) {
+    final normalizedExplicit = explicitWireApi?.trim().toLowerCase();
+    if (normalizedExplicit == 'responses' ||
+        normalizedExplicit == 'chat_completions') {
+      return normalizedExplicit!;
+    }
+    if (protocolType.trim().toLowerCase() != 'openai_compatible') {
+      return 'chat_completions';
+    }
+    final raw = _stripDirectRequestUrlMarker(baseUrl.trim()).toLowerCase();
+    if (raw.endsWith('/v1/responses') || raw.endsWith('/responses')) {
+      return 'responses';
+    }
+    return 'chat_completions';
+  }
+
   static bool _hasDirectRequestUrlMarker(String value) {
     return value.trim().endsWith(_kDirectRequestUrlMarker);
   }
@@ -971,6 +1009,14 @@ class ModelProviderConfigService {
       value,
       suffixAfterV1: '/chat/completions',
       suffixWithVersion: '/v1/chat/completions',
+    );
+  }
+
+  static String? buildResponsesRequestUrl(String value) {
+    return _buildRequestUrl(
+      value,
+      suffixAfterV1: '/responses',
+      suffixWithVersion: '/v1/responses',
     );
   }
 

--- a/ui/test/features/home/pages/vlm_model_setting/vlm_model_setting_page_test.dart
+++ b/ui/test/features/home/pages/vlm_model_setting/vlm_model_setting_page_test.dart
@@ -57,6 +57,7 @@ void main() {
   Map<String, dynamic> profilePayload({
     String baseUrl = 'https://api.openai.com/v1',
     String protocolType = 'openai_compatible',
+    String wireApi = 'chat_completions',
   }) {
     return <String, dynamic>{
       'profiles': <Map<String, dynamic>>[
@@ -71,6 +72,7 @@ void main() {
           'statusText': '',
           'configured': true,
           'protocolType': protocolType,
+          'wireApi': wireApi,
         },
       ],
       'editingProfileId': 'provider-1',
@@ -192,6 +194,41 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
 
     expect(find.text('https://api.anthropic.com/v1/messages'), findsOneWidget);
+    expect(find.byKey(const Key('provider-wire-api-button')), findsNothing);
+  });
+
+  testWidgets('openai compatible profile shows wire api selector', (
+    tester,
+  ) async {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(assistCoreChannel, (call) async {
+      switch (call.method) {
+        case 'listModelProviderProfiles':
+          return profilePayload(
+            baseUrl: 'https://api.openai.com/v1',
+            wireApi: 'responses',
+          );
+      }
+      return null;
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        darkTheme: AppTheme.darkTheme,
+        home: const VlmModelSettingPage(),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byKey(const Key('provider-wire-api-button')), findsOneWidget);
+    expect(find.text('接口方式'), findsOneWidget);
+    expect(find.byKey(const Key('provider-wire-api-text')), findsOneWidget);
+    expect(find.text('Responses'), findsOneWidget);
+    expect(find.text('https://api.openai.com/v1/responses'), findsOneWidget);
   });
 
   testWidgets('provider fields do not auto-save while focused', (tester) async {

--- a/ui/test/services/model_provider_config_service_test.dart
+++ b/ui/test/services/model_provider_config_service_test.dart
@@ -45,6 +45,12 @@ void main() {
       ),
       'https://api.example.com/v1/chat/completions',
     );
+    expect(
+      ModelProviderConfigService.buildResponsesRequestUrl(
+        'https://api.example.com',
+      ),
+      'https://api.example.com/v1/responses',
+    );
   });
 
   test('allows trailing marker to bypass automatic request suffixes', () {
@@ -82,7 +88,7 @@ void main() {
     () {
       expect(
         ModelProviderConfigService.buildModelsRequestUrl(
-          'https://api.example.com/v1/chat/completions',
+          'https://api.example.com/v1/responses',
         ),
         'https://api.example.com/v1/models',
       );
@@ -91,6 +97,12 @@ void main() {
           'https://api.example.com/v1/models',
         ),
         'https://api.example.com/v1/chat/completions',
+      );
+      expect(
+        ModelProviderConfigService.buildResponsesRequestUrl(
+          'https://api.example.com/v1/chat/completions',
+        ),
+        'https://api.example.com/v1/responses',
       );
     },
   );
@@ -124,6 +136,25 @@ void main() {
     expect(
       ModelProviderConfigService.buildChatCompletionsRequestUrl(''),
       isNull,
+    );
+  });
+
+  test('infers responses wire api from explicit responses endpoint input', () {
+    expect(
+      ModelProviderConfigService.inferWireApi(
+        'https://api.example.com/v1/responses',
+      ),
+      'responses',
+    );
+    expect(
+      ModelProviderConfigService.inferWireApi(
+        'https://api.example.com/responses#',
+      ),
+      'responses',
+    );
+    expect(
+      ModelProviderConfigService.inferWireApi('https://api.example.com/v1'),
+      'chat_completions',
     );
   });
 


### PR DESCRIPTION
为 OpenAI-compatible provider 增加可显式选择的 `wireApi`，支持在 `chat_completions` 与 `responses` 两种协议之间切换。补齐 `/v1/responses` 的请求体与流式事件适配，并修复实际联调中出现的两类问题：工具调用 `function.name` 丢失，以及最终助手回复被重复拼接。

## 变更类型

- [x]  新功能

## 关联 Issue

Closes #347

## 主要改动

1. 新增 `wireApi` 配置链路，打通 Flutter 配置页、provider 持久化、native/runtime 同步和路由解析。
2. 在 HTTP 层新增 OpenAI Responses 请求体构造、非流式解析和流式 SSE 适配，保持上层继续消费现有 chat-completions 语义。
3. 修复 Responses 流式工具调用 `call_id/item_id` 映射错位导致的空 `function.name`，并对 `content_part.done`/`output_item.done` 的最终文本快照做去重。

测试细节：

测试采用了百炼平台，抓包日志中能明显看出走了新增的 v1/responses 链路：
<img width="1940" height="273" alt="image" src="https://github.com/user-attachments/assets/b9ecf4d6-46ef-47fc-858f-fbea78dca6b7" />

用户侧在模型供应商这里可选择 v1/responses,默认还是 completions
<img width="864" height="1920" alt="aa846268013f54871756a14cc7967f4c" src="https://github.com/user-attachments/assets/ccb28193-bce8-4e96-ab8b-257e480f40b1" />

<img width="864" height="1920" alt="babcd1224e1c05be86694f913c4d800b" src="https://github.com/user-attachments/assets/8718be80-1ea6-428f-b5e4-ce2b0e3e6887" />


## UI 变更（如有）

有。模型提供商设置页新增 `wireApi` 选项：

- `Chat Completions`
- `Responses`

## 风险与回滚
无

