### PR TITLE
feature:适配 Claude Anthropic Chat/Agent 1M 上下文链路

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationContextCompactor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationContextCompactor.kt
@@ -156,13 +156,21 @@ Do NOT translate or alter code snippets, file paths, identifiers, or error messa
         }
     }
 
+    private fun resolveModelContextThreshold(): Int? {
+        return modelOverride?.contextLimit
+            ?.coerceAtLeast(1)
+    }
+
     open suspend fun resolvePromptTokenThreshold(conversationId: Long?): Int {
+        val fallbackThreshold = resolveModelContextThreshold()
+            ?: DEFAULT_PROMPT_TOKEN_THRESHOLD
         if (conversationId == null || conversationId <= 0L) {
-            return DEFAULT_PROMPT_TOKEN_THRESHOLD
+            return fallbackThreshold
         }
         val conversation = historyRepository.getConversation(conversationId)
-        val storedThreshold = conversation?.promptTokenThreshold ?: DEFAULT_PROMPT_TOKEN_THRESHOLD
-        return storedThreshold.coerceAtLeast(1)
+        val storedThreshold = conversation?.promptTokenThreshold
+            ?.takeIf { it > 0 }
+        return storedThreshold ?: fallbackThreshold
     }
 
     open suspend fun compactIfNeeded(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -636,7 +636,10 @@ class HttpAgentLlmClient(
         if (isOfficialDeepSeekTarget()) {
             return true
         }
-        return resolvedProtocolType() == DeepSeekProvider.PROTOCOL_TYPE
+        return when (resolvedProtocolType()) {
+            DeepSeekProvider.PROTOCOL_TYPE, "anthropic" -> true
+            else -> false
+        }
     }
 
     private fun shouldRetainAssistantReasoning(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeModels.kt
@@ -20,7 +20,8 @@ data class AgentModelOverride(
     val apiBase: String,
     val apiKey: String,
     val protocolType: String = "openai_compatible",
-    val wireApi: String = "chat_completions"
+    val wireApi: String = "chat_completions",
+    val contextLimit: Int? = null
 )
 
 data class ArtifactAction(

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -176,14 +176,28 @@ internal fun resolveChatTaskModelOverride(
     if (providerProfile == null || !providerProfile.isConfigured()) {
         return null
     }
+    val contextLimit = when (val rawContextLimit = raw["contextLimit"]) {
+        is Number -> rawContextLimit.toInt()
+        else -> rawContextLimit?.toString()?.trim()?.toIntOrNull()
+    }?.takeIf { it > 0 }
     return TaskParams.ChatModelOverride(
         providerProfileId = providerProfile.id,
         modelId = modelId,
         apiBase = providerProfile.baseUrl,
         apiKey = providerProfile.apiKey,
         protocolType = providerProfile.protocolType.ifEmpty { "openai_compatible" },
-        wireApi = providerProfile.wireApi
+        wireApi = providerProfile.wireApi,
+        contextLimit = contextLimit
     )
+}
+
+internal fun resolvePromptTokenThresholdFallback(
+    storedThreshold: Int?,
+    modelOverride: TaskParams.ChatModelOverride?
+): Int {
+    return storedThreshold?.coerceAtLeast(1)
+        ?: modelOverride?.contextLimit?.coerceAtLeast(1)
+        ?: AgentConversationContextCompactor.DEFAULT_PROMPT_TOKEN_THRESHOLD
 }
 
 internal fun normalizeReasoningEffort(raw: String?): String? {
@@ -412,7 +426,8 @@ internal fun chatModelOverrideToAgentModelOverride(
         apiBase = modelOverride.apiBase,
         apiKey = modelOverride.apiKey,
         protocolType = modelOverride.protocolType.ifEmpty { "openai_compatible" },
-        wireApi = modelOverride.wireApi
+        wireApi = modelOverride.wireApi,
+        contextLimit = modelOverride.contextLimit
     )
 }
 
@@ -1702,10 +1717,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             assistantEntryId = "$taskID-assistant",
                             modelOverride = modelOverride,
                             reasoningEffort = reasoningEffort,
-                            promptTokenThreshold = repository
-                                .getConversation(normalizedConversationId)
-                                ?.promptTokenThreshold
-                                ?.coerceAtLeast(1)
+                            promptTokenThreshold = resolvePromptTokenThresholdFallback(
+                                storedThreshold = repository
+                                    .getConversation(normalizedConversationId)
+                                    ?.promptTokenThreshold,
+                                modelOverride = modelOverride
+                            )
                         )
                     )
                 }
@@ -1749,9 +1766,10 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 normalizedType != "rate_limited"
             ) {
                 extractChatTaskPromptTokens(content)?.let { promptTokens ->
-                    val promptTokenThreshold =
-                        state.promptTokenThreshold?.coerceAtLeast(1)
-                            ?: AgentConversationContextCompactor.DEFAULT_PROMPT_TOKEN_THRESHOLD
+                    val promptTokenThreshold = resolvePromptTokenThresholdFallback(
+                        storedThreshold = state.promptTokenThreshold,
+                        modelOverride = state.modelOverride
+                    )
                     state.latestPromptTokens = promptTokens
                     state.promptTokenThreshold = promptTokenThreshold
                     repository.updatePromptTokenUsage(
@@ -1909,9 +1927,10 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             return null
         }
         val latestPromptTokens = state.latestPromptTokens ?: return null
-        val promptTokenThreshold =
-            state.promptTokenThreshold?.coerceAtLeast(1)
-                ?: AgentConversationContextCompactor.DEFAULT_PROMPT_TOKEN_THRESHOLD
+        val promptTokenThreshold = resolvePromptTokenThresholdFallback(
+            storedThreshold = state.promptTokenThreshold,
+            modelOverride = state.modelOverride
+        )
         if (latestPromptTokens <= promptTokenThreshold) {
             return null
         }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerAnthropicTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerAnthropicTest.kt
@@ -8,14 +8,15 @@ import java.io.OutputStreamWriter
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.nio.charset.StandardCharsets
+import kotlin.concurrent.thread
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlin.concurrent.thread
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HttpControllerAnthropicTest {
@@ -106,7 +107,18 @@ class HttpControllerAnthropicTest {
                     val body = """
                         {
                           "data": [
-                            {"id": "claude-sonnet-4-5", "display_name": "Claude Sonnet 4.5", "type": "model"},
+                            {
+                              "id": "claude-sonnet-4-5",
+                              "display_name": "Claude Sonnet 4.5",
+                              "type": "model",
+                              "context_limit": 1000000,
+                              "output_limit": 64000,
+                              "capabilities": {
+                                "reasoning": true,
+                                "tool_call": true,
+                                "vision": true
+                              }
+                            },
                             {"id": "claude-haiku-4-5", "display_name": "Claude Haiku 4.5", "type": "model"}
                           ]
                         }
@@ -139,6 +151,11 @@ class HttpControllerAnthropicTest {
                 listOf("Claude Haiku 4.5", "Claude Sonnet 4.5"),
                 models.map { it.displayName }
             )
+            assertEquals(1000000, models.last().contextLimit)
+            assertEquals(64000, models.last().outputLimit)
+            assertTrue(models.last().reasoning == true)
+            assertTrue(models.last().toolCall == true)
+            assertTrue(models.last().attachment == true)
             assertEquals("GET /v1/models HTTP/1.1", requestLines.first())
             assertEquals(
                 "x-api-key: sk-ant-test",
@@ -153,4 +170,5 @@ class HttpControllerAnthropicTest {
             serverSocket.close()
         }
     }
+
 }

--- a/app/src/test/java/cn/com/omnimind/bot/manager/AssistsCoreManagerChatOnlyTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/manager/AssistsCoreManagerChatOnlyTest.kt
@@ -63,6 +63,29 @@ class AssistsCoreManagerChatOnlyTest {
         assertEquals("https://example.com/v1", result?.apiBase)
         assertEquals("secret", result?.apiKey)
         assertEquals("openai_compatible", result?.protocolType)
+        assertNull(result?.contextLimit)
+    }
+
+    @Test
+    fun `resolveChatTaskModelOverride preserves contextLimit from payload`() {
+        val result = resolveChatTaskModelOverride(
+            raw = mapOf(
+                "providerProfileId" to "provider-1",
+                "modelId" to "claude-fable-5",
+                "contextLimit" to 1000000
+            )
+        ) { id ->
+            ModelProviderProfile(
+                id = id,
+                name = "Provider One",
+                baseUrl = "https://api.anthropic.com",
+                apiKey = "secret",
+                protocolType = "anthropic"
+            )
+        }
+
+        assertNotNull(result)
+        assertEquals(1000000, result?.contextLimit)
     }
 
     @Test
@@ -188,7 +211,8 @@ class AssistsCoreManagerChatOnlyTest {
                 modelId = "gpt-5.4-mini",
                 apiBase = "https://example.com/v1",
                 apiKey = "secret",
-                protocolType = "openai_compatible"
+                protocolType = "openai_compatible",
+                contextLimit = 1000000
             )
         )
 
@@ -198,6 +222,29 @@ class AssistsCoreManagerChatOnlyTest {
         assertEquals("https://example.com/v1", result?.apiBase)
         assertEquals("secret", result?.apiKey)
         assertEquals("openai_compatible", result?.protocolType)
+        assertEquals(1000000, result?.contextLimit)
+    }
+
+    @Test
+    fun `resolvePromptTokenThresholdFallback prefers stored threshold then model contextLimit`() {
+        val override = TaskParams.ChatModelOverride(
+            providerProfileId = "provider-1",
+            modelId = "claude-fable-5",
+            apiBase = "https://api.anthropic.com",
+            apiKey = "secret",
+            protocolType = "anthropic",
+            contextLimit = 1000000
+        )
+
+        assertEquals(256000, resolvePromptTokenThresholdFallback(256000, override))
+        assertEquals(1000000, resolvePromptTokenThresholdFallback(null, override))
+        assertEquals(
+            128000,
+            resolvePromptTokenThresholdFallback(
+                null,
+                override.copy(contextLimit = null)
+            )
+        )
     }
 
     @Test

--- a/assists/src/main/java/cn/com/omnimind/assists/api/bean/TaskParams.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/api/bean/TaskParams.kt
@@ -17,7 +17,8 @@ sealed class TaskParams {
         val apiBase: String,
         val apiKey: String,
         val protocolType: String = "openai_compatible",
-        val wireApi: String = "chat_completions"
+        val wireApi: String = "chat_completions",
+        val contextLimit: Int? = null
     )
     //陪伴任务参数
     data class CompanionTaskParams(

--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -75,7 +75,8 @@ object HttpController {
         val overrideApplied: Boolean,
         val protocolType: String = "openai_compatible",
         val wireApi: String = OpenAiWireApi.CHAT_COMPLETIONS,
-        val requiresReasoningEcho: Boolean = false
+        val requiresReasoningEcho: Boolean = false,
+        val requiresAnthropicThinkingReplay: Boolean = false
     )
 
     private data class ResolvedSceneRequest(
@@ -465,8 +466,198 @@ object HttpController {
             requiresReasoningEcho = DeepSeekProvider.shouldUseOfficialAdapter(
                 protocolType = protocolType,
                 apiBase = apiBase
-            )
+            ),
+            requiresAnthropicThinkingReplay = DeepSeekProvider.normalizeProtocolType(protocolType) == "anthropic"
         )
+    }
+
+    private fun KxJsonObject.findProviderModelValue(vararg keys: String): JsonElement? {
+        for (key in keys) {
+            this[key]?.let { return it }
+        }
+        return null
+    }
+
+    private fun parseProviderModelInt(
+        itemObj: KxJsonObject,
+        directKeys: List<String>,
+        nestedObjectKeys: List<String> = listOf("limits", "limit"),
+        nestedValueKeys: List<String> = directKeys
+    ): Int? {
+        (itemObj.findProviderModelValue(*directKeys.toTypedArray()) as? JsonPrimitive)
+            ?.contentOrNull
+            ?.trim()
+            ?.toIntOrNull()
+            ?.takeIf { it > 0 }
+            ?.let { return it }
+        for (nestedKey in nestedObjectKeys) {
+            val nested = itemObj[nestedKey] as? KxJsonObject ?: continue
+            (nested.findProviderModelValue(*nestedValueKeys.toTypedArray()) as? JsonPrimitive)
+                ?.contentOrNull
+                ?.trim()
+                ?.toIntOrNull()
+                ?.takeIf { it > 0 }
+                ?.let { return it }
+        }
+        return null
+    }
+
+    private fun parseProviderModelBoolean(
+        itemObj: KxJsonObject,
+        directKeys: List<String>,
+        nestedObjectKeys: List<String> = listOf("capabilities", "capability", "features", "feature"),
+        nestedValueKeys: List<String> = directKeys
+    ): Boolean? {
+        fun parseValue(element: JsonElement?): Boolean? {
+            val primitive = element as? JsonPrimitive ?: return null
+            primitive.booleanOrNull?.let { return it }
+            return when (primitive.contentOrNull?.trim()?.lowercase()) {
+                "true", "1", "yes", "supported", "enabled" -> true
+                "false", "0", "no", "unsupported", "disabled" -> false
+                else -> null
+            }
+        }
+
+        parseValue(itemObj.findProviderModelValue(*directKeys.toTypedArray()))?.let { return it }
+        for (nestedKey in nestedObjectKeys) {
+            val nested = itemObj[nestedKey] as? KxJsonObject ?: continue
+            parseValue(nested.findProviderModelValue(*nestedValueKeys.toTypedArray()))?.let { return it }
+        }
+        return null
+    }
+
+    private fun parseProviderModelStringList(
+        itemObj: KxJsonObject,
+        directKeys: List<String>,
+        nestedObjectKeys: List<String> = listOf("modalities", "modality"),
+        nestedValueKeys: List<String> = directKeys
+    ): List<String> {
+        fun parseValue(element: JsonElement?): List<String> {
+            return when (element) {
+                is KxJsonArray -> element.mapNotNull {
+                    (it as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf(String::isNotEmpty)
+                }
+                is JsonPrimitive -> element.contentOrNull
+                    ?.trim()
+                    ?.takeIf(String::isNotEmpty)
+                    ?.let(::listOf)
+                    ?: emptyList()
+                else -> emptyList()
+            }
+        }
+
+        parseValue(itemObj.findProviderModelValue(*directKeys.toTypedArray()))
+            .takeIf { it.isNotEmpty() }
+            ?.let { return it }
+        for (nestedKey in nestedObjectKeys) {
+            val nested = itemObj[nestedKey] as? KxJsonObject ?: continue
+            parseValue(nested.findProviderModelValue(*nestedValueKeys.toTypedArray()))
+                .takeIf { it.isNotEmpty() }
+                ?.let { return it }
+        }
+        return emptyList()
+    }
+
+    private fun appendAnthropicContentBlocks(
+        target: JSONArray,
+        content: JsonElement?
+    ) {
+        when (content) {
+            null -> Unit
+            is kotlinx.serialization.json.JsonPrimitive -> {
+                val text = content.contentOrNull ?: content.toString()
+                if (text.isNotEmpty()) {
+                    val block = JSONObject()
+                    block.put("type", "text")
+                    block.put("text", text)
+                    target.put(
+                        block
+                    )
+                }
+            }
+            is kotlinx.serialization.json.JsonArray -> {
+                content.forEach { block ->
+                    when (block) {
+                        is kotlinx.serialization.json.JsonObject -> target.put(JSONObject(block.toString()))
+                        is kotlinx.serialization.json.JsonPrimitive -> {
+                            val text = block.contentOrNull ?: block.toString()
+                            if (text.isNotEmpty()) {
+                                val textBlock = JSONObject()
+                                textBlock.put("type", "text")
+                                textBlock.put("text", text)
+                                target.put(
+                                    textBlock
+                                )
+                            }
+                        }
+                        else -> Unit
+                    }
+                }
+            }
+            else -> {
+                val block = JSONObject()
+                block.put("type", "text")
+                block.put("text", content.toString())
+                target.put(
+                    block
+                )
+            }
+        }
+    }
+
+    private fun buildAnthropicAssistantContent(message: ChatCompletionMessage): Any? {
+        val content = JSONArray()
+        message.reasoningContent?.trim()?.takeIf { it.isNotEmpty() }?.let { reasoning ->
+            val reasoningBlock = JSONObject()
+            reasoningBlock.put("type", "text")
+            reasoningBlock.put("text", reasoning)
+            content.put(
+                reasoningBlock
+            )
+        }
+        appendAnthropicContentBlocks(content, message.content)
+        message.toolCalls.orEmpty().forEach { toolCall ->
+            val inputJson = runCatching { JSONObject(toolCall.function.arguments) }.getOrElse { JSONObject() }
+            val toolUseBlock = JSONObject()
+            toolUseBlock.put("type", "tool_use")
+            toolUseBlock.put("id", toolCall.id)
+            toolUseBlock.put("name", toolCall.function.name)
+            toolUseBlock.put("input", inputJson)
+            content.put(
+                toolUseBlock
+            )
+        }
+        if (content.length() == 0) {
+            return null
+        }
+        if (
+            content.length() == 1 &&
+            message.reasoningContent.isNullOrBlank() &&
+            message.toolCalls.isNullOrEmpty()
+        ) {
+            val single = content.optJSONObject(0)
+            if (single?.optString("type") == "text") {
+                return single.optString("text", "")
+            }
+        }
+        return content
+    }
+
+    private fun buildAnthropicTextBlock(text: String): JSONObject {
+        val block = JSONObject()
+        block.put("type", "text")
+        block.put("text", text)
+        return block
+    }
+
+    private fun buildAnthropicMessage(
+        role: String,
+        content: Any
+    ): JSONObject {
+        val message = JSONObject()
+        message.put("role", role)
+        message.put("content", content)
+        return message
     }
 
     private fun resolveSceneRequest(
@@ -739,7 +930,7 @@ object HttpController {
                     contentRaw == null -> null
                     contentRaw is kotlinx.serialization.json.JsonPrimitive -> {
                         val text = contentRaw.content
-                        JSONObject().put("type", "text").put("text", text)
+                        buildAnthropicTextBlock(text)
                     }
                     contentRaw is kotlinx.serialization.json.JsonArray -> {
                         // preserve cache_control from array blocks
@@ -751,7 +942,7 @@ object HttpController {
                         }
                         if (arr.length() == 1) arr.optJSONObject(0) else arr
                     }
-                    else -> JSONObject().put("type", "text").put("text", contentRaw.toString())
+                    else -> buildAnthropicTextBlock(contentRaw.toString())
                 }
             }.filterNotNull()
 
@@ -768,7 +959,7 @@ object HttpController {
                     when (c) {
                         is JSONObject -> arr.put(c)
                         is JSONArray -> for (i in 0 until c.length()) arr.put(c.opt(i))
-                        else -> arr.put(JSONObject().put("type", "text").put("text", c.toString()))
+                        else -> arr.put(buildAnthropicTextBlock(c.toString()))
                     }
                 }
                 obj.put("system", arr)
@@ -780,42 +971,22 @@ object HttpController {
         for (msg in nonSystemMessages) {
             when (msg.role) {
                 "assistant" -> {
-                    val toolCalls = msg.toolCalls
-                    if (!toolCalls.isNullOrEmpty()) {
-                        val content = JSONArray()
-                        // optional text part
-                        val textPart = msg.content?.let {
-                            if (it is kotlinx.serialization.json.JsonPrimitive) it.content.trim() else null
-                        }?.takeIf { it.isNotEmpty() }
-                        if (textPart != null) {
-                            content.put(JSONObject().put("type", "text").put("text", textPart))
-                        }
-                        for (tc in toolCalls) {
-                            val inputJson = runCatching { JSONObject(tc.function.arguments) }.getOrElse { JSONObject() }
-                            content.put(
-                                JSONObject()
-                                    .put("type", "tool_use")
-                                    .put("id", tc.id)
-                                    .put("name", tc.function.name)
-                                    .put("input", inputJson)
-                            )
-                        }
-                        messages.put(JSONObject().put("role", "assistant").put("content", content))
-                    } else {
-                        val content = convertContentToAnthropicFormat(msg.content)
-                        if (content != null) {
-                            messages.put(JSONObject().put("role", "assistant").put("content", content))
-                        }
+                    val content = buildAnthropicAssistantContent(msg)
+                    if (content != null) {
+                        messages.put(buildAnthropicMessage("assistant", content))
                     }
                 }
                 "tool" -> {
                     // merge consecutive tool results into a single user message
                     val toolResultBlock = JSONObject()
-                        .put("type", "tool_result")
-                        .put("tool_use_id", msg.toolCallId ?: "")
-                        .put("content", msg.content?.let {
+                    toolResultBlock.put("type", "tool_result")
+                    toolResultBlock.put("tool_use_id", msg.toolCallId ?: "")
+                    toolResultBlock.put(
+                        "content",
+                        msg.content?.let {
                             if (it is kotlinx.serialization.json.JsonPrimitive) it.content else it.toString()
-                        } ?: "")
+                        } ?: ""
+                    )
                     // Try to merge with previous user message if it's a tool_result batch
                     val lastMsg = if (messages.length() > 0) messages.optJSONObject(messages.length() - 1) else null
                     if (lastMsg != null && lastMsg.optString("role") == "user" &&
@@ -827,22 +998,24 @@ object HttpController {
                         ) {
                             prevContent.put(toolResultBlock)
                         } else {
+                            val toolResultBatch = JSONArray()
+                            toolResultBatch.put(toolResultBlock)
                             messages.put(
-                                JSONObject().put("role", "user")
-                                    .put("content", JSONArray().put(toolResultBlock))
+                                buildAnthropicMessage("user", toolResultBatch)
                             )
                         }
                     } else {
+                        val toolResultBatch = JSONArray()
+                        toolResultBatch.put(toolResultBlock)
                         messages.put(
-                            JSONObject().put("role", "user")
-                                .put("content", JSONArray().put(toolResultBlock))
+                            buildAnthropicMessage("user", toolResultBatch)
                         )
                     }
                 }
                 else -> {
                     val content = convertContentToAnthropicFormat(msg.content)
                     if (content != null) {
-                        messages.put(JSONObject().put("role", msg.role).put("content", content))
+                        messages.put(buildAnthropicMessage(msg.role, content))
                     }
                 }
             }
@@ -855,7 +1028,7 @@ object HttpController {
             for (tool in request.tools) {
                 val f = tool.function
                 val toolObj = JSONObject()
-                    .put("name", f.name)
+                toolObj.put("name", f.name)
                 if (!f.description.isNullOrBlank()) toolObj.put("description", f.description)
                 toolObj.put("input_schema", JSONObject(f.parameters.toString()))
                 tools.put(toolObj)
@@ -867,7 +1040,8 @@ object HttpController {
             obj.put("stream", true)
         }
 
-        return applyAnthropicAutomaticCacheControl(obj.toString())
+        val requestJson = obj.toString() ?: "{}"
+        return applyAnthropicAutomaticCacheControl(requestJson)
     }
 
     private fun applyAnthropicAutomaticCacheControl(requestJson: String): String {
@@ -938,11 +1112,66 @@ object HttpController {
                 val ownedBy = itemObj["owned_by"]?.jsonPrimitive?.contentOrNull?.trim()
                     ?.takeIf { it.isNotEmpty() }
                     ?: itemObj["type"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() }
+                val contextLimit = parseProviderModelInt(
+                    itemObj = itemObj,
+                    directKeys = listOf("contextLimit", "context_limit", "contextWindow", "context_window", "max_context_tokens"),
+                    nestedValueKeys = listOf("context", "contextLimit", "context_limit", "contextWindow", "context_window")
+                )
+                val inputLimit = parseProviderModelInt(
+                    itemObj = itemObj,
+                    directKeys = listOf("inputLimit", "input_limit", "max_input_tokens"),
+                    nestedValueKeys = listOf("input", "inputLimit", "input_limit", "max_input_tokens")
+                )
+                val outputLimit = parseProviderModelInt(
+                    itemObj = itemObj,
+                    directKeys = listOf("outputLimit", "output_limit", "max_output_tokens", "max_tokens"),
+                    nestedValueKeys = listOf("output", "outputLimit", "output_limit", "max_output_tokens", "max_tokens")
+                )
+                val inputModalities = parseProviderModelStringList(
+                    itemObj = itemObj,
+                    directKeys = listOf("inputModalities", "input_modalities"),
+                    nestedValueKeys = listOf("input", "inputs")
+                )
+                val outputModalities = parseProviderModelStringList(
+                    itemObj = itemObj,
+                    directKeys = listOf("outputModalities", "output_modalities"),
+                    nestedValueKeys = listOf("output", "outputs")
+                )
                 add(
                     ProviderModelOption(
                         id = id,
                         displayName = displayName,
-                        ownedBy = ownedBy
+                        ownedBy = ownedBy,
+                        contextLimit = contextLimit,
+                        inputLimit = inputLimit,
+                        outputLimit = outputLimit,
+                        inputModalities = inputModalities,
+                        outputModalities = outputModalities,
+                        attachment = parseProviderModelBoolean(
+                            itemObj = itemObj,
+                            directKeys = listOf("attachment", "attachments", "vision"),
+                            nestedValueKeys = listOf("attachment", "attachments", "vision", "image")
+                        ),
+                        reasoning = parseProviderModelBoolean(
+                            itemObj = itemObj,
+                            directKeys = listOf("reasoning", "thinking"),
+                            nestedValueKeys = listOf("reasoning", "thinking")
+                        ),
+                        toolCall = parseProviderModelBoolean(
+                            itemObj = itemObj,
+                            directKeys = listOf("toolCall", "tool_call", "tools"),
+                            nestedValueKeys = listOf("toolCall", "tool_call", "tools", "function_calling")
+                        ),
+                        structuredOutput = parseProviderModelBoolean(
+                            itemObj = itemObj,
+                            directKeys = listOf("structuredOutput", "structured_output"),
+                            nestedValueKeys = listOf("structuredOutput", "structured_output", "json_schema")
+                        ),
+                        temperature = parseProviderModelBoolean(
+                            itemObj = itemObj,
+                            directKeys = listOf("temperature"),
+                            nestedValueKeys = listOf("temperature")
+                        )
                     )
                 )
             }

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -366,9 +366,19 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
         break;
       }
     }
+    ProviderModelOption? selectedModel;
+    for (final item in _modelOptionsByProfileId[override.providerProfileId] ??
+        const <ProviderModelOption>[]) {
+      if (item.id == override.modelId) {
+        selectedModel = item;
+        break;
+      }
+    }
     return {
       'providerProfileId': override.providerProfileId,
       'modelId': override.modelId,
+      if ((selectedModel?.contextLimit ?? 0) > 0)
+        'contextLimit': selectedModel!.contextLimit,
       if (profile != null && profile.baseUrl.trim().isNotEmpty)
         'apiBase': profile.baseUrl.trim(),
       if (profile != null && profile.protocolType.trim().isNotEmpty)

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -2,7 +2,7 @@ part of 'chat_page.dart';
 
 const int _kDefaultContextTokenThreshold = 128000;
 const int _kMinContextTokenThreshold = 10000;
-const int _kMaxContextTokenThreshold = 512000;
+const int _kMaxContextTokenThreshold = 1000000;
 const double _kChatMessageBottomSafeSpacing = 12.0;
 const double _kSlashCommandDrawerRadius = 18.0;
 const double _kSlashCommandDrawerHandleWidth = 36.0;
@@ -2580,7 +2580,14 @@ class _ContextThresholdSheetState extends State<_ContextThresholdSheet> {
   bool _isSaving = false;
   int? _queuedThreshold;
 
-  static const List<int> _presets = <int>[32000, 64000, 128000, 256000, 512000];
+  static const List<int> _presets = <int>[
+    32000,
+    64000,
+    128000,
+    256000,
+    512000,
+    1000000,
+  ];
 
   @override
   void initState() {
@@ -2742,6 +2749,12 @@ class _ContextThresholdSheetState extends State<_ContextThresholdSheet> {
   }
 
   String _formatThresholdLabel(int threshold) {
+    if (threshold >= 1000000) {
+      final millions = threshold / 1000000;
+      return millions % 1 == 0
+          ? '${millions.toStringAsFixed(0)}M'
+          : '${millions.toStringAsFixed(1)}M';
+    }
     if (threshold >= 1000) {
       final kilo = threshold / 1000;
       return kilo % 1 == 0

--- a/ui/lib/services/model_provider_config_service.dart
+++ b/ui/lib/services/model_provider_config_service.dart
@@ -534,24 +534,24 @@ class ModelProviderConfigService {
       displayName: shouldUseMetadataName && metadataDisplayName.isNotEmpty
           ? metadataDisplayName
           : item.displayName,
-      contextLimit: metadata?.contextLimit,
-      inputLimit: metadata?.inputLimit,
-      outputLimit: metadata?.outputLimit,
-      inputModalities: metadata?.inputModalities.isNotEmpty == true
-          ? metadata!.inputModalities
-          : item.inputModalities,
-      outputModalities: metadata?.outputModalities.isNotEmpty == true
-          ? metadata!.outputModalities
-          : item.outputModalities,
+      contextLimit: item.contextLimit ?? metadata?.contextLimit,
+      inputLimit: item.inputLimit ?? metadata?.inputLimit,
+      outputLimit: item.outputLimit ?? metadata?.outputLimit,
+      inputModalities: item.inputModalities.isNotEmpty
+          ? item.inputModalities
+          : (metadata?.inputModalities ?? item.inputModalities),
+      outputModalities: item.outputModalities.isNotEmpty
+          ? item.outputModalities
+          : (metadata?.outputModalities ?? item.outputModalities),
       modelsDevProviderId: metadataProvider?.id,
       modelsDevProviderName: metadataProvider?.name,
       providerLogoUrl: metadataProvider?.logoUrl,
       family: metadata?.family,
-      attachment: metadata?.attachment,
-      reasoning: metadata?.reasoning,
-      toolCall: metadata?.toolCall,
-      structuredOutput: metadata?.structuredOutput,
-      temperature: metadata?.temperature,
+      attachment: item.attachment ?? metadata?.attachment,
+      reasoning: item.reasoning ?? metadata?.reasoning,
+      toolCall: item.toolCall ?? metadata?.toolCall,
+      structuredOutput: item.structuredOutput ?? metadata?.structuredOutput,
+      temperature: item.temperature ?? metadata?.temperature,
       group: ModelsDevCatalogService.groupModelId(
         item.id,
         providerId: metadataProviderGroupId,

--- a/ui/test/services/model_provider_config_service_test.dart
+++ b/ui/test/services/model_provider_config_service_test.dart
@@ -202,6 +202,35 @@ void main() {
     expect(enriched.single.group, 'gpt-4o');
   });
 
+  test('keeps remote limit metadata when catalog fallback is lower', () async {
+    SharedPreferences.setMockInitialValues({});
+    await StorageService.init();
+    ModelsDevCatalogService.setCatalogForTesting(
+      ModelsDevCatalogService.parseCatalog(_modelsDevCatalogJson),
+    );
+
+    final enriched = await ModelProviderConfigService.enrichModelsForProfile(
+      profileId: 'provider-1',
+      providerName: 'OpenAI',
+      apiBase: 'https://api.openai.com/v1',
+      models: const [
+        ProviderModelOption(
+          id: 'gpt-4o',
+          displayName: 'gpt-4o',
+          contextLimit: 1000000,
+          inputLimit: 800000,
+          outputLimit: 32000,
+          toolCall: false,
+        ),
+      ],
+    );
+
+    expect(enriched.single.contextLimit, 1000000);
+    expect(enriched.single.inputLimit, 800000);
+    expect(enriched.single.outputLimit, 32000);
+    expect(enriched.single.toolCall, isFalse);
+  });
+
   test(
     'enriches common model ids even when provider is a custom proxy',
     () async {


### PR DESCRIPTION
## 变更摘要

本次改动完成了 Claude/Anthropic 兼容链路下的 `1M context` 适配，重点修复了 Chat/Agent 仍可能回退到旧上下文阈值、远端模型真实 `contextLimit` 无法完整透传，以及 Anthropic thinking/tool_use 多轮 replay 不完整的问题。  
修复后，Chat 和 Agent 都可以基于 provider 返回的更大上下文能力工作，阈值 UI 可配置到 `1,000,000`，Anthropic Agent 多轮工具调用也能稳定续跑。

## 变更类型

- [x]  新功能


## 关联 Issue

Closes #374 

## 主要改动

1. 在 provider 模型元数据链路中补齐 `contextLimit/inputLimit/outputLimit` 和能力字段解析，并将 Anthropic 路由标记为需要 thinking replay。
2. 将 Chat/Agent 的上下文阈值回退逻辑改为优先使用用户阈值，其次使用模型 `contextLimit`，最后才回退到默认 `128k`。
3. 修复 Anthropic assistant thinking/tool_use 多轮回放，保留 reasoning 内容参与下一轮 replay，并将 UI 阈值上限放开到 `1m`。

## 测试说明

使用 claude-opus-4.8 1m 模型正常完成Chat/Agent任务。
<img width="864" height="1920" alt="e16708d5aaac978132cb1bd2ad6af286" src="https://github.com/user-attachments/assets/d4e39d37-7f84-4da4-a89e-988f5f0ea834" />

<img width="2048" height="80" alt="~}}(W1K51$UG7ZNO_CL CKD" src="https://github.com/user-attachments/assets/bc1fd23b-09f8-4f57-bc57-8f2e32ed788e" />

<img width="1958" height="152" alt="N(}T9RNNDOLI%EGN8FYCY5Y" src="https://github.com/user-attachments/assets/a5334342-6690-4ebf-888c-7bd00caa7162" />


## UI 变更（如有）

有。上下文设置阈值展示支持 `1M`
<img width="864" height="1920" alt="fbe9097e0d5b2bb4db103920bc63a7f1" src="https://github.com/user-attachments/assets/48a65dc8-70e4-49db-9520-e8ed29df7b0b" />

