### PR TITLE
增强 Codex 上下文注入与终端变量支持

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          yes | sdkmanager --licenses >/dev/null
+          yes | sdkmanager --licenses >/dev/null || true
           sdkmanager \
             "platforms;android-${ANDROID_PLATFORM_VERSION}" \
             "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,91 @@
+name: Build Debug APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - 'codex-context-*'
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: '17'
+  FLUTTER_VERSION: '3.38.7'
+  ANDROID_BUILD_TOOLS_VERSION: '36.0.0'
+  ANDROID_PLATFORM_VERSION: '36'
+  NDK_VERSION: '28.2.13676358'
+  ALLOWED_THIRD_PARTY_WRAPPER_SHA: 'ee3739525a995bcb5601621a6e2daec1f183bbefc375743acc235cec33547e04'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Validate Gradle wrappers
+        uses: gradle/actions/wrapper-validation@v4
+        with:
+          allow-checksums: ${{ env.ALLOWED_THIRD_PARTY_WRAPPER_SHA }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: false
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK components
+        shell: bash
+        run: |
+          set -euo pipefail
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager \
+            "platforms;android-${ANDROID_PLATFORM_VERSION}" \
+            "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+            "ndk;${NDK_VERSION}"
+
+      - name: Export Android NDK environment
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Install Flutter dependencies
+        working-directory: ui
+        run: flutter pub get --enforce-lockfile
+
+      - name: Build develop standard debug APK
+        run: >-
+          ./gradlew --no-daemon --build-cache
+          :app:assembleDevelopStandardDebug
+          -Ptarget=lib/main_standard.dart
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenOmniBot-develop-standard-debug
+          if-no-files-found: error
+          retention-days: 14
+          path: app/build/outputs/apk/developStandard/debug/*.apk

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -9,7 +9,9 @@ import com.ai.assistance.operit.terminal.setup.EnvironmentSetupLogic
 import cn.com.omnimind.baselib.database.DatabaseHelper
 import cn.com.omnimind.bot.BuildConfig
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.agent.WorkspaceMemoryService
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
+import com.rk.libcommons.OmnibotTerminalEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -28,6 +30,7 @@ class CodexAppServerManager private constructor(
     private val mainHandler = Handler(Looper.getMainLooper())
     private val bindingRepository = CodexThreadBindingRepository(appContext)
     private val remoteConfigStore = CodexRemoteBridgeConfigStore(appContext)
+    private val contextInjectionConfigStore = CodexContextInjectionConfigStore(appContext)
     private val activeTurnsByThreadId = ConcurrentHashMap<String, String>()
 
     @Volatile
@@ -413,6 +416,7 @@ class CodexAppServerManager private constructor(
 
     private suspend fun readLocalConfig(): Map<String, Any?> {
         val remoteConfig = remoteConfigStore.read()
+        val contextInjectionConfig = contextInjectionConfigStore.read()
         val command = """
             mkdir -p ${shellQuote(CodexAppServerDefaults.CODEX_HOME)}
             printf '__OMNI_CODEX_CONFIG_START__\n'
@@ -459,14 +463,18 @@ class CodexAppServerManager private constructor(
             baseUrl = extractTomlString(configToml, "base_url").orEmpty(),
             apiKey = extractOpenAiApiKey(authJson).orEmpty(),
             remoteConfig = remoteConfig,
-            runtime = resolveRuntime().kind.payloadValue
+            runtime = resolveRuntime().kind.payloadValue,
+            contextInjectionEnabled = contextInjectionConfig.enabled
         )
     }
 
     private suspend fun writeLocalConfig(args: Map<String, Any?>): Map<String, Any?> {
+        val storedContextInjectionConfig = contextInjectionConfigStore.read()
         val baseUrl = args.stringValue("baseUrl").orEmpty()
         val model = args.stringValue("model").orEmpty()
         val apiKey = args.stringValue("apiKey").orEmpty()
+        val contextInjectionEnabled = args.booleanValue("contextInjectionEnabled")
+            ?: storedContextInjectionConfig.enabled
         val remoteConfig = CodexRemoteBridgeConfig(
             enabled = args["remoteEnabled"] == true,
             bridgeUrl = args.stringValue("remoteBridgeUrl").orEmpty(),
@@ -479,6 +487,9 @@ class CodexAppServerManager private constructor(
         }
 
         val savedRemoteConfig = remoteConfigStore.write(remoteConfig)
+        val savedContextInjectionConfig = contextInjectionConfigStore.write(
+            CodexContextInjectionConfig(enabled = contextInjectionEnabled)
+        )
         if (localComplete) {
             val configToml = buildCodexConfigToml(baseUrl = baseUrl, model = model)
             val authJson = JSONObject()
@@ -517,7 +528,8 @@ class CodexAppServerManager private constructor(
             baseUrl = baseUrl,
             apiKey = apiKey,
             remoteConfig = savedRemoteConfig,
-            runtime = resolveRuntime().kind.payloadValue
+            runtime = resolveRuntime().kind.payloadValue,
+            contextInjectionEnabled = savedContextInjectionConfig.enabled
         )
     }
 
@@ -598,9 +610,15 @@ class CodexAppServerManager private constructor(
         cwd: String,
         threadId: String
     ): MutableMap<String, Any?> {
+        val input = resolveInput(args)
+        val contextText = if (contextInjectionConfigStore.read().enabled) {
+            buildCodexContextInjectionTextForTurn()
+        } else {
+            null
+        }
         val params = linkedMapOf<String, Any?>(
             "threadId" to threadId,
-            "input" to resolveInput(args),
+            "input" to buildCodexInputWithOptionalContext(input, contextText),
             "cwd" to cwd,
             "approvalPolicy" to (args.stringValue("approvalPolicy") ?: "on-request"),
             "sandboxPolicy" to (args["sandboxPolicy"] ?: buildDefaultCodexSandboxPolicy(cwd))
@@ -610,6 +628,34 @@ class CodexAppServerManager private constructor(
         }
         addCodexOptionalRunParams(params, args)
         return params
+    }
+
+    private fun buildCodexContextInjectionTextForTurn(): String? {
+        val memoryContext = runCatching {
+            WorkspaceMemoryService(appContext).buildPromptContext()
+        }.onFailure { error ->
+            Log.w(
+                "CodexAppServerManager",
+                "Failed to load workspace memory for Codex context injection.",
+                error
+            )
+        }.getOrNull()
+        val terminalVariables = runCatching {
+            OmnibotTerminalEnvironment.loadUserVariables(appContext)
+        }.onFailure { error ->
+            Log.w(
+                "CodexAppServerManager",
+                "Failed to load terminal variables for Codex context injection.",
+                error
+            )
+        }.getOrDefault(emptyMap())
+
+        return buildCodexContextInjectionText(
+            soul = memoryContext?.soul.orEmpty(),
+            longTermMemory = memoryContext?.longTermMemory.orEmpty(),
+            todayShortMemory = memoryContext?.todayShortMemory.orEmpty(),
+            terminalVariables = terminalVariables
+        )
     }
 
     private fun buildReviewStartParams(
@@ -1005,6 +1051,8 @@ private data class CodexThreadListEntry(
     val archived: Boolean?
 )
 
+private const val MAX_CODEX_CONTEXT_VARIABLE_NAMES = 80
+
 internal fun Map<String, Any?>.withLocalIds(
     threadId: String?,
     conversationId: Long?,
@@ -1050,6 +1098,80 @@ internal fun buildCodexTextInput(text: String): List<Map<String, Any?>> {
             "text_elements" to emptyList<Map<String, Any?>>()
         )
     )
+}
+
+internal fun buildCodexInputWithOptionalContext(
+    input: List<Map<String, Any?>>,
+    contextText: String?
+): List<Map<String, Any?>> {
+    val trimmedContext = contextText?.trim().orEmpty()
+    if (trimmedContext.isEmpty()) {
+        return input
+    }
+    return buildCodexTextInput(trimmedContext) + input
+}
+
+internal fun buildCodexContextInjectionText(
+    soul: String,
+    longTermMemory: String,
+    todayShortMemory: String,
+    terminalVariables: Map<String, String>
+): String? {
+    val sections = mutableListOf<String>()
+
+    fun addTextSection(tag: String, text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) {
+            return
+        }
+        sections += buildString {
+            appendLine("[$tag]")
+            appendLine(trimmed)
+            append("[/$tag]")
+        }
+    }
+
+    addTextSection("workspace_soul", soul)
+    addTextSection("long_term_memory", longTermMemory)
+    addTextSection("today_short_memory", todayShortMemory)
+
+    val variableNames = terminalVariables.keys
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .distinct()
+        .sorted()
+    if (variableNames.isNotEmpty()) {
+        val visibleNames = variableNames.take(MAX_CODEX_CONTEXT_VARIABLE_NAMES)
+        sections += buildString {
+            appendLine("[terminal_variables]")
+            appendLine("Values are hidden. These variable names are configured in Omnibot terminal sessions:")
+            visibleNames.forEach { name ->
+                appendLine("- $name=(configured, value hidden)")
+            }
+            val omitted = variableNames.size - visibleNames.size
+            if (omitted > 0) {
+                appendLine("- ... ($omitted more)")
+            }
+            append("[/terminal_variables]")
+        }
+    }
+
+    if (sections.isEmpty()) {
+        return null
+    }
+    return buildString {
+        appendLine("[omnibot_context]")
+        appendLine("This background context is injected by Omnibot because the user enabled Codex context injection. Use it as persistent user/workspace context, not as the current task request.")
+        sections.forEachIndexed { index, section ->
+            appendLine()
+            append(section)
+            if (index != sections.lastIndex) {
+                appendLine()
+            }
+        }
+        appendLine()
+        append("[/omnibot_context]")
+    }
 }
 
 internal fun buildDefaultCodexSandboxPolicy(cwd: String): Map<String, Any?> {
@@ -1132,7 +1254,8 @@ private fun buildCodexLocalConfigPayload(
     baseUrl: String,
     apiKey: String,
     remoteConfig: CodexRemoteBridgeConfig,
-    runtime: String
+    runtime: String,
+    contextInjectionEnabled: Boolean
 ): Map<String, Any?> {
     return linkedMapOf(
         "codexHome" to CodexAppServerDefaults.CODEX_HOME,
@@ -1144,7 +1267,8 @@ private fun buildCodexLocalConfigPayload(
         "remoteBridgeToken" to remoteConfig.authToken,
         "remoteCwd" to remoteConfig.cwd,
         "remoteConfigured" to remoteConfig.isConfigured,
-        "runtime" to runtime
+        "runtime" to runtime,
+        "contextInjectionEnabled" to contextInjectionEnabled
     )
 }
 
@@ -1247,6 +1371,20 @@ private fun shellQuote(value: String): String {
 
 private fun Map<String, Any?>.stringValue(key: String): String? {
     return this[key]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+}
+
+private fun Map<String, Any?>.booleanValue(key: String): Boolean? {
+    val raw = this[key] ?: return null
+    return when (raw) {
+        is Boolean -> raw
+        is String -> when (raw.trim().lowercase()) {
+            "true", "1", "yes", "on" -> true
+            "false", "0", "no", "off" -> false
+            else -> null
+        }
+        is Number -> raw.toInt() != 0
+        else -> null
+    }
 }
 
 private fun Map<String, Any?>.longValue(key: String): Long? {

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -9,6 +9,8 @@ import com.ai.assistance.operit.terminal.setup.EnvironmentSetupLogic
 import cn.com.omnimind.baselib.database.DatabaseHelper
 import cn.com.omnimind.bot.BuildConfig
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.agent.SkillIndexEntry
+import cn.com.omnimind.bot.agent.SkillIndexService
 import cn.com.omnimind.bot.agent.WorkspaceMemoryService
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
 import com.rk.libcommons.OmnibotTerminalEnvironment
@@ -125,6 +127,17 @@ class CodexAppServerManager private constructor(
             activeTurnsByThreadId.clear()
         }
         return status()
+    }
+
+    suspend fun invalidateLocalTerminalEnvironment() {
+        sessionMutex.withLock {
+            if (activeRuntime == CodexRuntimeKind.LOCAL) {
+                session?.disconnect()
+                session = null
+                activeRuntime = null
+                activeTurnsByThreadId.clear()
+            }
+        }
     }
 
     suspend fun handleMethod(method: String, args: Map<String, Any?>): Any? {
@@ -631,8 +644,9 @@ class CodexAppServerManager private constructor(
     }
 
     private fun buildCodexContextInjectionTextForTurn(): String? {
+        val workspaceManager = AgentWorkspaceManager(appContext)
         val memoryContext = runCatching {
-            WorkspaceMemoryService(appContext).buildPromptContext()
+            WorkspaceMemoryService(appContext, workspaceManager).buildPromptContext()
         }.onFailure { error ->
             Log.w(
                 "CodexAppServerManager",
@@ -649,12 +663,28 @@ class CodexAppServerManager private constructor(
                 error
             )
         }.getOrDefault(emptyMap())
+        val skillsContext = runCatching {
+            val skillsRoot = workspaceManager.skillsRoot()
+            buildCodexSkillsContextText(
+                skillsRootShellPath = workspaceManager.shellPathForAndroid(skillsRoot)
+                    ?: "${AgentWorkspaceManager.SHELL_ROOT_PATH}/.omnibot/skills",
+                skillsRootAndroidPath = skillsRoot.absolutePath,
+                skills = SkillIndexService(appContext, workspaceManager).listSkillsForManagement()
+            )
+        }.onFailure { error ->
+            Log.w(
+                "CodexAppServerManager",
+                "Failed to load skills index for Codex context injection.",
+                error
+            )
+        }.getOrNull()
 
         return buildCodexContextInjectionText(
             soul = memoryContext?.soul.orEmpty(),
             longTermMemory = memoryContext?.longTermMemory.orEmpty(),
             todayShortMemory = memoryContext?.todayShortMemory.orEmpty(),
-            terminalVariables = terminalVariables
+            terminalVariables = terminalVariables,
+            skillsContext = skillsContext.orEmpty()
         )
     }
 
@@ -1052,6 +1082,8 @@ private data class CodexThreadListEntry(
 )
 
 private const val MAX_CODEX_CONTEXT_VARIABLE_NAMES = 80
+private const val MAX_CODEX_CONTEXT_SKILLS = 80
+private const val MAX_CODEX_CONTEXT_SKILL_DESCRIPTION_CHARS = 220
 
 internal fun Map<String, Any?>.withLocalIds(
     threadId: String?,
@@ -1115,7 +1147,8 @@ internal fun buildCodexContextInjectionText(
     soul: String,
     longTermMemory: String,
     todayShortMemory: String,
-    terminalVariables: Map<String, String>
+    terminalVariables: Map<String, String>,
+    skillsContext: String = ""
 ): String? {
     val sections = mutableListOf<String>()
 
@@ -1134,6 +1167,7 @@ internal fun buildCodexContextInjectionText(
     addTextSection("workspace_soul", soul)
     addTextSection("long_term_memory", longTermMemory)
     addTextSection("today_short_memory", todayShortMemory)
+    addTextSection("skills", skillsContext)
 
     val variableNames = terminalVariables.keys
         .map { it.trim() }
@@ -1172,6 +1206,63 @@ internal fun buildCodexContextInjectionText(
         appendLine()
         append("[/omnibot_context]")
     }
+}
+
+internal fun buildCodexSkillsContextText(
+    skillsRootShellPath: String,
+    skillsRootAndroidPath: String,
+    skills: List<SkillIndexEntry>
+): String? {
+    val installedSkills = skills
+        .filter { it.installed }
+        .sortedWith(
+            compareBy<SkillIndexEntry> { it.source }
+                .thenBy { it.name.lowercase() }
+        )
+    if (installedSkills.isEmpty()) {
+        return buildString {
+            appendLine("Omnibot skills root (shell): $skillsRootShellPath")
+            appendLine("Omnibot skills root (android): $skillsRootAndroidPath")
+            appendLine("To create a skill that appears in Omnibot Skill Store, create it at:")
+            appendLine("- $skillsRootShellPath/<skill-id>/SKILL.md")
+            appendLine("Use lowercase kebab-case for <skill-id>. The directory may include scripts/, references/, assets/, or evals/.")
+            append("No installed Omnibot skills are currently indexed.")
+        }
+    }
+
+    return buildString {
+        appendLine("Omnibot skills root (shell): $skillsRootShellPath")
+        appendLine("Omnibot skills root (android): $skillsRootAndroidPath")
+        appendLine("APK built-in skills are copied into this workspace root before indexing; Codex cannot read APK assets directly.")
+        appendLine("To create a skill that appears in Omnibot Skill Store, create it at:")
+        appendLine("- $skillsRootShellPath/<skill-id>/SKILL.md")
+        appendLine("Use lowercase kebab-case for <skill-id>. The directory may include scripts/, references/, assets/, or evals/.")
+        appendLine("When the user asks to create or update a skill, read the indexed skill-creator SKILL.md first if it is available.")
+        appendLine()
+        appendLine("Indexed skills:")
+        installedSkills.take(MAX_CODEX_CONTEXT_SKILLS).forEach { skill ->
+            val capabilities = buildList {
+                if (skill.hasScripts) add("scripts")
+                if (skill.hasReferences) add("references")
+                if (skill.hasAssets) add("assets")
+                if (skill.hasEvals) add("evals")
+            }.ifEmpty { listOf("none") }.joinToString(",")
+            val enabledLabel = if (skill.enabled) "enabled" else "disabled"
+            val description = skill.description
+                .replace('\n', ' ')
+                .trim()
+                .take(MAX_CODEX_CONTEXT_SKILL_DESCRIPTION_CHARS)
+            append("- id=${skill.id} | name=${skill.name} | source=${skill.source} | state=$enabledLabel | path=${skill.shellSkillFilePath} | capabilities=$capabilities")
+            if (description.isNotBlank()) {
+                append(" | description=$description")
+            }
+            appendLine()
+        }
+        val omitted = installedSkills.size - MAX_CODEX_CONTEXT_SKILLS
+        if (omitted > 0) {
+            append("- ... ($omitted more)")
+        }
+    }.trim()
 }
 
 internal fun buildDefaultCodexSandboxPolicy(cwd: String): Map<String, Any?> {

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerSession.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerSession.kt
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.rk.libcommons.OmnibotTerminalEnvironment
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -207,15 +208,21 @@ internal class CodexAppServerSession(
     }
 
     private fun buildStartEnvironment(): Map<String, String> {
-        return mapOf(
-            "OMNIBOT_HEADLESS" to "1",
-            "CODEX_HOME" to CodexAppServerDefaults.CODEX_HOME,
-            "OMNIBOT_SESSION_CWD" to CodexAppServerDefaults.FALLBACK_CWD
-        )
+        return linkedMapOf<String, String>().apply {
+            if (context != null) {
+                putAll(OmnibotTerminalEnvironment.buildTerminalEnvironment(context))
+            }
+            put("OMNIBOT_HEADLESS", "1")
+            put("CODEX_HOME", CodexAppServerDefaults.CODEX_HOME)
+            put("OMNIBOT_SESSION_CWD", CodexAppServerDefaults.FALLBACK_CWD)
+        }
     }
 
     private fun buildStartCommand(): String {
         return """
+            if [ -n "${'$'}{OMNIBOT_USER_ENV_FILE:-}" ] && [ -f "${'$'}OMNIBOT_USER_ENV_FILE" ]; then
+              . "${'$'}OMNIBOT_USER_ENV_FILE"
+            fi
             export CODEX_HOME=${CodexAppServerDefaults.CODEX_HOME}
             export PATH="/root/.npm-global/bin:${'$'}PATH"
             mkdir -p "${'$'}CODEX_HOME"

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexContextInjectionConfigStore.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexContextInjectionConfigStore.kt
@@ -1,0 +1,32 @@
+package cn.com.omnimind.bot.codex
+
+import android.content.Context
+
+internal data class CodexContextInjectionConfig(
+    val enabled: Boolean = false
+)
+
+internal class CodexContextInjectionConfigStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(
+        PREFS_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    fun read(): CodexContextInjectionConfig {
+        return CodexContextInjectionConfig(
+            enabled = prefs.getBoolean(KEY_ENABLED, false)
+        )
+    }
+
+    fun write(config: CodexContextInjectionConfig): CodexContextInjectionConfig {
+        prefs.edit()
+            .putBoolean(KEY_ENABLED, config.enabled)
+            .apply()
+        return read()
+    }
+
+    private companion object {
+        private const val PREFS_NAME = "codex_context_injection_config"
+        private const val KEY_ENABLED = "enabled"
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
@@ -12,6 +12,7 @@ import cn.com.omnimind.baselib.permission.PermissionRequest
 import cn.com.omnimind.baselib.shizuku.ShizukuCapabilityManager
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.codex.CodexAppServerManager
 import cn.com.omnimind.bot.terminal.EmbeddedTerminalAutoStartManager
 import cn.com.omnimind.bot.terminal.EmbeddedTerminalInitCoordinator
 import cn.com.omnimind.bot.terminal.EmbeddedTerminalLaunchHelper
@@ -703,6 +704,11 @@ class SpecialPermissionManager(private val context: Context) {
                     variables[key] = value
                 }
                 val normalized = OmnibotTerminalEnvironment.saveUserVariables(context, variables)
+                runCatching {
+                    CodexAppServerManager.getInstance(context).invalidateLocalTerminalEnvironment()
+                }.onFailure { error ->
+                    OmniLog.w(TAG, "Failed to invalidate Codex environment: ${error.message}")
+                }
                 withContext(Dispatchers.Main) {
                     result.success(
                         mapOf(

--- a/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
@@ -36,6 +36,59 @@ class CodexAppServerProtocolPayloadTest {
     }
 
     @Test
+    fun buildCodexInputWithOptionalContextPrependsContextText() {
+        val userInput = buildCodexTextInput("implement the change")
+
+        val input = buildCodexInputWithOptionalContext(
+            userInput,
+            "workspace memory"
+        )
+
+        assertEquals(2, input.size)
+        assertEquals("workspace memory", input[0]["text"])
+        assertEquals("implement the change", input[1]["text"])
+    }
+
+    @Test
+    fun buildCodexInputWithOptionalContextLeavesInputUntouchedWhenBlank() {
+        val userInput = buildCodexTextInput("implement the change")
+
+        val input = buildCodexInputWithOptionalContext(userInput, " ")
+
+        assertEquals(userInput, input)
+    }
+
+    @Test
+    fun buildCodexContextInjectionTextIncludesMemoryAndHidesVariableValues() {
+        val text = buildCodexContextInjectionText(
+            soul = "SOUL identity",
+            longTermMemory = "- Prefers concise answers",
+            todayShortMemory = "- Working on Codex mode",
+            terminalVariables = mapOf("OPENAI_API_KEY" to "sk-secret")
+        )!!
+
+        assertTrue(text.contains("[omnibot_context]"))
+        assertTrue(text.contains("[workspace_soul]"))
+        assertTrue(text.contains("SOUL identity"))
+        assertTrue(text.contains("[long_term_memory]"))
+        assertTrue(text.contains("[today_short_memory]"))
+        assertTrue(text.contains("- OPENAI_API_KEY=(configured, value hidden)"))
+        assertEquals(false, text.contains("sk-secret"))
+    }
+
+    @Test
+    fun buildCodexContextInjectionTextReturnsNullForEmptyContext() {
+        assertNull(
+            buildCodexContextInjectionText(
+                soul = "",
+                longTermMemory = "",
+                todayShortMemory = "",
+                terminalVariables = emptyMap()
+            )
+        )
+    }
+
+    @Test
     fun buildDefaultCodexSandboxPolicyUsesAbsoluteWritableRoot() {
         val policy = buildDefaultCodexSandboxPolicy("noise\n/workspace")
 

--- a/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
@@ -1,5 +1,6 @@
 package cn.com.omnimind.bot.codex
 
+import cn.com.omnimind.bot.agent.SkillIndexEntry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -64,7 +65,8 @@ class CodexAppServerProtocolPayloadTest {
             soul = "SOUL identity",
             longTermMemory = "- Prefers concise answers",
             todayShortMemory = "- Working on Codex mode",
-            terminalVariables = mapOf("OPENAI_API_KEY" to "sk-secret")
+            terminalVariables = mapOf("OPENAI_API_KEY" to "sk-secret"),
+            skillsContext = "Omnibot skills root (shell): /workspace/.omnibot/skills"
         )!!
 
         assertTrue(text.contains("[omnibot_context]"))
@@ -72,6 +74,8 @@ class CodexAppServerProtocolPayloadTest {
         assertTrue(text.contains("SOUL identity"))
         assertTrue(text.contains("[long_term_memory]"))
         assertTrue(text.contains("[today_short_memory]"))
+        assertTrue(text.contains("[skills]"))
+        assertTrue(text.contains("/workspace/.omnibot/skills"))
         assertTrue(text.contains("- OPENAI_API_KEY=(configured, value hidden)"))
         assertEquals(false, text.contains("sk-secret"))
     }
@@ -86,6 +90,35 @@ class CodexAppServerProtocolPayloadTest {
                 terminalVariables = emptyMap()
             )
         )
+    }
+
+    @Test
+    fun buildCodexSkillsContextTextExplainsWorkspaceSkillLocation() {
+        val text = buildCodexSkillsContextText(
+            skillsRootShellPath = "/workspace/.omnibot/skills",
+            skillsRootAndroidPath = "/sdcard/Omnibot/.omnibot/skills",
+            skills = listOf(
+                SkillIndexEntry(
+                    id = "skill-creator",
+                    name = "skill-creator",
+                    description = "Create Omnibot skills.",
+                    rootPath = "/sdcard/Omnibot/.omnibot/skills/skill-creator",
+                    shellRootPath = "/workspace/.omnibot/skills/skill-creator",
+                    skillFilePath = "/sdcard/Omnibot/.omnibot/skills/skill-creator/SKILL.md",
+                    shellSkillFilePath = "/workspace/.omnibot/skills/skill-creator/SKILL.md",
+                    hasScripts = false,
+                    hasReferences = true,
+                    hasAssets = false,
+                    hasEvals = false,
+                    source = "builtin",
+                    installed = true
+                )
+            )
+        )!!
+
+        assertTrue(text.contains("/workspace/.omnibot/skills/<skill-id>/SKILL.md"))
+        assertTrue(text.contains("id=skill-creator"))
+        assertTrue(text.contains("capabilities=references"))
     }
 
     @Test

--- a/ui/lib/features/home/pages/chat/chat_page_browser.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_browser.dart
@@ -248,9 +248,9 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     ChatPageMode mode,
     ChatIslandDisplayLayer layer,
   ) {
-    final resolvedLayer = mode == ChatPageMode.normal
-        ? layer
-        : ChatIslandDisplayLayer.mode;
+    final resolvedLayer = mode == ChatPageMode.openclaw
+        ? ChatIslandDisplayLayer.mode
+        : layer;
     _chatIslandDisplayLayerByMode[mode] = resolvedLayer;
     final runtime = _runtimeForMode(mode);
     if (runtime != null) {
@@ -260,11 +260,12 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
 
   @override
   void _handleChatIslandDisplayLayerChanged(ChatIslandDisplayLayer layer) {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal) {
+    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
+        _activeMode == ChatPageMode.openclaw) {
       return;
     }
     setState(() {
-      _setChatIslandDisplayLayerForMode(ChatPageMode.normal, layer);
+      _setChatIslandDisplayLayerForMode(_activeMode, layer);
       if (layer != ChatIslandDisplayLayer.tools) {
         _isBrowserOverlayVisible = false;
       }
@@ -273,12 +274,13 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
 
   @override
   Future<void> _handleTerminalToolTap() async {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal) {
+    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
+        _activeMode == ChatPageMode.openclaw) {
       return;
     }
     setState(() {
       _setChatIslandDisplayLayerForMode(
-        ChatPageMode.normal,
+        _activeMode,
         ChatIslandDisplayLayer.tools,
       );
     });
@@ -294,7 +296,8 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
 
   @override
   Future<void> _handleBrowserToolTap() async {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal) {
+    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
+        _activeMode == ChatPageMode.openclaw) {
       return;
     }
     if (!Platform.isAndroid) {
@@ -312,7 +315,7 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     }
     setState(() {
       _setChatIslandDisplayLayerForMode(
-        ChatPageMode.normal,
+        _activeMode,
         ChatIslandDisplayLayer.tools,
       );
       _isBrowserOverlayVisible = true;

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -183,6 +183,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         remoteBridgeUrl: config.remoteBridgeUrl,
         remoteBridgeToken: config.remoteBridgeToken,
         remoteCwd: nextCwd,
+        contextInjectionEnabled: config.contextInjectionEnabled,
       );
       final status = await CodexAppServerService.status();
       if (!mounted) return;

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -1302,7 +1302,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
       mode: kChatRuntimeModeCodex,
       initialMessages: messages,
       conversation: conversation,
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+      initialChatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
     );
     _runtimeCoordinator.replaceConversationSnapshot(
       conversationId: runtimeId,
@@ -1318,7 +1320,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
           ? ThinkingStage.thinking.value
           : ThinkingStage.complete.value,
       lastAgentTaskId: activeTaskId,
-      chatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+      chatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
       preserveLiveStreamingState: preserveLiveStreamingState,
     );
     if (activeTaskId != null) {
@@ -1407,7 +1411,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         _messagesByMode[ChatPageMode.codex]!,
       ),
       conversation: _currentConversationByMode[ChatPageMode.codex],
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+      initialChatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
     );
     return runtimeId;
   }
@@ -1434,9 +1440,11 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
             status: 0,
             messageCount: 0,
             createdAt: now,
-            updatedAt: now,
-          ),
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+              updatedAt: now,
+            ),
+      initialChatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
     );
     return runtimeId;
   }

--- a/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
@@ -43,7 +43,7 @@ mixin _ChatPageTerminalEnvMixin on _ChatPageStateBase {
   Future<void> _openTerminalEnvironmentEditor(
     BuildContext anchorContext,
   ) async {
-    if (_activeMode != ChatPageMode.normal) {
+    if (_activeMode == ChatPageMode.openclaw) {
       return;
     }
     if (_showSlashCommandPanel ||

--- a/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
@@ -29,6 +29,9 @@ mixin _ChatPageTerminalEnvMixin on _ChatPageStateBase {
       setState(() {
         _terminalEnvironmentVariables = normalized;
       });
+      if (_activeMode == ChatPageMode.codex) {
+        unawaited(_refreshCodexStatus());
+      }
     } catch (error) {
       if (mounted) {
         showToast('保存环境变量失败: $error', type: ToastType.error);

--- a/ui/lib/features/home/pages/codex/codex_sessions_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_sessions_page.dart
@@ -342,6 +342,7 @@ class _CodexSessionsPageState extends State<CodexSessionsPage> {
         remoteBridgeUrl: config.remoteBridgeUrl,
         remoteBridgeToken: config.remoteBridgeToken,
         remoteCwd: nextCwd,
+        contextInjectionEnabled: config.contextInjectionEnabled,
       );
       final status = await CodexAppServerService.status();
       if (!mounted) return;

--- a/ui/lib/features/home/pages/codex/codex_setting_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_setting_page.dart
@@ -906,8 +906,8 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                         Text(
                           _contextInjectionEnabled
                               ? _localeText(
-                                  zh: '已开启：Codex 每轮会收到 SOUL、长期记忆、今日短期记忆和终端变量名；变量值不会明文注入。',
-                                  en: 'Enabled: each Codex turn receives SOUL, long-term memory, today memory, and terminal variable names. Values are hidden.',
+                                  zh: '已开启：Codex 每轮会收到 SOUL、长期记忆、今日短期记忆、Skills 索引和终端变量名；变量值不会明文注入。',
+                                  en: 'Enabled: each Codex turn receives SOUL, memory, skills index, and terminal variable names. Values are hidden.',
                                 )
                               : _localeText(
                                   zh: '已关闭：Codex 使用干净上下文。',

--- a/ui/lib/features/home/pages/codex/codex_setting_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_setting_page.dart
@@ -39,11 +39,13 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
   bool _obscureApiKey = true;
   bool _obscureBridgeToken = true;
   bool _remoteEnabled = false;
+  bool _contextInjectionEnabled = false;
   String _codexHome = _defaultCodexHome;
   String _runtime = 'local';
   String? _error;
   String? _status;
   String? _lastSavedSignature;
+  String? _lastSavedConfigFieldsSignature;
 
   bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
   bool get _isDarkTheme => context.isDarkTheme;
@@ -122,12 +124,13 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       _setControllerText(_bridgeTokenController, config.remoteBridgeToken);
       _setControllerText(_bridgeCwdController, config.remoteCwd);
       _remoteEnabled = config.remoteEnabled;
+      _contextInjectionEnabled = config.contextInjectionEnabled;
     } finally {
       _isSyncing = false;
     }
   }
 
-  String _signature({
+  String _configFieldsSignature({
     required String baseUrl,
     required String model,
     required String apiKey,
@@ -147,6 +150,42 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     ].join('\n');
   }
 
+  String _signature({
+    required String baseUrl,
+    required String model,
+    required String apiKey,
+    required String remoteBridgeUrl,
+    required String remoteBridgeToken,
+    required String remoteCwd,
+    required bool remoteEnabled,
+    required bool contextInjectionEnabled,
+  }) {
+    return [
+      _configFieldsSignature(
+        baseUrl: baseUrl,
+        model: model,
+        apiKey: apiKey,
+        remoteBridgeUrl: remoteBridgeUrl,
+        remoteBridgeToken: remoteBridgeToken,
+        remoteCwd: remoteCwd,
+        remoteEnabled: remoteEnabled,
+      ),
+      contextInjectionEnabled ? 'context:on' : 'context:off',
+    ].join('\n');
+  }
+
+  String _currentConfigFieldsSignature() {
+    return _configFieldsSignature(
+      baseUrl: _baseUrlController.text,
+      model: _modelController.text,
+      apiKey: _apiKeyController.text,
+      remoteBridgeUrl: _bridgeUrlController.text,
+      remoteBridgeToken: _bridgeTokenController.text,
+      remoteCwd: _bridgeCwdController.text,
+      remoteEnabled: _remoteEnabled,
+    );
+  }
+
   String _currentSignature() {
     return _signature(
       baseUrl: _baseUrlController.text,
@@ -156,6 +195,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       remoteBridgeToken: _bridgeTokenController.text,
       remoteCwd: _bridgeCwdController.text,
       remoteEnabled: _remoteEnabled,
+      contextInjectionEnabled: _contextInjectionEnabled,
     );
   }
 
@@ -189,11 +229,22 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
 
   bool get _isRemoteIncomplete => _remoteEnabled && !_hasCompleteRemoteInput;
 
+  bool get _onlyContextInjectionChanged =>
+      _lastSavedConfigFieldsSignature != null &&
+      _currentConfigFieldsSignature() == _lastSavedConfigFieldsSignature &&
+      _currentSignature() != _lastSavedSignature;
+
+  bool get _canSaveCurrentConfig =>
+      !_isRemoteIncomplete && (_hasCompleteInput || _onlyContextInjectionChanged);
+
   void _handleEdited() {
     if (_isSyncing || !mounted) return;
     _saveDebounce?.cancel();
     final signature = _currentSignature();
-    final anyInput = _hasAnyLocalInput || _hasAnyRemoteInput || _remoteEnabled;
+    final anyInput = _hasAnyLocalInput ||
+        _hasAnyRemoteInput ||
+        _remoteEnabled ||
+        _contextInjectionEnabled;
     setState(() {
       _error = null;
       if (_isRemoteIncomplete) {
@@ -203,7 +254,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         );
       } else if (!anyInput) {
         _status = null;
-      } else if (!_hasCompleteInput) {
+      } else if (!_canSaveCurrentConfig) {
         _status = _localeText(
           zh: _remoteEnabled ? '填写完整后将自动保存。' : '本地配置填写完整后将自动保存。',
           en: _remoteEnabled
@@ -216,7 +267,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _status = _localeText(zh: '即将自动保存...', en: 'Autosave pending...');
       }
     });
-    if (_hasCompleteInput && signature != _lastSavedSignature) {
+    if (_canSaveCurrentConfig && signature != _lastSavedSignature) {
       _scheduleAutoSave();
     }
   }
@@ -236,9 +287,18 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
               en: 'Remote mode is disabled. Codex will use local Alpine.',
             );
     });
-    if (_hasCompleteInput && _currentSignature() != _lastSavedSignature) {
+    if (_canSaveCurrentConfig && _currentSignature() != _lastSavedSignature) {
       _scheduleAutoSave(delay: const Duration(milliseconds: 300));
     }
+  }
+
+  void _setContextInjectionEnabled(bool value) {
+    if (_contextInjectionEnabled == value) return;
+    setState(() {
+      _contextInjectionEnabled = value;
+      _error = null;
+    });
+    _handleEdited();
   }
 
   void _scheduleAutoSave({Duration delay = _autoSaveDelay}) {
@@ -264,6 +324,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _error = null;
         _status = null;
         _lastSavedSignature = _currentSignature();
+        _lastSavedConfigFieldsSignature = _currentConfigFieldsSignature();
       });
     } catch (error) {
       if (!mounted) return;
@@ -279,7 +340,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
 
   Future<void> _saveConfig() async {
     if (_isSaving) return;
-    if (_isRemoteIncomplete || !_hasCompleteInput) {
+    if (!_canSaveCurrentConfig) {
       if (!mounted) return;
       setState(() {
         _status = _isRemoteIncomplete
@@ -319,9 +380,10 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         remoteBridgeUrl: _bridgeUrlController.text.trim(),
         remoteBridgeToken: _bridgeTokenController.text.trim(),
         remoteCwd: _bridgeCwdController.text.trim(),
+        contextInjectionEnabled: _contextInjectionEnabled,
       );
       if (!mounted) return;
-      final savedSignature = _signature(
+      final savedConfigFieldsSignature = _configFieldsSignature(
         baseUrl: saved.baseUrl,
         model: saved.model,
         apiKey: saved.apiKey,
@@ -330,6 +392,16 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         remoteCwd: saved.remoteCwd,
         remoteEnabled: saved.remoteEnabled,
       );
+      final savedSignature = _signature(
+        baseUrl: saved.baseUrl,
+        model: saved.model,
+        apiKey: saved.apiKey,
+        remoteBridgeUrl: saved.remoteBridgeUrl,
+        remoteBridgeToken: saved.remoteBridgeToken,
+        remoteCwd: saved.remoteCwd,
+        remoteEnabled: saved.remoteEnabled,
+        contextInjectionEnabled: saved.contextInjectionEnabled,
+      );
       if (_currentSignature() == savingSignature) {
         _syncControllers(saved);
       }
@@ -337,6 +409,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _codexHome = saved.codexHome ?? _defaultCodexHome;
         _runtime = saved.runtime ?? 'local';
         _lastSavedSignature = savedSignature;
+        _lastSavedConfigFieldsSignature = savedConfigFieldsSignature;
         _error = null;
         _status = _currentSignature() == savedSignature
             ? _localeText(
@@ -361,7 +434,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     } finally {
       if (mounted) {
         setState(() => _isSaving = false);
-        if (_hasCompleteInput && _currentSignature() != savingSignature) {
+        if (_canSaveCurrentConfig && _currentSignature() != savingSignature) {
           _scheduleAutoSave(delay: const Duration(milliseconds: 300));
         }
       }
@@ -535,6 +608,36 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
               borderRadius: 28.75,
               value: _remoteEnabled,
               onToggle: _setRemoteEnabled,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContextInjectionSwitch() {
+    final palette = context.omniPalette;
+    final enabled = !_isSaving;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: enabled
+          ? () => _setContextInjectionEnabled(!_contextInjectionEnabled)
+          : null,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 12),
+        child: AbsorbPointer(
+          child: Opacity(
+            opacity: enabled ? 1 : 0.5,
+            child: FlutterSwitch(
+              width: 32,
+              height: 18.67,
+              toggleSize: 11.3,
+              padding: 3,
+              activeColor: palette.accentPrimary,
+              inactiveColor: palette.borderStrong,
+              borderRadius: 28.75,
+              value: _contextInjectionEnabled,
+              onToggle: _setContextInjectionEnabled,
             ),
           ),
         ),
@@ -777,6 +880,45 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                               ),
                             ),
                           ],
+                        ),
+                        const SizedBox(height: 14),
+                        Divider(height: 1, color: borderColor),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _localeText(
+                                  zh: '注入 Omnibot 上下文',
+                                  en: 'Inject Omnibot Context',
+                                ),
+                                style: TextStyle(
+                                  color: _primaryTextColor,
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: 'PingFang SC',
+                                ),
+                              ),
+                            ),
+                            _buildContextInjectionSwitch(),
+                          ],
+                        ),
+                        Text(
+                          _contextInjectionEnabled
+                              ? _localeText(
+                                  zh: '已开启：Codex 每轮会收到 SOUL、长期记忆、今日短期记忆和终端变量名；变量值不会明文注入。',
+                                  en: 'Enabled: each Codex turn receives SOUL, long-term memory, today memory, and terminal variable names. Values are hidden.',
+                                )
+                              : _localeText(
+                                  zh: '已关闭：Codex 使用干净上下文。',
+                                  en: 'Disabled: Codex uses a clean context.',
+                                ),
+                          style: TextStyle(
+                            color: _secondaryTextColor,
+                            fontSize: 12,
+                            height: 1.35,
+                            fontFamily: 'PingFang SC',
+                          ),
                         ),
                         const SizedBox(height: 14),
                         Divider(height: 1, color: borderColor),

--- a/ui/lib/services/codex_app_server_service.dart
+++ b/ui/lib/services/codex_app_server_service.dart
@@ -76,6 +76,7 @@ class CodexLocalConfig {
     this.remoteCwd = '',
     this.remoteConfigured = false,
     this.runtime,
+    this.contextInjectionEnabled = false,
   });
 
   final String baseUrl;
@@ -88,6 +89,7 @@ class CodexLocalConfig {
   final String remoteCwd;
   final bool remoteConfigured;
   final String? runtime;
+  final bool contextInjectionEnabled;
 
   factory CodexLocalConfig.fromMap(Map<dynamic, dynamic>? map) {
     final source = map ?? const <dynamic, dynamic>{};
@@ -102,6 +104,7 @@ class CodexLocalConfig {
       remoteCwd: _stringOrNull(source['remoteCwd']) ?? '',
       remoteConfigured: source['remoteConfigured'] == true,
       runtime: _stringOrNull(source['runtime']),
+      contextInjectionEnabled: source['contextInjectionEnabled'] == true,
     );
   }
 }
@@ -438,6 +441,7 @@ class CodexAppServerService {
     String remoteBridgeUrl = '',
     String remoteBridgeToken = '',
     String remoteCwd = '',
+    bool? contextInjectionEnabled,
   }) async {
     final result = await _invokeMap('config/local/write', {
       'baseUrl': baseUrl.trim(),
@@ -447,6 +451,8 @@ class CodexAppServerService {
       'remoteBridgeUrl': remoteBridgeUrl.trim(),
       'remoteBridgeToken': remoteBridgeToken.trim(),
       'remoteCwd': remoteCwd.trim(),
+      if (contextInjectionEnabled != null)
+        'contextInjectionEnabled': contextInjectionEnabled,
     });
     return CodexLocalConfig.fromMap(result);
   }

--- a/ui/test/services/codex_app_server_service_test.dart
+++ b/ui/test/services/codex_app_server_service_test.dart
@@ -128,6 +128,7 @@ void main() {
         'model': 'gpt-5.5',
         'apiKey': 'key',
         'codexHome': '/root/.codex',
+        'contextInjectionEnabled': true,
       };
     });
 
@@ -136,12 +137,15 @@ void main() {
       baseUrl: ' https://example.com/v1 ',
       model: ' gpt-5.5 ',
       apiKey: ' key ',
+      contextInjectionEnabled: true,
     );
 
     expect(read.baseUrl, 'https://example.com/v1');
     expect(read.model, 'gpt-5.5');
     expect(read.apiKey, 'key');
+    expect(read.contextInjectionEnabled, isTrue);
     expect(written.codexHome, '/root/.codex');
+    expect(written.contextInjectionEnabled, isTrue);
     expect(calls.map((call) => call.method), [
       'config/local/read',
       'config/local/write',
@@ -154,6 +158,7 @@ void main() {
       'remoteBridgeUrl': '',
       'remoteBridgeToken': '',
       'remoteCwd': '',
+      'contextInjectionEnabled': true,
     });
   });
 


### PR DESCRIPTION
## 更改内容

- 在「设置 -> Codex 配置」新增「注入 Omnibot 上下文」开关，默认关闭。
- 开启后，Codex 每轮会注入 SOUL、长期记忆、今日短期记忆、Skills 索引和终端变量名。
- 终端变量值不会明文注入 prompt，避免泄露 API Key 等敏感信息。
- 修复本地 Codex app-server 实际继承终端环境变量的问题；保存变量后会断开本地 Codex 会话，下一轮自动重启并加载新变量。
- Codex 模式顶部模式岛支持切换到工具层，并可打开与 Agent 模式相同的终端环境变量编辑面板。
- Codex 上下文中补充 Omnibot Skills 根目录和创建规范，指导新建 skill 写入 `/workspace/.omnibot/skills/<skill-id>/SKILL.md`，使技能仓库可以扫描显示。
- 增加 debug APK GitHub Actions 构建 workflow，方便无本地 Android/Flutter 环境时构建测试包。

## 验证

- `git diff --check` 通过。
- GitHub Actions `Build Debug APK` 已成功构建 debug APK。
- 本地环境缺少 `dart` / `flutter`，且 Gradle wrapper 下载曾遇到 SSL 握手问题，因此主要依赖 GitHub Actions 完整构建验证。