### PR TITLE
修复会话列表重命名保留与当前会话高亮

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -273,7 +273,7 @@ class CodexAppServerManager private constructor(
             mapOf("threadId" to threadId, "name" to name)
         ) as Map<String, Any?>
         if (shouldSyncLocalThreadBindings()) {
-            bindingRepository.updateTitle(threadId, name)
+            bindingRepository.updateTitle(threadId, name, force = true)
         }
         return response.withLocalIds(
             threadId = threadId,

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexThreadBindingRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexThreadBindingRepository.kt
@@ -49,14 +49,16 @@ internal class CodexThreadBindingRepository(
                 }
             }
             val conversation = DatabaseHelper.getConversationById(existingBinding.conversationId)
-            val updatedConversation = conversation?.let {
-                val titleForUpdate = if (conversationId != null && it.title.isNotBlank()) {
-                    null
-                } else {
-                    title
+            val updatedConversation = conversation?.let { existingConversation ->
+                val titleForUpdate = title?.takeIf { incomingTitle ->
+                    shouldApplyIncomingTitle(
+                        conversation = existingConversation,
+                        threadId = existingBinding.threadId,
+                        incomingTitle = incomingTitle
+                    )
                 }
                 buildUpdatedConversation(
-                    conversation = it,
+                    conversation = existingConversation,
                     title = titleForUpdate,
                     archived = archived,
                     updatedAt = now
@@ -145,11 +147,18 @@ internal class CodexThreadBindingRepository(
         return conversationId
     }
 
-    suspend fun updateTitle(threadId: String, title: String?) {
+    suspend fun updateTitle(
+        threadId: String,
+        title: String?,
+        force: Boolean = false
+    ) {
         val binding = getBindingByThreadId(threadId.trim()) ?: return
         val conversation = DatabaseHelper.getConversationById(binding.conversationId) ?: return
         val normalizedTitle = title?.trim().orEmpty()
         if (normalizedTitle.isEmpty() || normalizedTitle == conversation.title) {
+            return
+        }
+        if (!force && !shouldApplyIncomingTitle(conversation, threadId, normalizedTitle)) {
             return
         }
         val updated = conversation.copy(
@@ -213,6 +222,22 @@ internal class CodexThreadBindingRepository(
             isArchived = archived ?: conversation.isArchived,
             updatedAt = updatedAt
         )
+    }
+
+    private fun shouldApplyIncomingTitle(
+        conversation: Conversation,
+        threadId: String,
+        incomingTitle: String
+    ): Boolean {
+        val normalizedIncomingTitle = incomingTitle.trim()
+        if (normalizedIncomingTitle.isEmpty()) {
+            return false
+        }
+        val currentTitle = conversation.title.trim()
+        if (currentTitle.isEmpty() || currentTitle == normalizedIncomingTitle) {
+            return true
+        }
+        return currentTitle == "Codex" || currentTitle == defaultConversationTitle(threadId)
     }
 
     private fun publishConversationEvent(eventName: String, conversation: Conversation) {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -6012,12 +6012,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
      */
     fun updateConversation(call: MethodCall, result: MethodChannel.Result) {
         val conversationMap = call.argument<Map<String, Any>>("conversation")
+        val preserveUserMetadata = call.argument<Boolean>("preserveUserMetadata") ?: false
 
         workJob.launch {
             try {
                 if (conversationMap != null) {
                     conversationDomainService.updateConversationFromPayload(
-                        conversationMap.mapValues { it.value }
+                        conversationMap.mapValues { it.value },
+                        preserveUserMetadata = preserveUserMetadata
                     )
                     withContext(Dispatchers.Main) {
                         result.success("SUCCESS")

--- a/app/src/main/java/cn/com/omnimind/bot/webchat/ConversationDomainService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/webchat/ConversationDomainService.kt
@@ -66,7 +66,8 @@ class ConversationDomainService(
     }
 
     suspend fun updateConversationFromPayload(
-        conversationMap: Map<String, Any?>
+        conversationMap: Map<String, Any?>,
+        preserveUserMetadata: Boolean = false
     ): Map<String, Any?> {
         val conversationId = conversationMap.readLong("id")
             ?: throw IllegalArgumentException("conversation.id is invalid")
@@ -74,20 +75,40 @@ class ConversationDomainService(
             ?: throw IllegalArgumentException("Conversation not found")
         val incomingContextSummary = conversationMap["contextSummary"]?.toString()?.trim()
         val updated = existing.copy(
-            title = conversationMap["title"]?.toString()?.trim()?.ifEmpty {
+            title = if (preserveUserMetadata) {
                 existing.title
-            } ?: existing.title,
-            mode = normalizeConversationMode(
-                conversationMap["mode"]?.toString() ?: existing.mode
-            ),
-            isArchived = conversationMap.readBoolean("isArchived") ?: existing.isArchived,
-            isPinned = conversationMap.readBoolean("isPinned") ?: existing.isPinned,
-            parentConversationId = if (conversationMap.containsKey("parentConversationId")) {
+            } else {
+                conversationMap["title"]?.toString()?.trim()?.ifEmpty {
+                    existing.title
+                } ?: existing.title
+            },
+            mode = if (preserveUserMetadata) {
+                existing.mode
+            } else {
+                normalizeConversationMode(
+                    conversationMap["mode"]?.toString() ?: existing.mode
+                )
+            },
+            isArchived = if (preserveUserMetadata) {
+                existing.isArchived
+            } else {
+                conversationMap.readBoolean("isArchived") ?: existing.isArchived
+            },
+            isPinned = if (preserveUserMetadata) {
+                existing.isPinned
+            } else {
+                conversationMap.readBoolean("isPinned") ?: existing.isPinned
+            },
+            parentConversationId = if (preserveUserMetadata) {
+                existing.parentConversationId
+            } else if (conversationMap.containsKey("parentConversationId")) {
                 conversationMap.readLong("parentConversationId")?.takeIf { it > 0L }
             } else {
                 existing.parentConversationId
             },
-            parentConversationMode = if (conversationMap.containsKey("parentConversationMode")) {
+            parentConversationMode = if (preserveUserMetadata) {
+                existing.parentConversationMode
+            } else if (conversationMap.containsKey("parentConversationMode")) {
                 conversationMap["parentConversationMode"]
                     ?.toString()
                     ?.let(::normalizeConversationMode)
@@ -95,7 +116,9 @@ class ConversationDomainService(
             } else {
                 existing.parentConversationMode
             },
-            scheduledTaskId = if (conversationMap.containsKey("scheduledTaskId")) {
+            scheduledTaskId = if (preserveUserMetadata) {
+                existing.scheduledTaskId
+            } else if (conversationMap.containsKey("scheduledTaskId")) {
                 conversationMap["scheduledTaskId"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
             } else {
                 existing.scheduledTaskId
@@ -119,7 +142,11 @@ class ConversationDomainService(
                 ?: existing.promptTokenThreshold.coerceAtLeast(1),
             latestPromptTokensUpdatedAt = conversationMap.readLong("latestPromptTokensUpdatedAt")
                 ?: existing.latestPromptTokensUpdatedAt,
-            createdAt = conversationMap.readLong("createdAt") ?: existing.createdAt,
+            createdAt = if (preserveUserMetadata) {
+                existing.createdAt
+            } else {
+                conversationMap.readLong("createdAt") ?: existing.createdAt
+            },
             updatedAt = System.currentTimeMillis()
         )
         DatabaseHelper.updateConversation(updated)

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -43,8 +43,8 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       ),
       conversation:
           conversation ??
-          runtime?.conversation ??
-          _currentConversationByMode[mode],
+          _currentConversationByMode[mode] ??
+          runtime?.conversation,
       isAiResponding:
           runtime?.isAiResponding ?? (_isAiRespondingByMode[mode] ?? false),
       isContextCompressing:

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -130,7 +130,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     final normalizedPreferredMode = preferredMode == ConversationMode.openclaw
         ? ConversationMode.normal
         : preferredMode;
-    final normalizedIncomingTarget = _normalizeVisibleThreadTarget(
+    final normalizedIncomingTarget = await _normalizeVisibleThreadTarget(
       incomingTarget,
     );
     if (normalizedIncomingTarget != null) {
@@ -146,7 +146,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (normalizedPreferredMode == null) {
       final lastVisible =
           await ConversationHistoryService.getLastVisibleThreadTarget();
-      final normalizedLastVisible = _normalizeVisibleThreadTarget(
+      final normalizedLastVisible = await _normalizeVisibleThreadTarget(
         lastVisible,
         freshCodexOnImplicitRestore: true,
       );
@@ -160,7 +160,9 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
         await ConversationHistoryService.getCurrentConversationTarget(
           mode: resolvedMode,
         );
-    final normalizedSavedTarget = _normalizeVisibleThreadTarget(savedTarget);
+    final normalizedSavedTarget = await _normalizeVisibleThreadTarget(
+      savedTarget,
+    );
     if (normalizedSavedTarget != null) {
       return normalizedSavedTarget;
     }
@@ -168,7 +170,9 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     final latestTarget = await ConversationService.getLatestConversationTarget(
       mode: resolvedMode,
     );
-    final normalizedLatestTarget = _normalizeVisibleThreadTarget(latestTarget);
+    final normalizedLatestTarget = await _normalizeVisibleThreadTarget(
+      latestTarget,
+    );
     if (normalizedLatestTarget != null) {
       return normalizedLatestTarget;
     }
@@ -176,14 +180,27 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     return ConversationThreadTarget.newConversation(mode: resolvedMode);
   }
 
-  ConversationThreadTarget? _normalizeVisibleThreadTarget(
+  Future<ConversationThreadTarget?> _normalizeVisibleThreadTarget(
     ConversationThreadTarget? target, {
     bool freshCodexOnImplicitRestore = false,
-  }) {
+  }) async {
     if (target == null) {
       return null;
     }
     if (target.mode == ConversationMode.openclaw) {
+      return null;
+    }
+    final conversationId = target.conversationId;
+    if (!target.isNewConversation &&
+        conversationId != null &&
+        await ConversationService.isConversationDeleted(
+          conversationId,
+          mode: target.mode,
+        )) {
+      await ConversationHistoryService.clearConversationThreadReferences(
+        conversationId,
+        mode: target.mode,
+      );
       return null;
     }
     if (freshCodexOnImplicitRestore && target.mode == ConversationMode.codex) {
@@ -328,6 +345,20 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (conversationId == null) {
       return;
     }
+    final conversationMode = _conversationModeForPageMode(mode);
+    if (await ConversationService.isConversationDeleted(
+      conversationId,
+      mode: conversationMode,
+    )) {
+      await ConversationHistoryService.clearConversationThreadReferences(
+        conversationId,
+        mode: conversationMode,
+      );
+      return;
+    }
+    if (!mounted || !isConversationLifecycleTokenCurrent(lifecycleToken)) {
+      return;
+    }
 
     final runtime = _runtimeCoordinator.runtimeFor(
       conversationId: conversationId,
@@ -348,8 +379,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     try {
       conversation = conversations.firstWhere(
         (item) =>
-            item.id == conversationId &&
-            item.mode == _conversationModeForPageMode(mode),
+            item.id == conversationId && item.mode == conversationMode,
       );
     } catch (_) {
       conversation = null;
@@ -360,7 +390,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
         inMemoryMessages ??
         await ConversationHistoryService.getConversationMessages(
           conversationId,
-          mode: _conversationModeForPageMode(mode),
+          mode: conversationMode,
           expectedMessageCount: resolvedConversation?.messageCount,
         );
     if (!mounted || !isConversationLifecycleTokenCurrent(lifecycleToken)) {

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -355,7 +355,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       conversation = null;
     }
 
-    final resolvedConversation = inMemoryConversation ?? conversation;
+    final resolvedConversation = conversation ?? inMemoryConversation;
     final resolvedMessages =
         inMemoryMessages ??
         await ConversationHistoryService.getConversationMessages(

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1567,6 +1567,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                               newConversationMode: _conversationModeForPageMode(
                                 _activeMode,
                               ),
+                              activeConversationId: _currentConversationId,
+                              activeConversationMode:
+                                  activeConversationModeValue,
                               onThreadTargetSelected:
                                   _handleEmbeddedDrawerThreadTargetSelected,
                             ),
@@ -1820,6 +1823,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                         newConversationMode: _conversationModeForPageMode(
                           _activeMode,
                         ),
+                        activeConversationId: _currentConversationId,
+                        activeConversationMode: activeConversationModeValue,
                       ),
                 onDrawerChanged: (isOpen) {
                   if (isHdPadLandscape) {

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -567,15 +567,28 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           DateTime.now().millisecondsSinceEpoch;
       final updatedAt = newest?.createAt.millisecondsSinceEpoch ?? createdAt;
 
-      final recovered = ConversationModel(
-        id: conversationId,
+      final latestConversation = await ConversationService.getConversationById(
+        conversationId,
         mode: mode,
-        title: title,
-        summary: currentConversation?.summary,
-        status: currentConversation?.status ?? 0,
+        includeArchived: true,
+      );
+      final recoveredBase =
+          latestConversation ??
+          currentConversation ??
+          ConversationModel(
+            id: conversationId,
+            mode: mode,
+            title: title,
+            summary: currentConversation?.summary,
+            status: currentConversation?.status ?? 0,
+            lastMessage: lastText,
+            messageCount: savedMessages.length,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          );
+      final recovered = recoveredBase.copyWith(
         lastMessage: lastText,
         messageCount: savedMessages.length,
-        createdAt: createdAt,
         updatedAt: updatedAt,
       );
 
@@ -771,7 +784,14 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           );
         }
 
+        final latestConversation =
+            await ConversationService.getConversationById(
+              targetId,
+              mode: snapshotMode,
+              includeArchived: true,
+            );
         final baseConversation =
+            latestConversation ??
             snapshotConversation ??
             ConversationModel(
               id: targetId,

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -125,6 +125,20 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
 
       final conversationId = target.conversationId;
       if (conversationId != null) {
+        if (await ConversationService.isConversationDeleted(
+          conversationId,
+          mode: target.mode,
+        )) {
+          await ConversationHistoryService.clearConversationThreadReferences(
+            conversationId,
+            mode: target.mode,
+          );
+          if (!_isConversationOperationCurrent(token)) {
+            return;
+          }
+          await _restoreLatestConversationOrReset(lifecycleToken: token);
+          return;
+        }
         await loadConversation(
           conversationId,
           mode: target.mode,
@@ -180,8 +194,24 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
         return;
       }
 
+      final savedConversationId = savedTarget.conversationId!;
+      if (await ConversationService.isConversationDeleted(
+        savedConversationId,
+        mode: savedTarget.mode,
+      )) {
+        await ConversationHistoryService.clearConversationThreadReferences(
+          savedConversationId,
+          mode: savedTarget.mode,
+        );
+        if (!_isConversationOperationCurrent(token)) {
+          return;
+        }
+        await _restoreLatestConversationOrReset(lifecycleToken: token);
+        return;
+      }
+
       await loadConversation(
-        savedTarget.conversationId!,
+        savedConversationId,
         mode: savedTarget.mode,
         lifecycleToken: token,
       );
@@ -297,6 +327,15 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
       return;
     }
     final operationMode = mode ?? activeConversationModeValue;
+    if (await ConversationService.isConversationDeleted(
+      conversationId,
+      mode: operationMode,
+    )) {
+      return;
+    }
+    if (!_isConversationOperationCurrent(token)) {
+      return;
+    }
     try {
       final inMemoryConversation = preferInMemory
           ? getInMemoryConversationForConversation(
@@ -400,6 +439,15 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
     final conversationId = currentConversationId;
     if (conversationId == null) return;
     if (isEphemeralConversation(conversationId, operationMode)) return;
+    if (await ConversationService.isConversationDeleted(
+      conversationId,
+      mode: operationMode,
+    )) {
+      return;
+    }
+    if (!_isConversationOperationCurrent(token)) {
+      return;
+    }
 
     setState(() {
       isLoadingMore = true;
@@ -441,6 +489,23 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
     final activeConversationId = currentConversationId;
     if (activeConversationId == null) return;
     if (isEphemeralConversation(activeConversationId, operationMode)) return;
+    if (await ConversationService.isConversationDeleted(
+      activeConversationId,
+      mode: operationMode,
+    )) {
+      await ConversationHistoryService.clearConversationThreadReferences(
+        activeConversationId,
+        mode: operationMode,
+      );
+      if (!_isConversationOperationCurrent(token)) {
+        return;
+      }
+      invalidateConversationLifecycle();
+      final transitionToken = captureConversationLifecycleToken();
+      onConversationMissing(operationMode, activeConversationId);
+      await _restoreLatestConversationOrReset(lifecycleToken: transitionToken);
+      return;
+    }
 
     try {
       final allConversations = await ConversationService.getAllConversations(
@@ -542,6 +607,15 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
     int? lifecycleToken,
   }) async {
     final token = lifecycleToken ?? captureConversationLifecycleToken();
+    if (await ConversationService.isConversationDeleted(
+      conversationId,
+      mode: mode,
+    )) {
+      return false;
+    }
+    if (!_isConversationOperationCurrent(token)) {
+      return false;
+    }
     try {
       final savedMessages =
           await ConversationHistoryService.getConversationMessages(
@@ -696,6 +770,16 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
     final snapshotMode = activeConversationModeValue;
     if (snapshotConversationId != null &&
         isEphemeralConversation(snapshotConversationId, snapshotMode)) {
+      return;
+    }
+    if (snapshotConversationId != null &&
+        await ConversationService.isConversationDeleted(
+          snapshotConversationId,
+          mode: snapshotMode,
+        )) {
+      return;
+    }
+    if (!_isConversationOperationCurrent(token)) {
       return;
     }
 

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -321,7 +321,11 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
       } catch (_) {
         conversation = null;
       }
-      final resolvedConversation = inMemoryConversation ?? conversation;
+      // Keep in-memory messages while taking the latest conversation metadata
+      // from storage. Drawer actions such as rename/pin update the stored
+      // conversation first; preferring the runtime copy here can rehydrate a
+      // stale title and later write it back during persistence.
+      final resolvedConversation = conversation ?? inMemoryConversation;
 
       if (resolvedConversation != null) {
         if (!_isConversationOperationCurrent(token)) {

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -596,7 +596,10 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
         updatedAt: updatedAt,
       );
 
-      await ConversationService.updateConversation(recovered);
+      await ConversationService.updateConversation(
+        recovered,
+        preserveUserMetadata: true,
+      );
       if (!_isConversationOperationCurrent(token)) {
         return false;
       }
@@ -816,7 +819,10 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           updatedAt: now,
         );
 
-        await ConversationService.updateConversation(updatedConversation);
+        await ConversationService.updateConversation(
+          updatedConversation,
+          preserveUserMetadata: true,
+        );
 
         await _persistDeepThinkingCardsForConversation(
           targetId,

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -743,10 +743,17 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
             );
     }
 
+    final latestConversation = await ConversationService.getConversationById(
+      conversationId,
+      mode: conversationMode,
+      includeArchived: true,
+    );
+    final snapshotBase = snapshotConversation?.mode == conversationMode
+        ? snapshotConversation
+        : snapshotConversation?.copyWith(mode: conversationMode);
     final baseConversation =
-        (snapshotConversation?.mode == conversationMode
-            ? snapshotConversation
-            : snapshotConversation?.copyWith(mode: conversationMode)) ??
+        latestConversation ??
+        snapshotBase ??
         ConversationModel(
           id: conversationId,
           mode: conversationMode,

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -774,7 +774,10 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       updatedAt: now,
     );
 
-    await ConversationService.updateConversation(updatedConversation);
+    await ConversationService.updateConversation(
+      updatedConversation,
+      preserveUserMetadata: true,
+    );
     if (persistMessages) {
       await ConversationHistoryService.saveConversationMessages(
         conversationId,

--- a/ui/lib/features/home/pages/chat_history/chat_history_page.dart
+++ b/ui/lib/features/home/pages/chat_history/chat_history_page.dart
@@ -125,17 +125,24 @@ class _ChatHistoryPageState extends State<ChatHistoryPage> {
     }
 
     final originalIndex = _conversations.indexWhere(
-      (item) => item.id == conversation.id,
+      (item) => item.threadKey == conversation.threadKey,
     );
     if (originalIndex < 0) {
       return;
     }
 
-    setState(() {
-      _busyKeys.add(conversation.threadKey);
-      _conversations = List<ConversationModel>.from(_conversations)
-        ..removeAt(originalIndex);
-    });
+    await ConversationService.markConversationDeleted(
+      conversation.id,
+      mode: conversation.mode,
+    );
+
+    if (mounted) {
+      setState(() {
+        _busyKeys.add(conversation.threadKey);
+        _conversations = List<ConversationModel>.from(_conversations)
+          ..removeAt(originalIndex);
+      });
+    }
 
     final deleted = await ConversationService.deleteConversation(
       conversation.id,

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -725,7 +725,10 @@ class _ChatBotSheetState extends State<ChatBotSheet>
           updatedAt: now,
         );
 
-        await ConversationService.updateConversation(updatedConversation);
+        await ConversationService.updateConversation(
+          updatedConversation,
+          preserveUserMetadata: true,
+        );
         _currentConversation = updatedConversation;
         for (final message in _messages.where((item) {
           final cardData = item.cardData;

--- a/ui/lib/features/home/widgets/home_drawer.dart
+++ b/ui/lib/features/home/widgets/home_drawer.dart
@@ -88,6 +88,8 @@ class HomeDrawer extends ConsumerStatefulWidget {
     this.newConversationMode = ConversationMode.normal,
     this.embedded = false,
     this.closeOnNavigate = true,
+    this.activeConversationId,
+    this.activeConversationMode,
     this.onThreadTargetSelected,
   });
 
@@ -95,6 +97,8 @@ class HomeDrawer extends ConsumerStatefulWidget {
   final ConversationMode newConversationMode;
   final bool embedded;
   final bool closeOnNavigate;
+  final int? activeConversationId;
+  final ConversationMode? activeConversationMode;
   final ValueChanged<ConversationThreadTarget>? onThreadTargetSelected;
 
   @override

--- a/ui/lib/features/home/widgets/home_drawer_actions.dart
+++ b/ui/lib/features/home/widgets/home_drawer_actions.dart
@@ -190,17 +190,24 @@ extension _HomeDrawerActions on HomeDrawerState {
     }
 
     final originalIndex = _allConversations.indexWhere(
-      (item) => item.id == conversation.id,
+      (item) => item.threadKey == conversation.threadKey,
     );
     if (originalIndex < 0) {
       return;
     }
 
-    setState(() {
-      _busyConversationKeys.add(conversation.threadKey);
-      _removeConversationFromState(conversation);
-    });
-    _persistCurrentConversationSnapshot();
+    await ConversationService.markConversationDeleted(
+      conversation.id,
+      mode: conversation.mode,
+    );
+
+    if (mounted) {
+      setState(() {
+        _busyConversationKeys.add(conversation.threadKey);
+        _removeConversationFromState(conversation);
+      });
+      _persistCurrentConversationSnapshot();
+    }
 
     final deleted = await ConversationService.deleteConversation(
       conversation.id,

--- a/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
+++ b/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
@@ -663,6 +663,28 @@ extension _HomeDrawerConversationList on HomeDrawerState {
         : palette.accentPrimary.withValues(alpha: 0.045);
   }
 
+  bool _isActiveConversation(ConversationModel conversation) {
+    final activeConversationId = widget.activeConversationId;
+    final activeConversationMode = widget.activeConversationMode;
+    return activeConversationId != null &&
+        conversation.id == activeConversationId &&
+        (activeConversationMode == null ||
+            conversation.mode == activeConversationMode);
+  }
+
+  Color get _activeConversationBackgroundColor {
+    final palette = context.omniPalette;
+    return context.isDarkTheme
+        ? Color.lerp(palette.surfaceSecondary, palette.accentPrimary, 0.22)!
+        : palette.accentPrimary.withValues(alpha: 0.1);
+  }
+
+  Color get _activeConversationBorderColor {
+    return context.omniPalette.accentPrimary.withValues(
+      alpha: context.isDarkTheme ? 0.38 : 0.24,
+    );
+  }
+
   Widget _buildScheduledConversationGroup(
     _ScheduledConversationGroup group, {
     required bool showDivider,
@@ -725,6 +747,8 @@ extension _HomeDrawerConversationList on HomeDrawerState {
     final childCount = group.children.length;
     final countText = childCount > 0 ? '$childCount' : '${group.taskCount}';
     final isEditing = _editingThreadKey == group.parent.threadKey;
+    final isActive = _isActiveConversation(group.parent);
+    final itemRadius = BorderRadius.circular(8);
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -732,78 +756,114 @@ extension _HomeDrawerConversationList on HomeDrawerState {
             ? null
             : () => _openConversationFromDrawer(group.parent),
         onLongPress: isEditing ? null : () => _startEditingTitle(group.parent),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: itemRadius,
         splashColor: palette.accentPrimary.withValues(alpha: 0.08),
         highlightColor: Colors.transparent,
-        child: Stack(
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(0, 8, 2, 8),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  SizedBox(
-                    width: _kScheduledParentToggleHitWidth,
-                    height: 24,
-                    child: Align(
-                      alignment: Alignment.centerRight,
-                      child: SizedBox(
-                        width: _kScheduledParentToggleIconSlotWidth,
+        child: Semantics(
+          selected: isActive,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            curve: Curves.easeOutCubic,
+            decoration: BoxDecoration(
+              color: isActive
+                  ? _activeConversationBackgroundColor
+                  : Colors.transparent,
+              borderRadius: itemRadius,
+              border: Border.all(
+                color: isActive
+                    ? _activeConversationBorderColor
+                    : Colors.transparent,
+              ),
+            ),
+            child: Stack(
+              children: [
+                Positioned(
+                  left: 0,
+                  top: 8,
+                  bottom: 8,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 160),
+                    curve: Curves.easeOutCubic,
+                    width: 3,
+                    decoration: BoxDecoration(
+                      color: isActive
+                          ? palette.accentPrimary
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(0, 8, 2, 8),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        width: _kScheduledParentToggleHitWidth,
                         height: 24,
-                        child: Center(
-                          child: AnimatedRotation(
-                            turns: expanded ? 0 : -0.25,
-                            duration: HomeDrawerState._sectionToggleDuration,
-                            curve: Curves.easeInOutCubicEmphasized,
-                            child: SvgPicture.asset(
-                              'assets/common/chevron-down.svg',
-                              width: 16,
-                              height: 16,
-                              colorFilter: ColorFilter.mode(
-                                palette.textTertiary,
-                                BlendMode.srcIn,
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: SizedBox(
+                            width: _kScheduledParentToggleIconSlotWidth,
+                            height: 24,
+                            child: Center(
+                              child: AnimatedRotation(
+                                turns: expanded ? 0 : -0.25,
+                                duration:
+                                    HomeDrawerState._sectionToggleDuration,
+                                curve: Curves.easeInOutCubicEmphasized,
+                                child: SvgPicture.asset(
+                                  'assets/common/chevron-down.svg',
+                                  width: 16,
+                                  height: 16,
+                                  colorFilter: ColorFilter.mode(
+                                    palette.textTertiary,
+                                    BlendMode.srcIn,
+                                  ),
+                                ),
                               ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                  ),
-                  const SizedBox(width: 2),
-                  Expanded(
-                    child: _buildEditableConversationTitle(
-                      title: title,
-                      isEditing: isEditing,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    countText,
-                    style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: AppFontEffectScope.resolveNonChatWeight(
-                        context,
-                        FontWeight.w500,
+                      const SizedBox(width: 2),
+                      Expanded(
+                        child: _buildEditableConversationTitle(
+                          title: title,
+                          isEditing: isEditing,
+                          fontWeight: FontWeight.w600,
+                          isActive: isActive,
+                        ),
                       ),
-                      color: palette.textTertiary,
-                      fontFamily: 'PingFang SC',
-                    ),
+                      const SizedBox(width: 8),
+                      Text(
+                        countText,
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: AppFontEffectScope.resolveNonChatWeight(
+                            context,
+                            FontWeight.w500,
+                          ),
+                          color: palette.textTertiary,
+                          fontFamily: 'PingFang SC',
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+                Positioned(
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  width: _kScheduledParentToggleHitWidth,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onToggle,
+                  ),
+                ),
+              ],
             ),
-            Positioned(
-              left: 0,
-              top: 0,
-              bottom: 0,
-              width: _kScheduledParentToggleHitWidth,
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: onToggle,
-              ),
-            ),
-          ],
+          ),
         ),
       ),
     );
@@ -1020,6 +1080,8 @@ extension _HomeDrawerConversationList on HomeDrawerState {
     final title = _resolveConversationTitle(conversation);
     final showArchivedBadge = _isSearchActive && conversation.isArchived;
     final isEditing = _editingThreadKey == conversation.threadKey;
+    final isActive = _isActiveConversation(conversation);
+    final itemRadius = BorderRadius.circular(10);
 
     return ConversationSlidable(
       itemKey: conversation.threadKey,
@@ -1044,51 +1106,92 @@ extension _HomeDrawerConversationList on HomeDrawerState {
               onLongPress: isEditing
                   ? null
                   : () => _startEditingTitle(conversation),
-              borderRadius: BorderRadius.circular(14),
+              borderRadius: itemRadius,
               splashColor: context.omniPalette.accentPrimary.withValues(
                 alpha: 0.08,
               ),
               highlightColor: Colors.transparent,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(4, 9, 2, 9),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: _buildEditableConversationTitle(
-                            title: title,
-                            isEditing: isEditing,
+              child: Semantics(
+                selected: isActive,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 160),
+                  curve: Curves.easeOutCubic,
+                  decoration: BoxDecoration(
+                    color: isActive
+                        ? _activeConversationBackgroundColor
+                        : Colors.transparent,
+                    borderRadius: itemRadius,
+                    border: Border.all(
+                      color: isActive
+                          ? _activeConversationBorderColor
+                          : Colors.transparent,
+                    ),
+                  ),
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        left: 0,
+                        top: 9,
+                        bottom: 9,
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 160),
+                          curve: Curves.easeOutCubic,
+                          width: 3,
+                          decoration: BoxDecoration(
+                            color: isActive
+                                ? context.omniPalette.accentPrimary
+                                : Colors.transparent,
+                            borderRadius: BorderRadius.circular(999),
                           ),
                         ),
-                        if (showArchivedBadge) ...[
-                          const SizedBox(width: 10),
-                          _buildArchivedBadge(),
-                        ],
-                      ],
-                    ),
-                    _buildConversationImagePreviewStrip(conversation),
-                    if (_isSearchActive && result.matchedPreview != null) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        result.matchedPreview!,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: AppFontEffectScope.resolveNonChatWeight(
-                            context,
-                            FontWeight.w400,
-                          ),
-                          color: _drawerSecondaryTextColor,
-                          height: 1.4,
-                          fontFamily: 'PingFang SC',
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(8, 9, 6, 9),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Expanded(
+                                  child: _buildEditableConversationTitle(
+                                    title: title,
+                                    isEditing: isEditing,
+                                    isActive: isActive,
+                                  ),
+                                ),
+                                if (showArchivedBadge) ...[
+                                  const SizedBox(width: 10),
+                                  _buildArchivedBadge(),
+                                ],
+                              ],
+                            ),
+                            _buildConversationImagePreviewStrip(conversation),
+                            if (_isSearchActive &&
+                                result.matchedPreview != null) ...[
+                              const SizedBox(height: 4),
+                              Text(
+                                result.matchedPreview!,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: AppFontEffectScope
+                                      .resolveNonChatWeight(
+                                    context,
+                                    FontWeight.w400,
+                                  ),
+                                  color: _drawerSecondaryTextColor,
+                                  height: 1.4,
+                                  fontFamily: 'PingFang SC',
+                                ),
+                              ),
+                            ],
+                          ],
                         ),
                       ),
                     ],
-                  ],
+                  ),
                 ),
               ),
             ),
@@ -1103,7 +1206,11 @@ extension _HomeDrawerConversationList on HomeDrawerState {
     required String title,
     required bool isEditing,
     FontWeight fontWeight = FontWeight.w500,
+    bool isActive = false,
   }) {
+    final titleColor = isActive
+        ? context.omniPalette.accentPrimary
+        : _drawerTextColor;
     if (isEditing) {
       return TextField(
         controller: _titleEditingController,
@@ -1117,7 +1224,7 @@ extension _HomeDrawerConversationList on HomeDrawerState {
             context,
             fontWeight,
           ),
-          color: _drawerTextColor,
+          color: titleColor,
           height: 1.35,
           fontFamily: 'PingFang SC',
         ),
@@ -1146,7 +1253,7 @@ extension _HomeDrawerConversationList on HomeDrawerState {
           context,
           fontWeight,
         ),
-        color: _drawerTextColor,
+        color: titleColor,
         height: 1.35,
         fontFamily: 'PingFang SC',
       ),

--- a/ui/lib/features/home/widgets/home_drawer_image_previews.dart
+++ b/ui/lib/features/home/widgets/home_drawer_image_previews.dart
@@ -114,7 +114,7 @@ extension _HomeDrawerImagePreviews on HomeDrawerState {
       if (rawConversations is! List) {
         return;
       }
-      final conversations = rawConversations
+      final restoredConversations = rawConversations
           .whereType<Map>()
           .map(
             (item) => ConversationModel.fromJson(
@@ -122,6 +122,28 @@ extension _HomeDrawerImagePreviews on HomeDrawerState {
             ),
           )
           .toList(growable: false);
+      final deletedKeys = (StorageService.getStringList(
+                ConversationService.deletedConversationKeysKey,
+                defaultValue: const <String>[],
+              ) ??
+              const <String>[])
+          .map((key) => key.trim())
+          .where((key) => key.isNotEmpty)
+          .toSet();
+      final hiddenCodexIds = (StorageService.getStringList(
+                ConversationService.hiddenCodexConversationIdsKey,
+                defaultValue: const <String>[],
+              ) ??
+              const <String>[])
+          .map((id) => id.trim())
+          .map(int.tryParse)
+          .whereType<int>()
+          .toSet();
+      final conversations = ConversationService.filterDeletedConversationsSync(
+        restoredConversations,
+        deletedKeys: deletedKeys,
+        hiddenCodexConversationIds: hiddenCodexIds,
+      );
       if (conversations.isEmpty) {
         return;
       }

--- a/ui/lib/services/conversation_service.dart
+++ b/ui/lib/services/conversation_service.dart
@@ -128,6 +128,23 @@ class ConversationService {
     }
   }
 
+  static Future<ConversationModel?> getConversationById(
+    int conversationId, {
+    ConversationMode? mode,
+    bool includeArchived = false,
+  }) async {
+    final conversations = await getAllConversations(
+      includeArchived: includeArchived,
+    );
+    for (final conversation in conversations) {
+      if (conversation.id == conversationId &&
+          (mode == null || conversation.mode == mode)) {
+        return conversation;
+      }
+    }
+    return null;
+  }
+
   static Future<bool> updateConversationPromptTokenThreshold({
     required int conversationId,
     required int promptTokenThreshold,
@@ -283,15 +300,10 @@ class ConversationService {
     int conversationId, {
     bool includeArchived = false,
   }) async {
-    final conversations = await getAllConversations(
+    return getConversationById(
+      conversationId,
       includeArchived: includeArchived,
     );
-    for (final conversation in conversations) {
-      if (conversation.id == conversationId) {
-        return conversation;
-      }
-    }
-    return null;
   }
 
   static Future<List<ConversationModel>> _filterHiddenCodexConversations(
@@ -352,6 +364,19 @@ class ConversationService {
           conversationId: conversationId,
           name: newTitle,
         );
+        final localConversation = await getConversationById(
+          conversationId,
+          mode: mode,
+          includeArchived: true,
+        );
+        if (localConversation != null) {
+          final localUpdated = await updateConversation(
+            localConversation.copyWith(title: newTitle),
+          );
+          if (!localUpdated) {
+            debugPrint('同步 Codex 本地对话标题失败');
+          }
+        }
         return true;
       } catch (e) {
         debugPrint('更新 Codex 对话标题失败: $e');

--- a/ui/lib/services/conversation_service.dart
+++ b/ui/lib/services/conversation_service.dart
@@ -112,11 +112,18 @@ class ConversationService {
     }
   }
 
-  static Future<bool> updateConversation(ConversationModel conversation) async {
+  static Future<bool> updateConversation(
+    ConversationModel conversation, {
+    bool preserveUserMetadata = false,
+  }) async {
     try {
       final result = await _assistCore.invokeMethod<dynamic>(
         'updateConversation',
-        {'conversation': conversation.toJson()},
+        {
+          'conversation': conversation.toJson(),
+          if (preserveUserMetadata)
+            'preserveUserMetadata': preserveUserMetadata,
+        },
       );
       return result == 'SUCCESS';
     } on PlatformException catch (e) {

--- a/ui/lib/services/conversation_service.dart
+++ b/ui/lib/services/conversation_service.dart
@@ -10,8 +10,10 @@ class ConversationService {
   static const MethodChannel _assistCore = MethodChannel(
     'cn.com.omnimind.bot/AssistCoreEvent',
   );
-  static const String _hiddenCodexConversationIdsKey =
+  static const String hiddenCodexConversationIdsKey =
       'hidden_codex_conversation_ids';
+  static const String deletedConversationKeysKey =
+      'deleted_conversation_keys_v1';
 
   static List<ConversationModel> _normalizeConversations(List<dynamic> raw) {
     final conversations = raw
@@ -37,15 +39,17 @@ class ConversationService {
   static Future<List<ConversationModel>> getAllConversations({
     bool includeArchived = false,
     bool archivedOnly = false,
+    bool includeDeleted = false,
   }) async {
     try {
       final result = await _assistCore.invokeMethod<List<dynamic>>(
         'getConversations',
       );
       if (result == null) return [];
-      final conversations = await _filterHiddenCodexConversations(
-        _normalizeConversations(result),
-      );
+      final normalizedConversations = _normalizeConversations(result);
+      final conversations = includeDeleted
+          ? normalizedConversations
+          : await _filterDeletedConversations(normalizedConversations);
       if (archivedOnly) {
         return conversations.where((item) => item.isArchived).toList();
       }
@@ -139,9 +143,11 @@ class ConversationService {
     int conversationId, {
     ConversationMode? mode,
     bool includeArchived = false,
+    bool includeDeleted = false,
   }) async {
     final conversations = await getAllConversations(
       includeArchived: includeArchived,
+      includeDeleted: includeDeleted,
     );
     for (final conversation in conversations) {
       if (conversation.id == conversationId &&
@@ -150,6 +156,65 @@ class ConversationService {
       }
     }
     return null;
+  }
+
+  static Future<void> markConversationDeleted(
+    int conversationId, {
+    required ConversationMode mode,
+  }) async {
+    if (conversationId <= 0) {
+      return;
+    }
+    await _addDeletedConversationKey(_conversationKey(conversationId, mode));
+    if (mode == ConversationMode.codex) {
+      await _markCodexConversationHidden(conversationId);
+    }
+  }
+
+  static Future<void> unmarkConversationDeleted(
+    int conversationId, {
+    required ConversationMode mode,
+  }) async {
+    if (conversationId <= 0) {
+      return;
+    }
+    await _removeDeletedConversationKey(_conversationKey(conversationId, mode));
+    if (mode == ConversationMode.codex) {
+      await _unmarkCodexConversationHidden(conversationId);
+    }
+  }
+
+  static Future<bool> isConversationDeleted(
+    int conversationId, {
+    required ConversationMode mode,
+  }) async {
+    if (conversationId <= 0) {
+      return false;
+    }
+    final deletedKeys = await _getDeletedConversationKeys();
+    return deletedKeys.contains(_conversationKey(conversationId, mode));
+  }
+
+  static List<ConversationModel> filterDeletedConversationsSync(
+    List<ConversationModel> conversations, {
+    required Set<String> deletedKeys,
+    Set<int> hiddenCodexConversationIds = const <int>{},
+  }) {
+    if (conversations.isEmpty ||
+        (deletedKeys.isEmpty && hiddenCodexConversationIds.isEmpty)) {
+      return conversations;
+    }
+    return conversations
+        .where((conversation) {
+          if (conversation.mode == ConversationMode.codex &&
+              hiddenCodexConversationIds.contains(conversation.id)) {
+            return false;
+          }
+          return !deletedKeys.contains(
+            _conversationKey(conversation.id, conversation.mode),
+          );
+        })
+        .toList(growable: false);
   }
 
   static Future<bool> updateConversationPromptTokenThreshold({
@@ -176,6 +241,8 @@ class ConversationService {
     int conversationId, {
     ConversationMode? mode,
   }) async {
+    final resolvedMode = mode ?? ConversationMode.normal;
+    await markConversationDeleted(conversationId, mode: resolvedMode);
     if (mode == ConversationMode.codex) {
       final appServerArchived = await _setCodexThreadArchivedBestEffort(
         conversationId: conversationId,
@@ -183,7 +250,9 @@ class ConversationService {
       );
       final conversation = await _getConversationById(
         conversationId,
+        mode: ConversationMode.codex,
         includeArchived: true,
+        includeDeleted: true,
       );
       var localArchived = conversation == null;
       if (conversation != null) {
@@ -192,9 +261,9 @@ class ConversationService {
             await updateConversation(conversation.copyWith(isArchived: true));
       }
       if (!appServerArchived && !localArchived) {
+        await unmarkConversationDeleted(conversationId, mode: resolvedMode);
         return false;
       }
-      await _markCodexConversationHidden(conversationId);
       await ConversationHistoryService.clearConversationThreadReferences(
         conversationId,
         mode: ConversationMode.codex,
@@ -214,6 +283,7 @@ class ConversationService {
       );
       final deleted = result == 'SUCCESS';
       if (!deleted) {
+        await unmarkConversationDeleted(conversationId, mode: resolvedMode);
         return false;
       }
       await ConversationHistoryService.clearConversationMessages(
@@ -230,9 +300,11 @@ class ConversationService {
       return true;
     } on PlatformException catch (e) {
       debugPrint('删除对话失败: ${e.message}');
+      await unmarkConversationDeleted(conversationId, mode: resolvedMode);
       return false;
     } catch (e) {
       debugPrint('删除对话失败: $e');
+      await unmarkConversationDeleted(conversationId, mode: resolvedMode);
       return false;
     }
   }
@@ -305,37 +377,80 @@ class ConversationService {
 
   static Future<ConversationModel?> _getConversationById(
     int conversationId, {
+    ConversationMode? mode,
     bool includeArchived = false,
+    bool includeDeleted = false,
   }) async {
     return getConversationById(
       conversationId,
+      mode: mode,
       includeArchived: includeArchived,
+      includeDeleted: includeDeleted,
     );
   }
 
-  static Future<List<ConversationModel>> _filterHiddenCodexConversations(
+  static Future<List<ConversationModel>> _filterDeletedConversations(
     List<ConversationModel> conversations,
   ) async {
     if (conversations.isEmpty) {
       return conversations;
     }
-    final hiddenIds = await _getHiddenCodexConversationIds();
-    if (hiddenIds.isEmpty) {
+    final hiddenCodexIds = await _getHiddenCodexConversationIds();
+    final deletedKeys = await _getDeletedConversationKeys();
+    if (hiddenCodexIds.isEmpty && deletedKeys.isEmpty) {
       return conversations;
     }
-    return conversations
-        .where(
-          (conversation) =>
-              conversation.mode != ConversationMode.codex ||
-              !hiddenIds.contains(conversation.id),
-        )
-        .toList();
+    return filterDeletedConversationsSync(
+      conversations,
+      deletedKeys: deletedKeys,
+      hiddenCodexConversationIds: hiddenCodexIds,
+    );
+  }
+
+  static Future<Set<String>> _getDeletedConversationKeys() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return (prefs.getStringList(deletedConversationKeysKey) ??
+              const <String>[])
+          .map((key) => key.trim())
+          .where((key) => key.isNotEmpty)
+          .toSet();
+    } catch (e) {
+      debugPrint('[ConversationService] 读取已删除会话标记失败: $e');
+      return const <String>{};
+    }
+  }
+
+  static Future<void> _addDeletedConversationKey(String key) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final deletedKeys = await _getDeletedConversationKeys();
+      if (!deletedKeys.add(key)) {
+        return;
+      }
+      await prefs.setStringList(deletedConversationKeysKey, _sorted(deletedKeys));
+    } catch (e) {
+      debugPrint('[ConversationService] 保存已删除会话标记失败: $e');
+    }
+  }
+
+  static Future<void> _removeDeletedConversationKey(String key) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final deletedKeys = await _getDeletedConversationKeys();
+      if (!deletedKeys.remove(key)) {
+        return;
+      }
+      await prefs.setStringList(deletedConversationKeysKey, _sorted(deletedKeys));
+    } catch (e) {
+      debugPrint('[ConversationService] 移除已删除会话标记失败: $e');
+    }
   }
 
   static Future<Set<int>> _getHiddenCodexConversationIds() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      return (prefs.getStringList(_hiddenCodexConversationIdsKey) ??
+      return (prefs.getStringList(hiddenCodexConversationIdsKey) ??
               const <String>[])
           .map(int.tryParse)
           .whereType<int>()
@@ -353,11 +468,37 @@ class ConversationService {
       if (!hiddenIds.add(conversationId)) {
         return;
       }
-      final encoded = hiddenIds.map((id) => id.toString()).toList()..sort();
-      await prefs.setStringList(_hiddenCodexConversationIdsKey, encoded);
+      await prefs.setStringList(
+        hiddenCodexConversationIdsKey,
+        _sorted(hiddenIds.map((id) => id.toString())),
+      );
     } catch (e) {
       debugPrint('[ConversationService] 保存 Codex 隐藏会话失败: $e');
     }
+  }
+
+  static Future<void> _unmarkCodexConversationHidden(int conversationId) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final hiddenIds = await _getHiddenCodexConversationIds();
+      if (!hiddenIds.remove(conversationId)) {
+        return;
+      }
+      await prefs.setStringList(
+        hiddenCodexConversationIdsKey,
+        _sorted(hiddenIds.map((id) => id.toString())),
+      );
+    } catch (e) {
+      debugPrint('[ConversationService] 移除 Codex 隐藏会话失败: $e');
+    }
+  }
+
+  static String _conversationKey(int conversationId, ConversationMode mode) {
+    return '${mode.storageValue}:$conversationId';
+  }
+
+  static List<String> _sorted(Iterable<String> values) {
+    return values.toList()..sort();
   }
 
   static Future<bool> updateConversationTitle({

--- a/ui/lib/widgets/side_bar_drawer.dart
+++ b/ui/lib/widgets/side_bar_drawer.dart
@@ -460,7 +460,7 @@ class _SidebarDrawerState extends State<SidebarDrawer> {
     });
   }
 
-  void _deleteConversation(ConversationModel conversation) async {
+  Future<void> _deleteConversation(ConversationModel conversation) async {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) {
@@ -491,15 +491,36 @@ class _SidebarDrawerState extends State<SidebarDrawer> {
     );
 
     if (confirmed == true) {
-      final success = await ConversationService.deleteConversation(
+      final originalIndex = conversations.indexWhere(
+        (c) => c.threadKey == conversation.threadKey,
+      );
+      await ConversationService.markConversationDeleted(
         conversation.id,
         mode: conversation.mode,
       );
-      if (success) {
+      if (mounted) {
         setState(() {
           conversations.removeWhere(
             (c) => c.threadKey == conversation.threadKey,
           );
+        });
+      }
+
+      final success = await ConversationService.deleteConversation(
+        conversation.id,
+        mode: conversation.mode,
+      );
+      if (!mounted) {
+        return;
+      }
+      if (!success) {
+        setState(() {
+          final restoredIndex = originalIndex >= 0 &&
+                  originalIndex <= conversations.length
+              ? originalIndex
+              : conversations.length;
+          conversations = List<ConversationModel>.from(conversations)
+            ..insert(restoredIndex, conversation);
         });
       }
     }

--- a/ui/test/services/conversation_service_test.dart
+++ b/ui/test/services/conversation_service_test.dart
@@ -16,12 +16,14 @@ void main() {
   late List<Map<String, dynamic>> nativeConversations;
   late List<MethodCall> codexCalls;
   late bool codexArchiveShouldThrow;
+  late bool nativeDeleteShouldFail;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     nativeConversations = <Map<String, dynamic>>[];
     codexCalls = <MethodCall>[];
     codexArchiveShouldThrow = false;
+    nativeDeleteShouldFail = false;
     messenger.setMockMethodCallHandler(channel, (call) async {
       final args = Map<String, dynamic>.from(
         (call.arguments as Map?) ?? const {},
@@ -85,6 +87,9 @@ void main() {
           }
           return 'SUCCESS';
         case 'deleteConversation':
+          if (nativeDeleteShouldFail) {
+            return 'FAILURE';
+          }
           final conversationId = (args['conversationId'] as num?)?.toInt();
           nativeConversations.removeWhere(
             (item) => item['id'] == conversationId,
@@ -295,8 +300,90 @@ void main() {
       expect(remaining, hasLength(1));
       expect(remaining.single.id, 1);
       expect(remaining.single.mode, ConversationMode.normal);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getStringList(ConversationService.deletedConversationKeysKey),
+        contains('${ConversationMode.openclaw.storageValue}:2'),
+      );
     },
   );
+
+  test('filters conversations marked as deleted', () async {
+    nativeConversations = <Map<String, dynamic>>[
+      {
+        'id': 5,
+        'title': 'normal thread',
+        'mode': ConversationMode.normal.storageValue,
+        'summary': null,
+        'status': 0,
+        'lastMessage': null,
+        'messageCount': 0,
+        'createdAt': 1,
+        'updatedAt': 1,
+      },
+      {
+        'id': 6,
+        'title': 'chat only thread',
+        'mode': ConversationMode.chatOnly.storageValue,
+        'summary': null,
+        'status': 0,
+        'lastMessage': null,
+        'messageCount': 0,
+        'createdAt': 2,
+        'updatedAt': 2,
+      },
+    ];
+
+    await ConversationService.markConversationDeleted(
+      5,
+      mode: ConversationMode.normal,
+    );
+
+    final visible = await ConversationService.getAllConversations(
+      includeArchived: true,
+    );
+    expect(visible.map((conversation) => conversation.id), [6]);
+
+    final all = await ConversationService.getAllConversations(
+      includeArchived: true,
+      includeDeleted: true,
+    );
+    expect(all.map((conversation) => conversation.id), [6, 5]);
+  });
+
+  test('failed native delete removes deleted marker', () async {
+    nativeConversations = <Map<String, dynamic>>[
+      {
+        'id': 7,
+        'title': 'normal thread',
+        'mode': ConversationMode.normal.storageValue,
+        'summary': null,
+        'status': 0,
+        'lastMessage': null,
+        'messageCount': 0,
+        'createdAt': 1,
+        'updatedAt': 1,
+      },
+    ];
+    nativeDeleteShouldFail = true;
+
+    final deleted = await ConversationService.deleteConversation(
+      7,
+      mode: ConversationMode.normal,
+    );
+
+    expect(deleted, isFalse);
+    expect(
+      await ConversationService.getAllConversations(includeArchived: true),
+      hasLength(1),
+    );
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      prefs.getStringList(ConversationService.deletedConversationKeysKey),
+      isNot(contains('${ConversationMode.normal.storageValue}:7')),
+    );
+  });
 
   test('creates conversations with chat_only mode', () async {
     final conversationId = await ConversationService.createConversation(


### PR DESCRIPTION
## 变更说明

- 修复继续对话时运行时旧会话对象覆盖数据库元数据的问题，避免已重命名标题、置顶、归档等状态被回退。
- 会话保存/恢复只更新摘要、最后消息、消息数、更新时间等运行时字段；标题、置顶、归档、父会话等用户管理字段保留数据库最新值。
- 聊天页加载和同步 runtime 时，消息可继续使用内存缓存，但会话元数据优先使用数据库最新记录，避免抽屉操作后被旧内存对象反向覆盖。
- 修复 Codex 本地线程同步时服务端旧线程名覆盖用户手动重命名的问题；只有显式重命名或本地仍是默认标题时才同步标题。
- 给 HomeDrawer 增加当前会话 id/mode 输入，并在普通列表、置顶列表、搜索结果、日期分组和计划任务父会话中高亮当前激活会话。

## 已验证场景

- 仅重命名会话后继续对话，标题保持不变。
- 重命名后再置顶，继续对话后标题和置顶状态都保持不变。
- 当前会话在会话列表中能显示高亮状态。

## 验证

- 已运行 `git diff --check`。
- 已通过 fork 上的 GitHub Actions debug 包进行本地安装验证。
- 本机 PATH 中没有 `dart`/`flutter` 命令，因此未在本地运行 `dart format` 或 `flutter analyze`。