### PR TITLE
fix(ui): 修复Chat/Agent模式下键盘弹出时模型选择器错位

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -137,6 +137,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   final GlobalKey<HomeDrawerState> _drawerKey = GlobalKey<HomeDrawerState>();
   final GlobalKey _browserOverlayKey = GlobalKey();
   final GlobalKey _slashCommandStripKey = GlobalKey();
+  OverlayEntry? _conversationModelSelectorOverlayEntry;
 
   // ===================== State =====================
   bool _isPopupVisible = false;

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -593,6 +593,8 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
   @override
   void dispose() {
     unawaited(_clearVisibleChatConversation());
+    _conversationModelSelectorOverlayEntry?.remove();
+    _conversationModelSelectorOverlayEntry = null;
     WidgetsBinding.instance.removeObserver(this);
     unawaited(_runtimeCoordinator.flushAllPendingPersistence());
     _conversationListChangedSubscription?.cancel();

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -429,6 +429,63 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     );
   }
 
+  void _removeConversationModelSelectorOverlay() {
+    _suppressNextOutsideTapKeyboardHide = false;
+    final entry = _conversationModelSelectorOverlayEntry;
+    if (entry == null) {
+      return;
+    }
+    _conversationModelSelectorOverlayEntry = null;
+    entry.remove();
+  }
+
+  void _showConversationModelSelectorOverlay({
+    required Rect anchorRect,
+    required double popupWidth,
+    required double popupMaxHeight,
+  }) {
+    _removeConversationModelSelectorOverlay();
+    final overlay = Overlay.of(context, rootOverlay: true);
+    _conversationModelSelectorOverlayEntry = OverlayEntry(
+      builder: (overlayContext) {
+        return Material(
+          color: Colors.transparent,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: _removeConversationModelSelectorOverlay,
+                  child: const SizedBox.expand(),
+                ),
+              ),
+              GlassPopupAnchorLayout(
+                anchor: anchorRect,
+                child: _ConversationModelSelectorContent(
+                  width: popupWidth,
+                  maxHeight: popupMaxHeight,
+                  profiles: _modelProviderProfiles,
+                  providerModelsByProfileId: _modelOptionsByProfileId,
+                  currentSelection: _activeDispatchSceneSelection,
+                  onSelect: (selected) {
+                    _removeConversationModelSelectorOverlay();
+                    unawaited(
+                      _applyDispatchSceneModelSelection(
+                        providerProfileId: selected.providerProfileId,
+                        modelId: selected.modelId,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    overlay.insert(_conversationModelSelectorOverlayEntry!);
+  }
+
   @override
   Future<void> _openConversationModelSelector(
     BuildContext anchorContext,
@@ -448,10 +505,13 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     if (!_hasSelectableNormalChatModels) {
       return;
     }
-    _inputFocusNode.unfocus();
+    _suppressNextOutsideTapKeyboardHide = true;
+    // Keep the active input focus so the composer does not drop before the
+    // popup is anchored from the current button position.
     final anchorBox = anchorContext.findRenderObject() as RenderBox?;
     final anchorRect = glassPopupAnchorFromContext(anchorContext);
     if (anchorBox == null || !anchorBox.hasSize || anchorRect == null) {
+      _suppressNextOutsideTapKeyboardHide = false;
       return;
     }
     final popupWidth = math
@@ -459,23 +519,10 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
         .clamp(260.0, 320.0)
         .toDouble();
     const popupMaxHeight = 360.0;
-    final selected = await showGlassPopup<_ChatModelOverrideSelection>(
-      context: context,
-      anchor: anchorRect,
-      child: _ConversationModelSelectorContent(
-        width: popupWidth,
-        maxHeight: popupMaxHeight,
-        profiles: _modelProviderProfiles,
-        providerModelsByProfileId: _modelOptionsByProfileId,
-        currentSelection: _activeDispatchSceneSelection,
-      ),
-    );
-    if (selected == null) {
-      return;
-    }
-    await _applyDispatchSceneModelSelection(
-      providerProfileId: selected.providerProfileId,
-      modelId: selected.modelId,
+    _showConversationModelSelectorOverlay(
+      anchorRect: anchorRect,
+      popupWidth: popupWidth,
+      popupMaxHeight: popupMaxHeight,
     );
   }
 
@@ -1051,6 +1098,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
     required this.profiles,
     required this.providerModelsByProfileId,
     required this.currentSelection,
+    this.onSelect,
   });
 
   final double width;
@@ -1058,6 +1106,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
   final List<ModelProviderProfileSummary> profiles;
   final Map<String, List<ProviderModelOption>> providerModelsByProfileId;
   final _ChatModelOverrideSelection? currentSelection;
+  final ValueChanged<_ChatModelOverrideSelection>? onSelect;
 
   @override
   State<_ConversationModelSelectorContent> createState() =>
@@ -1451,12 +1500,16 @@ class _ConversationModelSelectorContentState
         modelId: model.id,
         child: InkWell(
           onTap: () {
-            Navigator.of(context).pop(
-              _ChatModelOverrideSelection(
-                providerProfileId: profile.id,
-                modelId: model.id,
-              ),
+            final selection = _ChatModelOverrideSelection(
+              providerProfileId: profile.id,
+              modelId: model.id,
             );
+            final onSelect = widget.onSelect;
+            if (onSelect != null) {
+              onSelect(selection);
+              return;
+            }
+            Navigator.of(context).pop(selection);
           },
           borderRadius: BorderRadius.circular(12),
           child: Container(

--- a/ui/lib/features/home/pages/chat/chat_page_openclaw.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_openclaw.dart
@@ -169,6 +169,7 @@ mixin _ChatPageOpenClawMixin on _ChatPageStateBase {
       return;
     }
     if (insideInputArea || insideInputAuxiliarySurface) {
+      _suppressNextOutsideTapKeyboardHide = false;
       return;
     }
     if (_openClawPanelExpanded) {

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1303,6 +1303,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                               modelId: _activeNormalChatModelId ?? '',
                               hasSelectableModels:
                                   _hasSelectableNormalChatModels,
+                              onPointerDown: () {
+                                _suppressNextOutsideTapKeyboardHide = true;
+                              },
                               onOpen: (anchorContext) =>
                                   _openConversationModelSelector(anchorContext),
                             )

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
@@ -65,11 +65,13 @@ class ChatModelPickerSettings {
     required this.modelId,
     required this.hasSelectableModels,
     required this.onOpen,
+    this.onPointerDown,
   });
 
   final String modelId;
   final bool hasSelectableModels;
   final FutureOr<void> Function(BuildContext anchorContext) onOpen;
+  final VoidCallback? onPointerDown;
 }
 
 class ChatInputAttachment {

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
@@ -771,11 +771,15 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
       await Future<void>.sync(() => settings.onOpen(anchorContext));
     }
 
-    return SizedBox(
+    return TextFieldTapRegion(
+      child: SizedBox(
       key: _modelPickerButtonKey,
       width: compact ? 24 : 28,
       height: compact ? 24 : 28,
-      child: Tooltip(
+      child: Listener(
+        behavior: HitTestBehavior.opaque,
+        onPointerDown: (_) => settings.onPointerDown?.call(),
+        child: Tooltip(
         message: modelId.isEmpty
             ? (english ? 'Select model' : '选择模型')
             : modelId,
@@ -801,6 +805,8 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
               ),
             ),
           ),
+        ),
+      ),
         ),
       ),
     );

--- a/ui/lib/widgets/glass_popup.dart
+++ b/ui/lib/widgets/glass_popup.dart
@@ -22,6 +22,46 @@ enum GlassPopupHorizontalPlacement {
   centerOnScreen,
 }
 
+class GlassPopupAnchorLayout extends StatelessWidget {
+  const GlassPopupAnchorLayout({
+    super.key,
+    required this.anchor,
+    required this.child,
+    this.preferBelow = true,
+    this.verticalGap = 6,
+    this.screenPadding = const EdgeInsets.all(8),
+    this.unfoldAlignment,
+    this.horizontalPlacement = GlassPopupHorizontalPlacement.edgeAlign,
+  });
+
+  final Rect anchor;
+  final Widget child;
+  final bool preferBelow;
+  final double verticalGap;
+  final EdgeInsets screenPadding;
+  final Alignment? unfoldAlignment;
+  final GlassPopupHorizontalPlacement horizontalPlacement;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    return CustomSingleChildLayout(
+      delegate: _GlassPopupLayoutDelegate(
+        anchor: anchor,
+        preferBelow: preferBelow,
+        verticalGap: verticalGap,
+        screenPadding: screenPadding,
+        mediaPadding: mediaQuery.padding,
+        textDirection: Directionality.of(context),
+        explicitUnfoldAlignment: unfoldAlignment,
+        horizontalPlacement: horizontalPlacement,
+        onAlignmentResolved: (_) {},
+      ),
+      child: child,
+    );
+  }
+}
+
 /// 玻璃风格 popup 的统一入口。
 ///
 /// 设计目标：还原 Android 原生 PopupMenu 的"从 anchor 一侧的角先展宽、再展高、
@@ -53,6 +93,7 @@ Future<T?> showGlassPopup<T>({
   Color? barrierColor,
   String? barrierLabel,
   RouteSettings? routeSettings,
+  bool? requestFocus,
 
   /// 设置为 true 时不播放展开/收起动画——直接瞬间出现 / 瞬间消失。
   /// 用于长按消息气泡这类"系统级 context menu"——动画反而显得拖沓。
@@ -81,6 +122,7 @@ Future<T?> showGlassPopup<T>({
       barrierLabel:
           barrierLabel ?? MaterialLocalizations.of(context).modalBarrierDismissLabel,
       settings: routeSettings,
+      requestFocus: requestFocus,
     ),
   );
 }
@@ -102,6 +144,7 @@ class GlassPopupRoute<T> extends PopupRoute<T> {
     required this.barrierLabel,
     required this.instant,
     Color? barrierColor,
+    super.requestFocus,
     super.settings,
   }) : _barrierColor = barrierColor;
 

--- a/ui/test/features/home/pages/command_overlay/widgets/chat_input_area_test.dart
+++ b/ui/test/features/home/pages/command_overlay/widgets/chat_input_area_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:ui/features/home/pages/command_overlay/widgets/chat_input_area.dart';
+import 'package:ui/widgets/glass_popup.dart';
 import 'package:ui/widgets/provider_vendor_icon.dart';
 
 void main() {
@@ -295,6 +296,45 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(opened, isFalse);
+  });
+
+  testWidgets('normal chat model picker popup can keep input focus', (
+    tester,
+  ) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _buildTestApp(
+        contextUsageRatio: null,
+        useLargeComposerStyle: true,
+        focusNode: focusNode,
+        modelPickerSettings: ChatModelPickerSettings(
+          modelId: 'gpt-5.4',
+          hasSelectableModels: true,
+          onOpen: (anchorContext) {
+            final anchor = glassPopupAnchorFromContext(anchorContext)!;
+            return showGlassPopup<void>(
+              context: anchorContext,
+              anchor: anchor,
+              requestFocus: false,
+              child: const SizedBox(width: 120, height: 80),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-model-picker-button')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(focusNode.hasFocus, isTrue);
   });
 
   testWidgets('large composer codex controls fit on narrow screens', (


### PR DESCRIPTION
## 变更摘要

本次修复解决了当前版本下 `Agent/普通聊天` 模式下，输入框已激活且键盘弹出时，点击模型按钮会导致输入框回落、模型列表错位的问题。  
最终方案不是继续压制焦点变化，而是把普通聊天模型选择器从 `PopupRoute` 改成页内 `OverlayEntry`，避免弹层入栈时触发键盘/布局抖动。

## 变更类型

- [x]  Bug 修复

## 关联 Issue

Closes #379 

## 主要改动

1. 将普通聊天模型选择器从路由弹窗改为页内 `OverlayEntry`，避免键盘弹出时点击模型按钮触发布局回落。
2. 抽出 `GlassPopupAnchorLayout` 复用现有 anchor 定位逻辑，让页内 overlay 仍保持原来的 popup 定位表现。
3. 给模型选择器内容组件增加可选 `onSelect` 回调，使其既可被路由弹窗使用，也可被页内 overlay 直接复用。



测试细节：

修复后录屏：

https://github.com/user-attachments/assets/1c60dc33-c8af-4002-9c42-de28fc67f35f



## UI 变更（如有）

有。  可见录屏


