### PR TITLE
支持 Codex 上下文注入与工作目录文件发送至对话

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          yes | sdkmanager --licenses >/dev/null
+          yes | sdkmanager --licenses >/dev/null || true
           sdkmanager \
             "platforms;android-${ANDROID_PLATFORM_VERSION}" \
             "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \

--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -1,0 +1,91 @@
+name: Build Debug APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - 'codex-context-*'
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: '17'
+  FLUTTER_VERSION: '3.38.7'
+  ANDROID_BUILD_TOOLS_VERSION: '36.0.0'
+  ANDROID_PLATFORM_VERSION: '36'
+  NDK_VERSION: '28.2.13676358'
+  ALLOWED_THIRD_PARTY_WRAPPER_SHA: 'ee3739525a995bcb5601621a6e2daec1f183bbefc375743acc235cec33547e04'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Validate Gradle wrappers
+        uses: gradle/actions/wrapper-validation@v4
+        with:
+          allow-checksums: ${{ env.ALLOWED_THIRD_PARTY_WRAPPER_SHA }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          validate-wrappers: false
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK components
+        shell: bash
+        run: |
+          set -euo pipefail
+          yes | sdkmanager --licenses >/dev/null
+          sdkmanager \
+            "platforms;android-${ANDROID_PLATFORM_VERSION}" \
+            "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+            "ndk;${NDK_VERSION}"
+
+      - name: Export Android NDK environment
+        shell: bash
+        run: |
+          echo "ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Install Flutter dependencies
+        working-directory: ui
+        run: flutter pub get --enforce-lockfile
+
+      - name: Build develop standard debug APK
+        run: >-
+          ./gradlew --no-daemon --build-cache
+          :app:assembleDevelopStandardDebug
+          -Ptarget=lib/main_standard.dart
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenOmniBot-develop-standard-debug
+          if-no-files-found: error
+          retention-days: 14
+          path: app/build/outputs/apk/developStandard/debug/*.apk

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -289,7 +289,7 @@ class CodexAppServerManager private constructor(
             mapOf("threadId" to threadId, "name" to name)
         ) as Map<String, Any?>
         if (shouldSyncLocalThreadBindings()) {
-            bindingRepository.updateTitle(threadId, name)
+            bindingRepository.updateTitle(threadId, name, force = true)
         }
         return response.withLocalIds(
             threadId = threadId,

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -9,7 +9,9 @@ import com.ai.assistance.operit.terminal.setup.EnvironmentSetupLogic
 import cn.com.omnimind.baselib.database.DatabaseHelper
 import cn.com.omnimind.bot.BuildConfig
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.agent.WorkspaceMemoryService
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
+import com.rk.libcommons.OmnibotTerminalEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -28,6 +30,7 @@ class CodexAppServerManager private constructor(
     private val mainHandler = Handler(Looper.getMainLooper())
     private val bindingRepository = CodexThreadBindingRepository(appContext)
     private val remoteConfigStore = CodexRemoteBridgeConfigStore(appContext)
+    private val contextInjectionConfigStore = CodexContextInjectionConfigStore(appContext)
     private val activeTurnsByThreadId = ConcurrentHashMap<String, String>()
 
     @Volatile
@@ -413,6 +416,7 @@ class CodexAppServerManager private constructor(
 
     private suspend fun readLocalConfig(): Map<String, Any?> {
         val remoteConfig = remoteConfigStore.read()
+        val contextInjectionConfig = contextInjectionConfigStore.read()
         val command = """
             mkdir -p ${shellQuote(CodexAppServerDefaults.CODEX_HOME)}
             printf '__OMNI_CODEX_CONFIG_START__\n'
@@ -459,14 +463,18 @@ class CodexAppServerManager private constructor(
             baseUrl = extractTomlString(configToml, "base_url").orEmpty(),
             apiKey = extractOpenAiApiKey(authJson).orEmpty(),
             remoteConfig = remoteConfig,
-            runtime = resolveRuntime().kind.payloadValue
+            runtime = resolveRuntime().kind.payloadValue,
+            contextInjectionEnabled = contextInjectionConfig.enabled
         )
     }
 
     private suspend fun writeLocalConfig(args: Map<String, Any?>): Map<String, Any?> {
+        val storedContextInjectionConfig = contextInjectionConfigStore.read()
         val baseUrl = args.stringValue("baseUrl").orEmpty()
         val model = args.stringValue("model").orEmpty()
         val apiKey = args.stringValue("apiKey").orEmpty()
+        val contextInjectionEnabled = args.booleanValue("contextInjectionEnabled")
+            ?: storedContextInjectionConfig.enabled
         val remoteConfig = CodexRemoteBridgeConfig(
             enabled = args["remoteEnabled"] == true,
             bridgeUrl = args.stringValue("remoteBridgeUrl").orEmpty(),
@@ -479,6 +487,9 @@ class CodexAppServerManager private constructor(
         }
 
         val savedRemoteConfig = remoteConfigStore.write(remoteConfig)
+        val savedContextInjectionConfig = contextInjectionConfigStore.write(
+            CodexContextInjectionConfig(enabled = contextInjectionEnabled)
+        )
         if (localComplete) {
             val configToml = buildCodexConfigToml(baseUrl = baseUrl, model = model)
             val authJson = JSONObject()
@@ -517,7 +528,8 @@ class CodexAppServerManager private constructor(
             baseUrl = baseUrl,
             apiKey = apiKey,
             remoteConfig = savedRemoteConfig,
-            runtime = resolveRuntime().kind.payloadValue
+            runtime = resolveRuntime().kind.payloadValue,
+            contextInjectionEnabled = savedContextInjectionConfig.enabled
         )
     }
 
@@ -598,9 +610,15 @@ class CodexAppServerManager private constructor(
         cwd: String,
         threadId: String
     ): MutableMap<String, Any?> {
+        val input = resolveInput(args)
+        val contextText = if (contextInjectionConfigStore.read().enabled) {
+            buildCodexContextInjectionTextForTurn()
+        } else {
+            null
+        }
         val params = linkedMapOf<String, Any?>(
             "threadId" to threadId,
-            "input" to resolveInput(args),
+            "input" to buildCodexInputWithOptionalContext(input, contextText),
             "cwd" to cwd,
             "approvalPolicy" to (args.stringValue("approvalPolicy") ?: "on-request"),
             "sandboxPolicy" to (args["sandboxPolicy"] ?: buildDefaultCodexSandboxPolicy(cwd))
@@ -610,6 +628,34 @@ class CodexAppServerManager private constructor(
         }
         addCodexOptionalRunParams(params, args)
         return params
+    }
+
+    private fun buildCodexContextInjectionTextForTurn(): String? {
+        val memoryContext = runCatching {
+            WorkspaceMemoryService(appContext).buildPromptContext()
+        }.onFailure { error ->
+            Log.w(
+                "CodexAppServerManager",
+                "Failed to load workspace memory for Codex context injection.",
+                error
+            )
+        }.getOrNull()
+        val terminalVariables = runCatching {
+            OmnibotTerminalEnvironment.loadUserVariables(appContext)
+        }.onFailure { error ->
+            Log.w(
+                "CodexAppServerManager",
+                "Failed to load terminal variables for Codex context injection.",
+                error
+            )
+        }.getOrDefault(emptyMap())
+
+        return buildCodexContextInjectionText(
+            soul = memoryContext?.soul.orEmpty(),
+            longTermMemory = memoryContext?.longTermMemory.orEmpty(),
+            todayShortMemory = memoryContext?.todayShortMemory.orEmpty(),
+            terminalVariables = terminalVariables
+        )
     }
 
     private fun buildReviewStartParams(
@@ -1005,6 +1051,8 @@ private data class CodexThreadListEntry(
     val archived: Boolean?
 )
 
+private const val MAX_CODEX_CONTEXT_VARIABLE_NAMES = 80
+
 internal fun Map<String, Any?>.withLocalIds(
     threadId: String?,
     conversationId: Long?,
@@ -1050,6 +1098,80 @@ internal fun buildCodexTextInput(text: String): List<Map<String, Any?>> {
             "text_elements" to emptyList<Map<String, Any?>>()
         )
     )
+}
+
+internal fun buildCodexInputWithOptionalContext(
+    input: List<Map<String, Any?>>,
+    contextText: String?
+): List<Map<String, Any?>> {
+    val trimmedContext = contextText?.trim().orEmpty()
+    if (trimmedContext.isEmpty()) {
+        return input
+    }
+    return buildCodexTextInput(trimmedContext) + input
+}
+
+internal fun buildCodexContextInjectionText(
+    soul: String,
+    longTermMemory: String,
+    todayShortMemory: String,
+    terminalVariables: Map<String, String>
+): String? {
+    val sections = mutableListOf<String>()
+
+    fun addTextSection(tag: String, text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) {
+            return
+        }
+        sections += buildString {
+            appendLine("[$tag]")
+            appendLine(trimmed)
+            append("[/$tag]")
+        }
+    }
+
+    addTextSection("workspace_soul", soul)
+    addTextSection("long_term_memory", longTermMemory)
+    addTextSection("today_short_memory", todayShortMemory)
+
+    val variableNames = terminalVariables.keys
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .distinct()
+        .sorted()
+    if (variableNames.isNotEmpty()) {
+        val visibleNames = variableNames.take(MAX_CODEX_CONTEXT_VARIABLE_NAMES)
+        sections += buildString {
+            appendLine("[terminal_variables]")
+            appendLine("Values are hidden. These variable names are configured in Omnibot terminal sessions:")
+            visibleNames.forEach { name ->
+                appendLine("- $name=(configured, value hidden)")
+            }
+            val omitted = variableNames.size - visibleNames.size
+            if (omitted > 0) {
+                appendLine("- ... ($omitted more)")
+            }
+            append("[/terminal_variables]")
+        }
+    }
+
+    if (sections.isEmpty()) {
+        return null
+    }
+    return buildString {
+        appendLine("[omnibot_context]")
+        appendLine("This background context is injected by Omnibot because the user enabled Codex context injection. Use it as persistent user/workspace context, not as the current task request.")
+        sections.forEachIndexed { index, section ->
+            appendLine()
+            append(section)
+            if (index != sections.lastIndex) {
+                appendLine()
+            }
+        }
+        appendLine()
+        append("[/omnibot_context]")
+    }
 }
 
 internal fun buildDefaultCodexSandboxPolicy(cwd: String): Map<String, Any?> {
@@ -1132,7 +1254,8 @@ private fun buildCodexLocalConfigPayload(
     baseUrl: String,
     apiKey: String,
     remoteConfig: CodexRemoteBridgeConfig,
-    runtime: String
+    runtime: String,
+    contextInjectionEnabled: Boolean
 ): Map<String, Any?> {
     return linkedMapOf(
         "codexHome" to CodexAppServerDefaults.CODEX_HOME,
@@ -1144,7 +1267,8 @@ private fun buildCodexLocalConfigPayload(
         "remoteBridgeToken" to remoteConfig.authToken,
         "remoteCwd" to remoteConfig.cwd,
         "remoteConfigured" to remoteConfig.isConfigured,
-        "runtime" to runtime
+        "runtime" to runtime,
+        "contextInjectionEnabled" to contextInjectionEnabled
     )
 }
 
@@ -1247,6 +1371,20 @@ private fun shellQuote(value: String): String {
 
 private fun Map<String, Any?>.stringValue(key: String): String? {
     return this[key]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+}
+
+private fun Map<String, Any?>.booleanValue(key: String): Boolean? {
+    val raw = this[key] ?: return null
+    return when (raw) {
+        is Boolean -> raw
+        is String -> when (raw.trim().lowercase()) {
+            "true", "1", "yes", "on" -> true
+            "false", "0", "no", "off" -> false
+            else -> null
+        }
+        is Number -> raw.toInt() != 0
+        else -> null
+    }
 }
 
 private fun Map<String, Any?>.longValue(key: String): Long? {

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -9,6 +9,8 @@ import com.ai.assistance.operit.terminal.setup.EnvironmentSetupLogic
 import cn.com.omnimind.baselib.database.DatabaseHelper
 import cn.com.omnimind.bot.BuildConfig
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.agent.SkillIndexEntry
+import cn.com.omnimind.bot.agent.SkillIndexService
 import cn.com.omnimind.bot.agent.WorkspaceMemoryService
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
 import com.rk.libcommons.OmnibotTerminalEnvironment
@@ -125,6 +127,17 @@ class CodexAppServerManager private constructor(
             activeTurnsByThreadId.clear()
         }
         return status()
+    }
+
+    suspend fun invalidateLocalTerminalEnvironment() {
+        sessionMutex.withLock {
+            if (activeRuntime == CodexRuntimeKind.LOCAL) {
+                session?.disconnect()
+                session = null
+                activeRuntime = null
+                activeTurnsByThreadId.clear()
+            }
+        }
     }
 
     suspend fun handleMethod(method: String, args: Map<String, Any?>): Any? {
@@ -631,8 +644,9 @@ class CodexAppServerManager private constructor(
     }
 
     private fun buildCodexContextInjectionTextForTurn(): String? {
+        val workspaceManager = AgentWorkspaceManager(appContext)
         val memoryContext = runCatching {
-            WorkspaceMemoryService(appContext).buildPromptContext()
+            WorkspaceMemoryService(appContext, workspaceManager).buildPromptContext()
         }.onFailure { error ->
             Log.w(
                 "CodexAppServerManager",
@@ -649,12 +663,28 @@ class CodexAppServerManager private constructor(
                 error
             )
         }.getOrDefault(emptyMap())
+        val skillsContext = runCatching {
+            val skillsRoot = workspaceManager.skillsRoot()
+            buildCodexSkillsContextText(
+                skillsRootShellPath = workspaceManager.shellPathForAndroid(skillsRoot)
+                    ?: "${AgentWorkspaceManager.SHELL_ROOT_PATH}/.omnibot/skills",
+                skillsRootAndroidPath = skillsRoot.absolutePath,
+                skills = SkillIndexService(appContext, workspaceManager).listSkillsForManagement()
+            )
+        }.onFailure { error ->
+            Log.w(
+                "CodexAppServerManager",
+                "Failed to load skills index for Codex context injection.",
+                error
+            )
+        }.getOrNull()
 
         return buildCodexContextInjectionText(
             soul = memoryContext?.soul.orEmpty(),
             longTermMemory = memoryContext?.longTermMemory.orEmpty(),
             todayShortMemory = memoryContext?.todayShortMemory.orEmpty(),
-            terminalVariables = terminalVariables
+            terminalVariables = terminalVariables,
+            skillsContext = skillsContext.orEmpty()
         )
     }
 
@@ -1052,6 +1082,8 @@ private data class CodexThreadListEntry(
 )
 
 private const val MAX_CODEX_CONTEXT_VARIABLE_NAMES = 80
+private const val MAX_CODEX_CONTEXT_SKILLS = 80
+private const val MAX_CODEX_CONTEXT_SKILL_DESCRIPTION_CHARS = 220
 
 internal fun Map<String, Any?>.withLocalIds(
     threadId: String?,
@@ -1115,7 +1147,8 @@ internal fun buildCodexContextInjectionText(
     soul: String,
     longTermMemory: String,
     todayShortMemory: String,
-    terminalVariables: Map<String, String>
+    terminalVariables: Map<String, String>,
+    skillsContext: String = ""
 ): String? {
     val sections = mutableListOf<String>()
 
@@ -1134,6 +1167,7 @@ internal fun buildCodexContextInjectionText(
     addTextSection("workspace_soul", soul)
     addTextSection("long_term_memory", longTermMemory)
     addTextSection("today_short_memory", todayShortMemory)
+    addTextSection("skills", skillsContext)
 
     val variableNames = terminalVariables.keys
         .map { it.trim() }
@@ -1172,6 +1206,63 @@ internal fun buildCodexContextInjectionText(
         appendLine()
         append("[/omnibot_context]")
     }
+}
+
+internal fun buildCodexSkillsContextText(
+    skillsRootShellPath: String,
+    skillsRootAndroidPath: String,
+    skills: List<SkillIndexEntry>
+): String? {
+    val installedSkills = skills
+        .filter { it.installed }
+        .sortedWith(
+            compareBy<SkillIndexEntry> { it.source }
+                .thenBy { it.name.lowercase() }
+        )
+    if (installedSkills.isEmpty()) {
+        return buildString {
+            appendLine("Omnibot skills root (shell): $skillsRootShellPath")
+            appendLine("Omnibot skills root (android): $skillsRootAndroidPath")
+            appendLine("To create a skill that appears in Omnibot Skill Store, create it at:")
+            appendLine("- $skillsRootShellPath/<skill-id>/SKILL.md")
+            appendLine("Use lowercase kebab-case for <skill-id>. The directory may include scripts/, references/, assets/, or evals/.")
+            append("No installed Omnibot skills are currently indexed.")
+        }
+    }
+
+    return buildString {
+        appendLine("Omnibot skills root (shell): $skillsRootShellPath")
+        appendLine("Omnibot skills root (android): $skillsRootAndroidPath")
+        appendLine("APK built-in skills are copied into this workspace root before indexing; Codex cannot read APK assets directly.")
+        appendLine("To create a skill that appears in Omnibot Skill Store, create it at:")
+        appendLine("- $skillsRootShellPath/<skill-id>/SKILL.md")
+        appendLine("Use lowercase kebab-case for <skill-id>. The directory may include scripts/, references/, assets/, or evals/.")
+        appendLine("When the user asks to create or update a skill, read the indexed skill-creator SKILL.md first if it is available.")
+        appendLine()
+        appendLine("Indexed skills:")
+        installedSkills.take(MAX_CODEX_CONTEXT_SKILLS).forEach { skill ->
+            val capabilities = buildList {
+                if (skill.hasScripts) add("scripts")
+                if (skill.hasReferences) add("references")
+                if (skill.hasAssets) add("assets")
+                if (skill.hasEvals) add("evals")
+            }.ifEmpty { listOf("none") }.joinToString(",")
+            val enabledLabel = if (skill.enabled) "enabled" else "disabled"
+            val description = skill.description
+                .replace('\n', ' ')
+                .trim()
+                .take(MAX_CODEX_CONTEXT_SKILL_DESCRIPTION_CHARS)
+            append("- id=${skill.id} | name=${skill.name} | source=${skill.source} | state=$enabledLabel | path=${skill.shellSkillFilePath} | capabilities=$capabilities")
+            if (description.isNotBlank()) {
+                append(" | description=$description")
+            }
+            appendLine()
+        }
+        val omitted = installedSkills.size - MAX_CODEX_CONTEXT_SKILLS
+        if (omitted > 0) {
+            append("- ... ($omitted more)")
+        }
+    }.trim()
 }
 
 internal fun buildDefaultCodexSandboxPolicy(cwd: String): Map<String, Any?> {

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerSession.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerSession.kt
@@ -7,6 +7,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.rk.libcommons.OmnibotTerminalEnvironment
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -207,15 +208,21 @@ internal class CodexAppServerSession(
     }
 
     private fun buildStartEnvironment(): Map<String, String> {
-        return mapOf(
-            "OMNIBOT_HEADLESS" to "1",
-            "CODEX_HOME" to CodexAppServerDefaults.CODEX_HOME,
-            "OMNIBOT_SESSION_CWD" to CodexAppServerDefaults.FALLBACK_CWD
-        )
+        return linkedMapOf<String, String>().apply {
+            if (context != null) {
+                putAll(OmnibotTerminalEnvironment.buildTerminalEnvironment(context))
+            }
+            put("OMNIBOT_HEADLESS", "1")
+            put("CODEX_HOME", CodexAppServerDefaults.CODEX_HOME)
+            put("OMNIBOT_SESSION_CWD", CodexAppServerDefaults.FALLBACK_CWD)
+        }
     }
 
     private fun buildStartCommand(): String {
         return """
+            if [ -n "${'$'}{OMNIBOT_USER_ENV_FILE:-}" ] && [ -f "${'$'}OMNIBOT_USER_ENV_FILE" ]; then
+              . "${'$'}OMNIBOT_USER_ENV_FILE"
+            fi
             export CODEX_HOME=${CodexAppServerDefaults.CODEX_HOME}
             export PATH="/root/.npm-global/bin:${'$'}PATH"
             mkdir -p "${'$'}CODEX_HOME"

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexContextInjectionConfigStore.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexContextInjectionConfigStore.kt
@@ -1,0 +1,32 @@
+package cn.com.omnimind.bot.codex
+
+import android.content.Context
+
+internal data class CodexContextInjectionConfig(
+    val enabled: Boolean = false
+)
+
+internal class CodexContextInjectionConfigStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(
+        PREFS_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    fun read(): CodexContextInjectionConfig {
+        return CodexContextInjectionConfig(
+            enabled = prefs.getBoolean(KEY_ENABLED, false)
+        )
+    }
+
+    fun write(config: CodexContextInjectionConfig): CodexContextInjectionConfig {
+        prefs.edit()
+            .putBoolean(KEY_ENABLED, config.enabled)
+            .apply()
+        return read()
+    }
+
+    private companion object {
+        private const val PREFS_NAME = "codex_context_injection_config"
+        private const val KEY_ENABLED = "enabled"
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexThreadBindingRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexThreadBindingRepository.kt
@@ -49,14 +49,16 @@ internal class CodexThreadBindingRepository(
                 }
             }
             val conversation = DatabaseHelper.getConversationById(existingBinding.conversationId)
-            val updatedConversation = conversation?.let {
-                val titleForUpdate = if (conversationId != null && it.title.isNotBlank()) {
-                    null
-                } else {
-                    title
+            val updatedConversation = conversation?.let { existingConversation ->
+                val titleForUpdate = title?.takeIf { incomingTitle ->
+                    shouldApplyIncomingTitle(
+                        conversation = existingConversation,
+                        threadId = existingBinding.threadId,
+                        incomingTitle = incomingTitle
+                    )
                 }
                 buildUpdatedConversation(
-                    conversation = it,
+                    conversation = existingConversation,
                     title = titleForUpdate,
                     archived = archived,
                     updatedAt = now
@@ -145,11 +147,18 @@ internal class CodexThreadBindingRepository(
         return conversationId
     }
 
-    suspend fun updateTitle(threadId: String, title: String?) {
+    suspend fun updateTitle(
+        threadId: String,
+        title: String?,
+        force: Boolean = false
+    ) {
         val binding = getBindingByThreadId(threadId.trim()) ?: return
         val conversation = DatabaseHelper.getConversationById(binding.conversationId) ?: return
         val normalizedTitle = title?.trim().orEmpty()
         if (normalizedTitle.isEmpty() || normalizedTitle == conversation.title) {
+            return
+        }
+        if (!force && !shouldApplyIncomingTitle(conversation, threadId, normalizedTitle)) {
             return
         }
         val updated = conversation.copy(
@@ -213,6 +222,22 @@ internal class CodexThreadBindingRepository(
             isArchived = archived ?: conversation.isArchived,
             updatedAt = updatedAt
         )
+    }
+
+    private fun shouldApplyIncomingTitle(
+        conversation: Conversation,
+        threadId: String,
+        incomingTitle: String
+    ): Boolean {
+        val normalizedIncomingTitle = incomingTitle.trim()
+        if (normalizedIncomingTitle.isEmpty()) {
+            return false
+        }
+        val currentTitle = conversation.title.trim()
+        if (currentTitle.isEmpty() || currentTitle == normalizedIncomingTitle) {
+            return true
+        }
+        return currentTitle == "Codex" || currentTitle == defaultConversationTitle(threadId)
     }
 
     private fun publishConversationEvent(eventName: String, conversation: Conversation) {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -6012,12 +6012,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
      */
     fun updateConversation(call: MethodCall, result: MethodChannel.Result) {
         val conversationMap = call.argument<Map<String, Any>>("conversation")
+        val preserveUserMetadata = call.argument<Boolean>("preserveUserMetadata") ?: false
 
         workJob.launch {
             try {
                 if (conversationMap != null) {
                     conversationDomainService.updateConversationFromPayload(
-                        conversationMap.mapValues { it.value }
+                        conversationMap.mapValues { it.value },
+                        preserveUserMetadata = preserveUserMetadata
                     )
                     withContext(Dispatchers.Main) {
                         result.success("SUCCESS")

--- a/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
@@ -12,6 +12,7 @@ import cn.com.omnimind.baselib.permission.PermissionRequest
 import cn.com.omnimind.baselib.shizuku.ShizukuCapabilityManager
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.codex.CodexAppServerManager
 import cn.com.omnimind.bot.terminal.EmbeddedTerminalAutoStartManager
 import cn.com.omnimind.bot.terminal.EmbeddedTerminalInitCoordinator
 import cn.com.omnimind.bot.terminal.EmbeddedTerminalLaunchHelper
@@ -703,6 +704,11 @@ class SpecialPermissionManager(private val context: Context) {
                     variables[key] = value
                 }
                 val normalized = OmnibotTerminalEnvironment.saveUserVariables(context, variables)
+                runCatching {
+                    CodexAppServerManager.getInstance(context).invalidateLocalTerminalEnvironment()
+                }.onFailure { error ->
+                    OmniLog.w(TAG, "Failed to invalidate Codex environment: ${error.message}")
+                }
                 withContext(Dispatchers.Main) {
                     result.success(
                         mapOf(

--- a/app/src/main/java/cn/com/omnimind/bot/webchat/ConversationDomainService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/webchat/ConversationDomainService.kt
@@ -66,7 +66,8 @@ class ConversationDomainService(
     }
 
     suspend fun updateConversationFromPayload(
-        conversationMap: Map<String, Any?>
+        conversationMap: Map<String, Any?>,
+        preserveUserMetadata: Boolean = false
     ): Map<String, Any?> {
         val conversationId = conversationMap.readLong("id")
             ?: throw IllegalArgumentException("conversation.id is invalid")
@@ -74,20 +75,40 @@ class ConversationDomainService(
             ?: throw IllegalArgumentException("Conversation not found")
         val incomingContextSummary = conversationMap["contextSummary"]?.toString()?.trim()
         val updated = existing.copy(
-            title = conversationMap["title"]?.toString()?.trim()?.ifEmpty {
+            title = if (preserveUserMetadata) {
                 existing.title
-            } ?: existing.title,
-            mode = normalizeConversationMode(
-                conversationMap["mode"]?.toString() ?: existing.mode
-            ),
-            isArchived = conversationMap.readBoolean("isArchived") ?: existing.isArchived,
-            isPinned = conversationMap.readBoolean("isPinned") ?: existing.isPinned,
-            parentConversationId = if (conversationMap.containsKey("parentConversationId")) {
+            } else {
+                conversationMap["title"]?.toString()?.trim()?.ifEmpty {
+                    existing.title
+                } ?: existing.title
+            },
+            mode = if (preserveUserMetadata) {
+                existing.mode
+            } else {
+                normalizeConversationMode(
+                    conversationMap["mode"]?.toString() ?: existing.mode
+                )
+            },
+            isArchived = if (preserveUserMetadata) {
+                existing.isArchived
+            } else {
+                conversationMap.readBoolean("isArchived") ?: existing.isArchived
+            },
+            isPinned = if (preserveUserMetadata) {
+                existing.isPinned
+            } else {
+                conversationMap.readBoolean("isPinned") ?: existing.isPinned
+            },
+            parentConversationId = if (preserveUserMetadata) {
+                existing.parentConversationId
+            } else if (conversationMap.containsKey("parentConversationId")) {
                 conversationMap.readLong("parentConversationId")?.takeIf { it > 0L }
             } else {
                 existing.parentConversationId
             },
-            parentConversationMode = if (conversationMap.containsKey("parentConversationMode")) {
+            parentConversationMode = if (preserveUserMetadata) {
+                existing.parentConversationMode
+            } else if (conversationMap.containsKey("parentConversationMode")) {
                 conversationMap["parentConversationMode"]
                     ?.toString()
                     ?.let(::normalizeConversationMode)
@@ -95,7 +116,9 @@ class ConversationDomainService(
             } else {
                 existing.parentConversationMode
             },
-            scheduledTaskId = if (conversationMap.containsKey("scheduledTaskId")) {
+            scheduledTaskId = if (preserveUserMetadata) {
+                existing.scheduledTaskId
+            } else if (conversationMap.containsKey("scheduledTaskId")) {
                 conversationMap["scheduledTaskId"]?.toString()?.trim()?.takeIf { it.isNotEmpty() }
             } else {
                 existing.scheduledTaskId
@@ -119,7 +142,11 @@ class ConversationDomainService(
                 ?: existing.promptTokenThreshold.coerceAtLeast(1),
             latestPromptTokensUpdatedAt = conversationMap.readLong("latestPromptTokensUpdatedAt")
                 ?: existing.latestPromptTokensUpdatedAt,
-            createdAt = conversationMap.readLong("createdAt") ?: existing.createdAt,
+            createdAt = if (preserveUserMetadata) {
+                existing.createdAt
+            } else {
+                conversationMap.readLong("createdAt") ?: existing.createdAt
+            },
             updatedAt = System.currentTimeMillis()
         )
         DatabaseHelper.updateConversation(updated)

--- a/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
@@ -36,6 +36,59 @@ class CodexAppServerProtocolPayloadTest {
     }
 
     @Test
+    fun buildCodexInputWithOptionalContextPrependsContextText() {
+        val userInput = buildCodexTextInput("implement the change")
+
+        val input = buildCodexInputWithOptionalContext(
+            userInput,
+            "workspace memory"
+        )
+
+        assertEquals(2, input.size)
+        assertEquals("workspace memory", input[0]["text"])
+        assertEquals("implement the change", input[1]["text"])
+    }
+
+    @Test
+    fun buildCodexInputWithOptionalContextLeavesInputUntouchedWhenBlank() {
+        val userInput = buildCodexTextInput("implement the change")
+
+        val input = buildCodexInputWithOptionalContext(userInput, " ")
+
+        assertEquals(userInput, input)
+    }
+
+    @Test
+    fun buildCodexContextInjectionTextIncludesMemoryAndHidesVariableValues() {
+        val text = buildCodexContextInjectionText(
+            soul = "SOUL identity",
+            longTermMemory = "- Prefers concise answers",
+            todayShortMemory = "- Working on Codex mode",
+            terminalVariables = mapOf("OPENAI_API_KEY" to "sk-secret")
+        )!!
+
+        assertTrue(text.contains("[omnibot_context]"))
+        assertTrue(text.contains("[workspace_soul]"))
+        assertTrue(text.contains("SOUL identity"))
+        assertTrue(text.contains("[long_term_memory]"))
+        assertTrue(text.contains("[today_short_memory]"))
+        assertTrue(text.contains("- OPENAI_API_KEY=(configured, value hidden)"))
+        assertEquals(false, text.contains("sk-secret"))
+    }
+
+    @Test
+    fun buildCodexContextInjectionTextReturnsNullForEmptyContext() {
+        assertNull(
+            buildCodexContextInjectionText(
+                soul = "",
+                longTermMemory = "",
+                todayShortMemory = "",
+                terminalVariables = emptyMap()
+            )
+        )
+    }
+
+    @Test
     fun buildDefaultCodexSandboxPolicyUsesAbsoluteWritableRoot() {
         val policy = buildDefaultCodexSandboxPolicy("noise\n/workspace")
 

--- a/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
@@ -1,5 +1,6 @@
 package cn.com.omnimind.bot.codex
 
+import cn.com.omnimind.bot.agent.SkillIndexEntry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -64,7 +65,8 @@ class CodexAppServerProtocolPayloadTest {
             soul = "SOUL identity",
             longTermMemory = "- Prefers concise answers",
             todayShortMemory = "- Working on Codex mode",
-            terminalVariables = mapOf("OPENAI_API_KEY" to "sk-secret")
+            terminalVariables = mapOf("OPENAI_API_KEY" to "sk-secret"),
+            skillsContext = "Omnibot skills root (shell): /workspace/.omnibot/skills"
         )!!
 
         assertTrue(text.contains("[omnibot_context]"))
@@ -72,6 +74,8 @@ class CodexAppServerProtocolPayloadTest {
         assertTrue(text.contains("SOUL identity"))
         assertTrue(text.contains("[long_term_memory]"))
         assertTrue(text.contains("[today_short_memory]"))
+        assertTrue(text.contains("[skills]"))
+        assertTrue(text.contains("/workspace/.omnibot/skills"))
         assertTrue(text.contains("- OPENAI_API_KEY=(configured, value hidden)"))
         assertEquals(false, text.contains("sk-secret"))
     }
@@ -86,6 +90,35 @@ class CodexAppServerProtocolPayloadTest {
                 terminalVariables = emptyMap()
             )
         )
+    }
+
+    @Test
+    fun buildCodexSkillsContextTextExplainsWorkspaceSkillLocation() {
+        val text = buildCodexSkillsContextText(
+            skillsRootShellPath = "/workspace/.omnibot/skills",
+            skillsRootAndroidPath = "/sdcard/Omnibot/.omnibot/skills",
+            skills = listOf(
+                SkillIndexEntry(
+                    id = "skill-creator",
+                    name = "skill-creator",
+                    description = "Create Omnibot skills.",
+                    rootPath = "/sdcard/Omnibot/.omnibot/skills/skill-creator",
+                    shellRootPath = "/workspace/.omnibot/skills/skill-creator",
+                    skillFilePath = "/sdcard/Omnibot/.omnibot/skills/skill-creator/SKILL.md",
+                    shellSkillFilePath = "/workspace/.omnibot/skills/skill-creator/SKILL.md",
+                    hasScripts = false,
+                    hasReferences = true,
+                    hasAssets = false,
+                    hasEvals = false,
+                    source = "builtin",
+                    installed = true
+                )
+            )
+        )!!
+
+        assertTrue(text.contains("/workspace/.omnibot/skills/<skill-id>/SKILL.md"))
+        assertTrue(text.contains("id=skill-creator"))
+        assertTrue(text.contains("capabilities=references"))
     }
 
     @Test

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -1935,6 +1935,16 @@ abstract class _ChatPageStateBase extends State<ChatPage>
 
   Future<void> _pickAttachments();
 
+  Future<void> _sendWorkspaceFileToCurrentConversation(
+    OmnibotResourceMetadata metadata,
+  );
+
+  Future<void> _sendRemoteWorkspaceFileToCurrentConversation(
+    CodexRemoteDirectoryEntry entry,
+  );
+
+  String _messageTextWithLatestAttachmentPrompt(String text);
+
   void _removePendingAttachment(String id);
 
   String _fileNameFromPath(String path);

--- a/ui/lib/features/home/pages/chat/chat_page_browser.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_browser.dart
@@ -248,9 +248,9 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     ChatPageMode mode,
     ChatIslandDisplayLayer layer,
   ) {
-    final resolvedLayer = mode == ChatPageMode.normal
-        ? layer
-        : ChatIslandDisplayLayer.mode;
+    final resolvedLayer = mode == ChatPageMode.openclaw
+        ? ChatIslandDisplayLayer.mode
+        : layer;
     _chatIslandDisplayLayerByMode[mode] = resolvedLayer;
     final runtime = _runtimeForMode(mode);
     if (runtime != null) {
@@ -260,11 +260,12 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
 
   @override
   void _handleChatIslandDisplayLayerChanged(ChatIslandDisplayLayer layer) {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal) {
+    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
+        _activeMode == ChatPageMode.openclaw) {
       return;
     }
     setState(() {
-      _setChatIslandDisplayLayerForMode(ChatPageMode.normal, layer);
+      _setChatIslandDisplayLayerForMode(_activeMode, layer);
       if (layer != ChatIslandDisplayLayer.tools) {
         _isBrowserOverlayVisible = false;
       }
@@ -273,12 +274,13 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
 
   @override
   Future<void> _handleTerminalToolTap() async {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal) {
+    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
+        _activeMode == ChatPageMode.openclaw) {
       return;
     }
     setState(() {
       _setChatIslandDisplayLayerForMode(
-        ChatPageMode.normal,
+        _activeMode,
         ChatIslandDisplayLayer.tools,
       );
     });
@@ -294,7 +296,8 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
 
   @override
   Future<void> _handleBrowserToolTap() async {
-    if (_activeSurfaceMode != ChatSurfaceMode.normal) {
+    if (_activeSurfaceMode != ChatSurfaceMode.normal ||
+        _activeMode == ChatPageMode.openclaw) {
       return;
     }
     if (!Platform.isAndroid) {
@@ -312,7 +315,7 @@ mixin _ChatPageBrowserMixin on _ChatPageStateBase {
     }
     setState(() {
       _setChatIslandDisplayLayerForMode(
-        ChatPageMode.normal,
+        _activeMode,
         ChatIslandDisplayLayer.tools,
       );
       _isBrowserOverlayVisible = true;

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -918,10 +918,11 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
           });
         }
       }
+      final turnText = _messageTextWithLatestAttachmentPrompt(messageText);
       final response = await CodexAppServerService.startTurn(
         conversationId: remoteCodex ? null : resolvedConversationId,
         threadId: _activeCodexThreadId,
-        text: messageText,
+        text: turnText,
         approvalPolicy: _codexPermissionMode.approvalPolicy,
         approvalsReviewer: _codexPermissionMode.approvalsReviewer,
         sandboxPolicy: _codexPermissionMode.sandboxPolicy,

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -183,6 +183,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         remoteBridgeUrl: config.remoteBridgeUrl,
         remoteBridgeToken: config.remoteBridgeToken,
         remoteCwd: nextCwd,
+        contextInjectionEnabled: config.contextInjectionEnabled,
       );
       final status = await CodexAppServerService.status();
       if (!mounted) return;

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -1302,7 +1302,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
       mode: kChatRuntimeModeCodex,
       initialMessages: messages,
       conversation: conversation,
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+      initialChatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
     );
     _runtimeCoordinator.replaceConversationSnapshot(
       conversationId: runtimeId,
@@ -1318,7 +1320,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
           ? ThinkingStage.thinking.value
           : ThinkingStage.complete.value,
       lastAgentTaskId: activeTaskId,
-      chatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+      chatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
       preserveLiveStreamingState: preserveLiveStreamingState,
     );
     if (activeTaskId != null) {
@@ -1407,7 +1411,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         _messagesByMode[ChatPageMode.codex]!,
       ),
       conversation: _currentConversationByMode[ChatPageMode.codex],
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+      initialChatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
     );
     return runtimeId;
   }
@@ -1434,9 +1440,11 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
             status: 0,
             messageCount: 0,
             createdAt: now,
-            updatedAt: now,
-          ),
-      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+              updatedAt: now,
+            ),
+      initialChatIslandDisplayLayer: _chatIslandDisplayLayerForMode(
+        ChatPageMode.codex,
+      ),
     );
     return runtimeId;
   }

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -256,6 +256,174 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
   }
 
   @override
+  Future<void> _sendWorkspaceFileToCurrentConversation(
+    OmnibotResourceMetadata metadata,
+  ) async {
+    if (!mounted) return;
+    final path = metadata.path.trim();
+    if (path.isEmpty || metadata.isDirectory || !File(path).existsSync()) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish ? 'File not found' : '文件不存在',
+      );
+      return;
+    }
+
+    try {
+      final stat = await File(path).stat();
+      await _addWorkspacePathAttachmentToCurrentConversation(
+        name: metadata.title.trim().isNotEmpty
+            ? metadata.title.trim()
+            : _fileNameFromPath(path),
+        path: path,
+        promptPath: metadata.shellPath.trim().isNotEmpty
+            ? metadata.shellPath.trim()
+            : path,
+        size: stat.size > 0 ? stat.size : null,
+        mimeType: metadata.mimeType.trim().isNotEmpty
+            ? metadata.mimeType.trim()
+            : _mimeTypeFromExtension(path),
+        isImage: _isImageFilePath(path, mimeType: metadata.mimeType),
+      );
+    } catch (error) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish
+            ? 'Failed to add file: $error'
+            : '添加文件失败：$error',
+      );
+    }
+  }
+
+  @override
+  Future<void> _sendRemoteWorkspaceFileToCurrentConversation(
+    CodexRemoteDirectoryEntry entry,
+  ) async {
+    if (!mounted) return;
+    if (entry.isDirectory) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish
+            ? 'Only files can be sent to the current chat'
+            : '只能发送文件到当前对话',
+      );
+      return;
+    }
+    final path = entry.path.trim();
+    if (path.isEmpty) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish ? 'File path is empty' : '文件路径为空',
+      );
+      return;
+    }
+    await _addWorkspacePathAttachmentToCurrentConversation(
+      name: entry.name.trim().isNotEmpty
+          ? entry.name.trim()
+          : _fileNameFromPath(path),
+      path: path,
+      promptPath: path,
+      mimeType: _mimeTypeFromExtension(path),
+      isImage: false,
+    );
+  }
+
+  Future<void> _addWorkspacePathAttachmentToCurrentConversation({
+    required String name,
+    required String path,
+    required String promptPath,
+    int? size,
+    String? mimeType,
+    bool isImage = false,
+  }) async {
+    if (!mounted) return;
+    final targetMode = _activeMode;
+    final attachments = _pendingAttachmentsByMode[targetMode]!;
+    final normalizedPath = path.trim();
+    final normalizedPromptPath = promptPath.trim();
+    final exists = attachments.any((item) {
+      if (item.path == normalizedPath) return true;
+      final itemPromptPath = item.promptPath?.trim();
+      return itemPromptPath != null &&
+          itemPromptPath.isNotEmpty &&
+          itemPromptPath == normalizedPromptPath;
+    });
+    if (exists) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish
+            ? 'File is already attached'
+            : '文件已添加到当前对话',
+      );
+      await _switchChatMode(ChatSurfaceMode.normal);
+      return;
+    }
+
+    setState(() {
+      attachments.add(
+        ChatInputAttachment(
+          id: '${normalizedPath}_${DateTime.now().microsecondsSinceEpoch}',
+          name: name.trim().isNotEmpty ? name.trim() : _fileNameFromPath(path),
+          path: normalizedPath,
+          size: size,
+          mimeType: mimeType,
+          isImage: isImage,
+          promptPath: normalizedPromptPath.isNotEmpty
+              ? normalizedPromptPath
+              : normalizedPath,
+        ),
+      );
+    });
+
+    await _switchChatMode(ChatSurfaceMode.normal);
+    if (!mounted) return;
+    _showSnackBar(
+      LegacyTextLocalizer.isEnglish
+          ? 'Added to current chat'
+          : '已添加到当前对话',
+    );
+  }
+
+  @override
+  String _messageTextWithLatestAttachmentPrompt(String text) {
+    final prompt = _latestUserAttachmentPathPrompt();
+    if (prompt.isEmpty) return text;
+    final trimmedText = text.trim();
+    if (trimmedText.isEmpty) return prompt;
+    return '$text\n$prompt';
+  }
+
+  String _latestUserAttachmentPathPrompt() {
+    for (final message in _messages) {
+      if (message.user != 1) continue;
+      final raw = message.content?['attachments'];
+      if (raw is! List) return '';
+      final lines = raw
+          .whereType<Map>()
+          .map(
+            (item) =>
+                item.map((key, value) => MapEntry(key.toString(), value)),
+          )
+          .map((attachment) {
+            final path = _attachmentPromptPath(attachment);
+            if (path.isEmpty) return '';
+            final rawName = attachment['name'];
+            final name = rawName is String ? rawName.trim() : '';
+            return name.isEmpty ? '- $path' : '- $name: $path';
+          })
+          .where((line) => line.isNotEmpty)
+          .toList();
+      if (lines.isEmpty) return '';
+      return '已添加到 workspace，可通过以下路径读取：\n${lines.join('\n')}';
+    }
+    return '';
+  }
+
+  String _attachmentPromptPath(Map<String, dynamic> attachment) {
+    final promptPath = attachment['promptPath']?.toString().trim() ?? '';
+    if (promptPath.isNotEmpty) return promptPath;
+    final workspacePath = attachment['workspacePath']?.toString().trim() ?? '';
+    if (workspacePath.isNotEmpty) return workspacePath;
+    if (_attachmentShouldSendToModel(attachment)) return '';
+    return attachment['path']?.toString().trim() ?? '';
+  }
+
+  @override
   void _removePendingAttachment(String id) {
     if (!mounted) return;
     setState(() {

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -43,8 +43,8 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
       ),
       conversation:
           conversation ??
-          runtime?.conversation ??
-          _currentConversationByMode[mode],
+          _currentConversationByMode[mode] ??
+          runtime?.conversation,
       isAiResponding:
           runtime?.isAiResponding ?? (_isAiRespondingByMode[mode] ?? false),
       isContextCompressing:

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -355,7 +355,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       conversation = null;
     }
 
-    final resolvedConversation = inMemoryConversation ?? conversation;
+    final resolvedConversation = conversation ?? inMemoryConversation;
     final resolvedMessages =
         inMemoryMessages ??
         await ConversationHistoryService.getConversationMessages(

--- a/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
@@ -43,7 +43,7 @@ mixin _ChatPageTerminalEnvMixin on _ChatPageStateBase {
   Future<void> _openTerminalEnvironmentEditor(
     BuildContext anchorContext,
   ) async {
-    if (_activeMode != ChatPageMode.normal) {
+    if (_activeMode == ChatPageMode.openclaw) {
       return;
     }
     if (_showSlashCommandPanel ||

--- a/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_terminal_env.dart
@@ -29,6 +29,9 @@ mixin _ChatPageTerminalEnvMixin on _ChatPageStateBase {
       setState(() {
         _terminalEnvironmentVariables = normalized;
       });
+      if (_activeMode == ChatPageMode.codex) {
+        unawaited(_refreshCodexStatus());
+      }
     } catch (error) {
       if (mounted) {
         showToast('保存环境变量失败: $error', type: ToastType.error);

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1570,6 +1570,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                               newConversationMode: _conversationModeForPageMode(
                                 _activeMode,
                               ),
+                              activeConversationId: _currentConversationId,
+                              activeConversationMode:
+                                  activeConversationModeValue,
                               onThreadTargetSelected:
                                   _handleEmbeddedDrawerThreadTargetSelected,
                             ),
@@ -1816,6 +1819,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                         newConversationMode: _conversationModeForPageMode(
                           _activeMode,
                         ),
+                        activeConversationId: _currentConversationId,
+                        activeConversationMode: activeConversationModeValue,
                       ),
                 onDrawerChanged: (isOpen) {
                   if (isHdPadLandscape) {

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -934,6 +934,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
           translucentSurfaces: AppBackgroundService.current.isActive,
           showBreadcrumbHeader: true,
           showHeaderTitle: false,
+          onSendFileToCurrentConversation:
+              _sendWorkspaceFileToCurrentConversation,
           onCanGoUpChanged: (canGoUp) {
             if (_workspaceBrowserCanGoUp == canGoUp || !mounted) return;
             setState(() {
@@ -972,6 +974,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
       translucentSurfaces: translucentSurfaces,
       showBreadcrumbHeader: true,
       showHeaderTitle: false,
+      onSendFileToCurrentConversation:
+          _sendRemoteWorkspaceFileToCurrentConversation,
       onCanGoUpChanged: (canGoUp) {
         if (_workspaceBrowserCanGoUp == canGoUp || !mounted) return;
         setState(() {
@@ -1491,6 +1495,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
           showHeaderTitle: false,
           enableInlineDirectoryExpansion: false,
           inlineFilePreview: true,
+          onSendFileToCurrentConversation:
+              _sendWorkspaceFileToCurrentConversation,
           onCanGoUpChanged: (canGoUp) {
             if (_workspaceBrowserCanGoUp == canGoUp || !mounted) return;
             setState(() {

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -567,15 +567,28 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           DateTime.now().millisecondsSinceEpoch;
       final updatedAt = newest?.createAt.millisecondsSinceEpoch ?? createdAt;
 
-      final recovered = ConversationModel(
-        id: conversationId,
+      final latestConversation = await ConversationService.getConversationById(
+        conversationId,
         mode: mode,
-        title: title,
-        summary: currentConversation?.summary,
-        status: currentConversation?.status ?? 0,
+        includeArchived: true,
+      );
+      final recoveredBase =
+          latestConversation ??
+          currentConversation ??
+          ConversationModel(
+            id: conversationId,
+            mode: mode,
+            title: title,
+            summary: currentConversation?.summary,
+            status: currentConversation?.status ?? 0,
+            lastMessage: lastText,
+            messageCount: savedMessages.length,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          );
+      final recovered = recoveredBase.copyWith(
         lastMessage: lastText,
         messageCount: savedMessages.length,
-        createdAt: createdAt,
         updatedAt: updatedAt,
       );
 
@@ -771,7 +784,14 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           );
         }
 
+        final latestConversation =
+            await ConversationService.getConversationById(
+              targetId,
+              mode: snapshotMode,
+              includeArchived: true,
+            );
         final baseConversation =
+            latestConversation ??
             snapshotConversation ??
             ConversationModel(
               id: targetId,

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -321,7 +321,11 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
       } catch (_) {
         conversation = null;
       }
-      final resolvedConversation = inMemoryConversation ?? conversation;
+      // Keep in-memory messages while taking the latest conversation metadata
+      // from storage. Drawer actions such as rename/pin update the stored
+      // conversation first; preferring the runtime copy here can rehydrate a
+      // stale title and later write it back during persistence.
+      final resolvedConversation = conversation ?? inMemoryConversation;
 
       if (resolvedConversation != null) {
         if (!_isConversationOperationCurrent(token)) {

--- a/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
+++ b/ui/lib/features/home/pages/chat/mixins/conversation_manager.dart
@@ -596,7 +596,10 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
         updatedAt: updatedAt,
       );
 
-      await ConversationService.updateConversation(recovered);
+      await ConversationService.updateConversation(
+        recovered,
+        preserveUserMetadata: true,
+      );
       if (!_isConversationOperationCurrent(token)) {
         return false;
       }
@@ -816,7 +819,10 @@ mixin ConversationManager<T extends StatefulWidget> on State<T> {
           updatedAt: now,
         );
 
-        await ConversationService.updateConversation(updatedConversation);
+        await ConversationService.updateConversation(
+          updatedConversation,
+          preserveUserMetadata: true,
+        );
 
         await _persistDeepThinkingCardsForConversation(
           targetId,

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -743,10 +743,17 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
             );
     }
 
+    final latestConversation = await ConversationService.getConversationById(
+      conversationId,
+      mode: conversationMode,
+      includeArchived: true,
+    );
+    final snapshotBase = snapshotConversation?.mode == conversationMode
+        ? snapshotConversation
+        : snapshotConversation?.copyWith(mode: conversationMode);
     final baseConversation =
-        (snapshotConversation?.mode == conversationMode
-            ? snapshotConversation
-            : snapshotConversation?.copyWith(mode: conversationMode)) ??
+        latestConversation ??
+        snapshotBase ??
         ConversationModel(
           id: conversationId,
           mode: conversationMode,

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -774,7 +774,10 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       updatedAt: now,
     );
 
-    await ConversationService.updateConversation(updatedConversation);
+    await ConversationService.updateConversation(
+      updatedConversation,
+      preserveUserMetadata: true,
+    );
     if (persistMessages) {
       await ConversationHistoryService.saveConversationMessages(
         conversationId,

--- a/ui/lib/features/home/pages/codex/codex_remote_workspace_browser.dart
+++ b/ui/lib/features/home/pages/codex/codex_remote_workspace_browser.dart
@@ -20,7 +20,14 @@ class _RemoteWorkspaceBreadcrumbSegment {
   final bool isCurrent;
 }
 
-enum _RemoteWorkspaceEntryAction { open, edit, rename, delete, copyPath }
+enum _RemoteWorkspaceEntryAction {
+  sendToCurrentConversation,
+  open,
+  edit,
+  rename,
+  delete,
+  copyPath,
+}
 
 class CodexRemoteWorkspaceBrowser extends StatefulWidget {
   const CodexRemoteWorkspaceBrowser({
@@ -33,6 +40,7 @@ class CodexRemoteWorkspaceBrowser extends StatefulWidget {
     this.onCanGoUpChanged,
     this.showBreadcrumbHeader = true,
     this.showHeaderTitle = false,
+    this.onSendFileToCurrentConversation,
   });
 
   final String workspacePath;
@@ -43,6 +51,8 @@ class CodexRemoteWorkspaceBrowser extends StatefulWidget {
   final ValueChanged<bool>? onCanGoUpChanged;
   final bool showBreadcrumbHeader;
   final bool showHeaderTitle;
+  final FutureOr<void> Function(CodexRemoteDirectoryEntry entry)?
+      onSendFileToCurrentConversation;
 
   @override
   State<CodexRemoteWorkspaceBrowser> createState() =>
@@ -225,6 +235,8 @@ class CodexRemoteWorkspaceBrowserState
   Future<void> _showEntryActionSheet(CodexRemoteDirectoryEntry entry) async {
     final palette = context.omniPalette;
     final isDirectory = entry.isDirectory;
+    final canSendToConversation =
+        !isDirectory && widget.onSendFileToCurrentConversation != null;
     final action = await showModalBottomSheet<_RemoteWorkspaceEntryAction>(
       context: context,
       backgroundColor: _surfaceColor(opacity: 0.92),
@@ -259,6 +271,16 @@ class CodexRemoteWorkspaceBrowserState
                   ),
                 ),
                 const SizedBox(height: 12),
+                if (canSendToConversation) ...[
+                  _buildActionTile(
+                    context: sheetContext,
+                    icon: Icons.add_comment_outlined,
+                    label: _isEnglish ? 'Send to chat' : '发送至对话',
+                    action:
+                        _RemoteWorkspaceEntryAction.sendToCurrentConversation,
+                  ),
+                  const SizedBox(height: 8),
+                ],
                 if (!isDirectory) ...[
                   _buildActionTile(
                     context: sheetContext,
@@ -324,6 +346,8 @@ class CodexRemoteWorkspaceBrowserState
     );
     if (!mounted || action == null) return;
     switch (action) {
+      case _RemoteWorkspaceEntryAction.sendToCurrentConversation:
+        await _sendEntryToCurrentConversation(entry);
       case _RemoteWorkspaceEntryAction.open:
         await _openFileEntry(entry);
       case _RemoteWorkspaceEntryAction.edit:
@@ -334,6 +358,30 @@ class CodexRemoteWorkspaceBrowserState
         await _confirmAndDeleteEntry(entry);
       case _RemoteWorkspaceEntryAction.copyPath:
         await _copyRemotePath(entry);
+    }
+  }
+
+  Future<void> _sendEntryToCurrentConversation(
+    CodexRemoteDirectoryEntry entry,
+  ) async {
+    final callback = widget.onSendFileToCurrentConversation;
+    if (callback == null) return;
+    if (entry.isDirectory) {
+      showToast(
+        _isEnglish
+            ? 'Only files can be sent to the current chat'
+            : '只能发送文件到当前对话',
+        type: ToastType.warning,
+      );
+      return;
+    }
+    try {
+      await callback(entry);
+    } catch (error) {
+      showToast(
+        _isEnglish ? 'Failed to send file: $error' : '发送文件失败：$error',
+        type: ToastType.error,
+      );
     }
   }
 

--- a/ui/lib/features/home/pages/codex/codex_sessions_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_sessions_page.dart
@@ -342,6 +342,7 @@ class _CodexSessionsPageState extends State<CodexSessionsPage> {
         remoteBridgeUrl: config.remoteBridgeUrl,
         remoteBridgeToken: config.remoteBridgeToken,
         remoteCwd: nextCwd,
+        contextInjectionEnabled: config.contextInjectionEnabled,
       );
       final status = await CodexAppServerService.status();
       if (!mounted) return;

--- a/ui/lib/features/home/pages/codex/codex_setting_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_setting_page.dart
@@ -906,8 +906,8 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                         Text(
                           _contextInjectionEnabled
                               ? _localeText(
-                                  zh: '已开启：Codex 每轮会收到 SOUL、长期记忆、今日短期记忆和终端变量名；变量值不会明文注入。',
-                                  en: 'Enabled: each Codex turn receives SOUL, long-term memory, today memory, and terminal variable names. Values are hidden.',
+                                  zh: '已开启：Codex 每轮会收到 SOUL、长期记忆、今日短期记忆、Skills 索引和终端变量名；变量值不会明文注入。',
+                                  en: 'Enabled: each Codex turn receives SOUL, memory, skills index, and terminal variable names. Values are hidden.',
                                 )
                               : _localeText(
                                   zh: '已关闭：Codex 使用干净上下文。',

--- a/ui/lib/features/home/pages/codex/codex_setting_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_setting_page.dart
@@ -39,11 +39,13 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
   bool _obscureApiKey = true;
   bool _obscureBridgeToken = true;
   bool _remoteEnabled = false;
+  bool _contextInjectionEnabled = false;
   String _codexHome = _defaultCodexHome;
   String _runtime = 'local';
   String? _error;
   String? _status;
   String? _lastSavedSignature;
+  String? _lastSavedConfigFieldsSignature;
 
   bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
   bool get _isDarkTheme => context.isDarkTheme;
@@ -122,12 +124,13 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       _setControllerText(_bridgeTokenController, config.remoteBridgeToken);
       _setControllerText(_bridgeCwdController, config.remoteCwd);
       _remoteEnabled = config.remoteEnabled;
+      _contextInjectionEnabled = config.contextInjectionEnabled;
     } finally {
       _isSyncing = false;
     }
   }
 
-  String _signature({
+  String _configFieldsSignature({
     required String baseUrl,
     required String model,
     required String apiKey,
@@ -147,6 +150,42 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     ].join('\n');
   }
 
+  String _signature({
+    required String baseUrl,
+    required String model,
+    required String apiKey,
+    required String remoteBridgeUrl,
+    required String remoteBridgeToken,
+    required String remoteCwd,
+    required bool remoteEnabled,
+    required bool contextInjectionEnabled,
+  }) {
+    return [
+      _configFieldsSignature(
+        baseUrl: baseUrl,
+        model: model,
+        apiKey: apiKey,
+        remoteBridgeUrl: remoteBridgeUrl,
+        remoteBridgeToken: remoteBridgeToken,
+        remoteCwd: remoteCwd,
+        remoteEnabled: remoteEnabled,
+      ),
+      contextInjectionEnabled ? 'context:on' : 'context:off',
+    ].join('\n');
+  }
+
+  String _currentConfigFieldsSignature() {
+    return _configFieldsSignature(
+      baseUrl: _baseUrlController.text,
+      model: _modelController.text,
+      apiKey: _apiKeyController.text,
+      remoteBridgeUrl: _bridgeUrlController.text,
+      remoteBridgeToken: _bridgeTokenController.text,
+      remoteCwd: _bridgeCwdController.text,
+      remoteEnabled: _remoteEnabled,
+    );
+  }
+
   String _currentSignature() {
     return _signature(
       baseUrl: _baseUrlController.text,
@@ -156,6 +195,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       remoteBridgeToken: _bridgeTokenController.text,
       remoteCwd: _bridgeCwdController.text,
       remoteEnabled: _remoteEnabled,
+      contextInjectionEnabled: _contextInjectionEnabled,
     );
   }
 
@@ -189,11 +229,22 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
 
   bool get _isRemoteIncomplete => _remoteEnabled && !_hasCompleteRemoteInput;
 
+  bool get _onlyContextInjectionChanged =>
+      _lastSavedConfigFieldsSignature != null &&
+      _currentConfigFieldsSignature() == _lastSavedConfigFieldsSignature &&
+      _currentSignature() != _lastSavedSignature;
+
+  bool get _canSaveCurrentConfig =>
+      !_isRemoteIncomplete && (_hasCompleteInput || _onlyContextInjectionChanged);
+
   void _handleEdited() {
     if (_isSyncing || !mounted) return;
     _saveDebounce?.cancel();
     final signature = _currentSignature();
-    final anyInput = _hasAnyLocalInput || _hasAnyRemoteInput || _remoteEnabled;
+    final anyInput = _hasAnyLocalInput ||
+        _hasAnyRemoteInput ||
+        _remoteEnabled ||
+        _contextInjectionEnabled;
     setState(() {
       _error = null;
       if (_isRemoteIncomplete) {
@@ -203,7 +254,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         );
       } else if (!anyInput) {
         _status = null;
-      } else if (!_hasCompleteInput) {
+      } else if (!_canSaveCurrentConfig) {
         _status = _localeText(
           zh: _remoteEnabled ? '填写完整后将自动保存。' : '本地配置填写完整后将自动保存。',
           en: _remoteEnabled
@@ -216,7 +267,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _status = _localeText(zh: '即将自动保存...', en: 'Autosave pending...');
       }
     });
-    if (_hasCompleteInput && signature != _lastSavedSignature) {
+    if (_canSaveCurrentConfig && signature != _lastSavedSignature) {
       _scheduleAutoSave();
     }
   }
@@ -236,9 +287,18 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
               en: 'Remote mode is disabled. Codex will use local Alpine.',
             );
     });
-    if (_hasCompleteInput && _currentSignature() != _lastSavedSignature) {
+    if (_canSaveCurrentConfig && _currentSignature() != _lastSavedSignature) {
       _scheduleAutoSave(delay: const Duration(milliseconds: 300));
     }
+  }
+
+  void _setContextInjectionEnabled(bool value) {
+    if (_contextInjectionEnabled == value) return;
+    setState(() {
+      _contextInjectionEnabled = value;
+      _error = null;
+    });
+    _handleEdited();
   }
 
   void _scheduleAutoSave({Duration delay = _autoSaveDelay}) {
@@ -264,6 +324,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _error = null;
         _status = null;
         _lastSavedSignature = _currentSignature();
+        _lastSavedConfigFieldsSignature = _currentConfigFieldsSignature();
       });
     } catch (error) {
       if (!mounted) return;
@@ -279,7 +340,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
 
   Future<void> _saveConfig() async {
     if (_isSaving) return;
-    if (_isRemoteIncomplete || !_hasCompleteInput) {
+    if (!_canSaveCurrentConfig) {
       if (!mounted) return;
       setState(() {
         _status = _isRemoteIncomplete
@@ -319,9 +380,10 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         remoteBridgeUrl: _bridgeUrlController.text.trim(),
         remoteBridgeToken: _bridgeTokenController.text.trim(),
         remoteCwd: _bridgeCwdController.text.trim(),
+        contextInjectionEnabled: _contextInjectionEnabled,
       );
       if (!mounted) return;
-      final savedSignature = _signature(
+      final savedConfigFieldsSignature = _configFieldsSignature(
         baseUrl: saved.baseUrl,
         model: saved.model,
         apiKey: saved.apiKey,
@@ -330,6 +392,16 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         remoteCwd: saved.remoteCwd,
         remoteEnabled: saved.remoteEnabled,
       );
+      final savedSignature = _signature(
+        baseUrl: saved.baseUrl,
+        model: saved.model,
+        apiKey: saved.apiKey,
+        remoteBridgeUrl: saved.remoteBridgeUrl,
+        remoteBridgeToken: saved.remoteBridgeToken,
+        remoteCwd: saved.remoteCwd,
+        remoteEnabled: saved.remoteEnabled,
+        contextInjectionEnabled: saved.contextInjectionEnabled,
+      );
       if (_currentSignature() == savingSignature) {
         _syncControllers(saved);
       }
@@ -337,6 +409,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _codexHome = saved.codexHome ?? _defaultCodexHome;
         _runtime = saved.runtime ?? 'local';
         _lastSavedSignature = savedSignature;
+        _lastSavedConfigFieldsSignature = savedConfigFieldsSignature;
         _error = null;
         _status = _currentSignature() == savedSignature
             ? _localeText(
@@ -361,7 +434,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     } finally {
       if (mounted) {
         setState(() => _isSaving = false);
-        if (_hasCompleteInput && _currentSignature() != savingSignature) {
+        if (_canSaveCurrentConfig && _currentSignature() != savingSignature) {
           _scheduleAutoSave(delay: const Duration(milliseconds: 300));
         }
       }
@@ -535,6 +608,36 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
               borderRadius: 28.75,
               value: _remoteEnabled,
               onToggle: _setRemoteEnabled,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContextInjectionSwitch() {
+    final palette = context.omniPalette;
+    final enabled = !_isSaving;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: enabled
+          ? () => _setContextInjectionEnabled(!_contextInjectionEnabled)
+          : null,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 12),
+        child: AbsorbPointer(
+          child: Opacity(
+            opacity: enabled ? 1 : 0.5,
+            child: FlutterSwitch(
+              width: 32,
+              height: 18.67,
+              toggleSize: 11.3,
+              padding: 3,
+              activeColor: palette.accentPrimary,
+              inactiveColor: palette.borderStrong,
+              borderRadius: 28.75,
+              value: _contextInjectionEnabled,
+              onToggle: _setContextInjectionEnabled,
             ),
           ),
         ),
@@ -777,6 +880,45 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                               ),
                             ),
                           ],
+                        ),
+                        const SizedBox(height: 14),
+                        Divider(height: 1, color: borderColor),
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _localeText(
+                                  zh: '注入 Omnibot 上下文',
+                                  en: 'Inject Omnibot Context',
+                                ),
+                                style: TextStyle(
+                                  color: _primaryTextColor,
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: 'PingFang SC',
+                                ),
+                              ),
+                            ),
+                            _buildContextInjectionSwitch(),
+                          ],
+                        ),
+                        Text(
+                          _contextInjectionEnabled
+                              ? _localeText(
+                                  zh: '已开启：Codex 每轮会收到 SOUL、长期记忆、今日短期记忆和终端变量名；变量值不会明文注入。',
+                                  en: 'Enabled: each Codex turn receives SOUL, long-term memory, today memory, and terminal variable names. Values are hidden.',
+                                )
+                              : _localeText(
+                                  zh: '已关闭：Codex 使用干净上下文。',
+                                  en: 'Disabled: Codex uses a clean context.',
+                                ),
+                          style: TextStyle(
+                            color: _secondaryTextColor,
+                            fontSize: 12,
+                            height: 1.35,
+                            fontFamily: 'PingFang SC',
+                          ),
                         ),
                         const SizedBox(height: 14),
                         Divider(height: 1, color: borderColor),

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -725,7 +725,10 @@ class _ChatBotSheetState extends State<ChatBotSheet>
           updatedAt: now,
         );
 
-        await ConversationService.updateConversation(updatedConversation);
+        await ConversationService.updateConversation(
+          updatedConversation,
+          preserveUserMetadata: true,
+        );
         _currentConversation = updatedConversation;
         for (final message in _messages.where((item) {
           final cardData = item.cardData;

--- a/ui/lib/features/home/pages/omnibot_workspace/widgets/omnibot_workspace_browser.dart
+++ b/ui/lib/features/home/pages/omnibot_workspace/widgets/omnibot_workspace_browser.dart
@@ -27,7 +27,13 @@ class _WorkspaceBreadcrumbSegment {
   final bool isFile;
 }
 
-enum _WorkspaceEntryAction { edit, rename, delete, unmount }
+enum _WorkspaceEntryAction {
+  sendToCurrentConversation,
+  edit,
+  rename,
+  delete,
+  unmount,
+}
 
 class _WorkspaceDragPayload {
   const _WorkspaceDragPayload({
@@ -49,6 +55,8 @@ class OmnibotWorkspaceBrowser extends StatefulWidget {
   final bool showHeaderTitle;
   final bool enableInlineDirectoryExpansion;
   final bool inlineFilePreview;
+  final FutureOr<void> Function(OmnibotResourceMetadata metadata)?
+      onSendFileToCurrentConversation;
 
   const OmnibotWorkspaceBrowser({
     super.key,
@@ -61,6 +69,7 @@ class OmnibotWorkspaceBrowser extends StatefulWidget {
     this.showHeaderTitle = true,
     this.enableInlineDirectoryExpansion = true,
     this.inlineFilePreview = false,
+    this.onSendFileToCurrentConversation,
   });
 
   @override
@@ -1234,6 +1243,9 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
     final name = _entryNameFromPath(entry.path);
     final mountEntry = _workspaceMountEntryFor(entry);
     final editable = _canEditEntry(entry);
+    final canSendToConversation =
+        widget.onSendFileToCurrentConversation != null &&
+        FileSystemEntity.typeSync(entry.path) == FileSystemEntityType.file;
     final action = await showModalBottomSheet<_WorkspaceEntryAction>(
       context: context,
       backgroundColor: _surfaceColor(opacity: 0.92),
@@ -1281,6 +1293,30 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
                   ),
                 ),
                 const SizedBox(height: 12),
+                if (canSendToConversation) ...[
+                  ListTile(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    tileColor: _secondarySurfaceColor(),
+                    leading: Icon(
+                      Icons.add_comment_outlined,
+                      color: palette.textPrimary,
+                    ),
+                    title: Text(
+                      _isEnglish ? 'Send to chat' : '发送至对话',
+                      style: TextStyle(
+                        color: palette.textPrimary,
+                        fontWeight: FontWeight.w600,
+                        fontFamily: 'PingFang SC',
+                      ),
+                    ),
+                    onTap: () => Navigator.of(sheetContext).pop(
+                      _WorkspaceEntryAction.sendToCurrentConversation,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                ],
                 if (mountEntry == null && editable) ...[
                   ListTile(
                     shape: RoundedRectangleBorder(
@@ -1382,6 +1418,10 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
     );
 
     if (!mounted || action == null) return;
+    if (action == _WorkspaceEntryAction.sendToCurrentConversation) {
+      await _sendEntryToCurrentConversation(entry);
+      return;
+    }
     if (action == _WorkspaceEntryAction.unmount) {
       if (mountEntry != null) {
         await _confirmAndUnmountWorkspaceMount(mountEntry);
@@ -1397,6 +1437,36 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
       return;
     }
     await _confirmAndDeleteEntry(entry);
+  }
+
+  Future<void> _sendEntryToCurrentConversation(FileSystemEntity entry) async {
+    final callback = widget.onSendFileToCurrentConversation;
+    if (callback == null) return;
+
+    final path = _normalizePath(entry.path);
+    if (FileSystemEntity.typeSync(path) != FileSystemEntityType.file) {
+      showToast(
+        _isEnglish
+            ? 'Only files can be sent to the current chat'
+            : '只能发送文件到当前对话',
+        type: ToastType.warning,
+      );
+      return;
+    }
+
+    try {
+      await callback(
+        OmnibotResourceService.describePath(
+          path,
+          title: _entryNameFromPath(path),
+        ),
+      );
+    } catch (error) {
+      showToast(
+        _isEnglish ? 'Failed to send file: $error' : '发送文件失败：$error',
+        type: ToastType.error,
+      );
+    }
   }
 
   bool _canEditEntry(FileSystemEntity entry) {

--- a/ui/lib/features/home/widgets/home_drawer.dart
+++ b/ui/lib/features/home/widgets/home_drawer.dart
@@ -88,6 +88,8 @@ class HomeDrawer extends ConsumerStatefulWidget {
     this.newConversationMode = ConversationMode.normal,
     this.embedded = false,
     this.closeOnNavigate = true,
+    this.activeConversationId,
+    this.activeConversationMode,
     this.onThreadTargetSelected,
   });
 
@@ -95,6 +97,8 @@ class HomeDrawer extends ConsumerStatefulWidget {
   final ConversationMode newConversationMode;
   final bool embedded;
   final bool closeOnNavigate;
+  final int? activeConversationId;
+  final ConversationMode? activeConversationMode;
   final ValueChanged<ConversationThreadTarget>? onThreadTargetSelected;
 
   @override

--- a/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
+++ b/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
@@ -658,6 +658,28 @@ extension _HomeDrawerConversationList on HomeDrawerState {
         : palette.accentPrimary.withValues(alpha: 0.045);
   }
 
+  bool _isActiveConversation(ConversationModel conversation) {
+    final activeConversationId = widget.activeConversationId;
+    final activeConversationMode = widget.activeConversationMode;
+    return activeConversationId != null &&
+        conversation.id == activeConversationId &&
+        (activeConversationMode == null ||
+            conversation.mode == activeConversationMode);
+  }
+
+  Color get _activeConversationBackgroundColor {
+    final palette = context.omniPalette;
+    return context.isDarkTheme
+        ? Color.lerp(palette.surfaceSecondary, palette.accentPrimary, 0.22)!
+        : palette.accentPrimary.withValues(alpha: 0.1);
+  }
+
+  Color get _activeConversationBorderColor {
+    return context.omniPalette.accentPrimary.withValues(
+      alpha: context.isDarkTheme ? 0.38 : 0.24,
+    );
+  }
+
   Widget _buildScheduledConversationGroup(
     _ScheduledConversationGroup group, {
     required bool showDivider,
@@ -720,6 +742,8 @@ extension _HomeDrawerConversationList on HomeDrawerState {
     final childCount = group.children.length;
     final countText = childCount > 0 ? '$childCount' : '${group.taskCount}';
     final isEditing = _editingThreadKey == group.parent.threadKey;
+    final isActive = _isActiveConversation(group.parent);
+    final itemRadius = BorderRadius.circular(8);
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -727,60 +751,99 @@ extension _HomeDrawerConversationList on HomeDrawerState {
             ? null
             : () => _openConversationFromDrawer(group.parent),
         onLongPress: isEditing ? null : () => _startEditingTitle(group.parent),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: itemRadius,
         splashColor: palette.accentPrimary.withValues(alpha: 0.08),
         highlightColor: Colors.transparent,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(4, 8, 2, 8),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: onToggle,
-                child: SizedBox(
-                  width: 24,
-                  height: 24,
-                  child: Center(
-                    child: AnimatedRotation(
-                      turns: expanded ? 0 : -0.25,
-                      duration: HomeDrawerState._sectionToggleDuration,
-                      curve: Curves.easeInOutCubicEmphasized,
-                      child: SvgPicture.asset(
-                        'assets/common/chevron-down.svg',
-                        width: 16,
-                        height: 16,
-                        colorFilter: ColorFilter.mode(
-                          palette.textTertiary,
-                          BlendMode.srcIn,
-                        ),
-                      ),
+        child: Semantics(
+          selected: isActive,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            curve: Curves.easeOutCubic,
+            decoration: BoxDecoration(
+              color: isActive
+                  ? _activeConversationBackgroundColor
+                  : Colors.transparent,
+              borderRadius: itemRadius,
+              border: Border.all(
+                color: isActive
+                    ? _activeConversationBorderColor
+                    : Colors.transparent,
+              ),
+            ),
+            child: Stack(
+              children: [
+                Positioned(
+                  left: 0,
+                  top: 8,
+                  bottom: 8,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 160),
+                    curve: Curves.easeOutCubic,
+                    width: 3,
+                    decoration: BoxDecoration(
+                      color: isActive
+                          ? palette.accentPrimary
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(999),
                     ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 2),
-              Expanded(
-                child: _buildEditableConversationTitle(
-                  title: title,
-                  isEditing: isEditing,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                countText,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: AppFontEffectScope.resolveNonChatWeight(
-                    context,
-                    FontWeight.w500,
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 8, 6, 8),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: onToggle,
+                        child: SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: Center(
+                            child: AnimatedRotation(
+                              turns: expanded ? 0 : -0.25,
+                              duration: HomeDrawerState._sectionToggleDuration,
+                              curve: Curves.easeInOutCubicEmphasized,
+                              child: SvgPicture.asset(
+                                'assets/common/chevron-down.svg',
+                                width: 16,
+                                height: 16,
+                                colorFilter: ColorFilter.mode(
+                                  palette.textTertiary,
+                                  BlendMode.srcIn,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 2),
+                      Expanded(
+                        child: _buildEditableConversationTitle(
+                          title: title,
+                          isEditing: isEditing,
+                          fontWeight: FontWeight.w600,
+                          isActive: isActive,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        countText,
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: AppFontEffectScope.resolveNonChatWeight(
+                            context,
+                            FontWeight.w500,
+                          ),
+                          color: palette.textTertiary,
+                          fontFamily: 'PingFang SC',
+                        ),
+                      ),
+                    ],
                   ),
-                  color: palette.textTertiary,
-                  fontFamily: 'PingFang SC',
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -996,6 +1059,8 @@ extension _HomeDrawerConversationList on HomeDrawerState {
     final title = _resolveConversationTitle(conversation);
     final showArchivedBadge = _isSearchActive && conversation.isArchived;
     final isEditing = _editingThreadKey == conversation.threadKey;
+    final isActive = _isActiveConversation(conversation);
+    final itemRadius = BorderRadius.circular(10);
 
     return ConversationSlidable(
       itemKey: conversation.threadKey,
@@ -1020,51 +1085,92 @@ extension _HomeDrawerConversationList on HomeDrawerState {
               onLongPress: isEditing
                   ? null
                   : () => _startEditingTitle(conversation),
-              borderRadius: BorderRadius.circular(14),
+              borderRadius: itemRadius,
               splashColor: context.omniPalette.accentPrimary.withValues(
                 alpha: 0.08,
               ),
               highlightColor: Colors.transparent,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(4, 9, 2, 9),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: _buildEditableConversationTitle(
-                            title: title,
-                            isEditing: isEditing,
+              child: Semantics(
+                selected: isActive,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 160),
+                  curve: Curves.easeOutCubic,
+                  decoration: BoxDecoration(
+                    color: isActive
+                        ? _activeConversationBackgroundColor
+                        : Colors.transparent,
+                    borderRadius: itemRadius,
+                    border: Border.all(
+                      color: isActive
+                          ? _activeConversationBorderColor
+                          : Colors.transparent,
+                    ),
+                  ),
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        left: 0,
+                        top: 9,
+                        bottom: 9,
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 160),
+                          curve: Curves.easeOutCubic,
+                          width: 3,
+                          decoration: BoxDecoration(
+                            color: isActive
+                                ? context.omniPalette.accentPrimary
+                                : Colors.transparent,
+                            borderRadius: BorderRadius.circular(999),
                           ),
                         ),
-                        if (showArchivedBadge) ...[
-                          const SizedBox(width: 10),
-                          _buildArchivedBadge(),
-                        ],
-                      ],
-                    ),
-                    _buildConversationImagePreviewStrip(conversation),
-                    if (_isSearchActive && result.matchedPreview != null) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        result.matchedPreview!,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: AppFontEffectScope.resolveNonChatWeight(
-                            context,
-                            FontWeight.w400,
-                          ),
-                          color: _drawerSecondaryTextColor,
-                          height: 1.4,
-                          fontFamily: 'PingFang SC',
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(8, 9, 6, 9),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Expanded(
+                                  child: _buildEditableConversationTitle(
+                                    title: title,
+                                    isEditing: isEditing,
+                                    isActive: isActive,
+                                  ),
+                                ),
+                                if (showArchivedBadge) ...[
+                                  const SizedBox(width: 10),
+                                  _buildArchivedBadge(),
+                                ],
+                              ],
+                            ),
+                            _buildConversationImagePreviewStrip(conversation),
+                            if (_isSearchActive &&
+                                result.matchedPreview != null) ...[
+                              const SizedBox(height: 4),
+                              Text(
+                                result.matchedPreview!,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: AppFontEffectScope
+                                      .resolveNonChatWeight(
+                                    context,
+                                    FontWeight.w400,
+                                  ),
+                                  color: _drawerSecondaryTextColor,
+                                  height: 1.4,
+                                  fontFamily: 'PingFang SC',
+                                ),
+                              ),
+                            ],
+                          ],
                         ),
                       ),
                     ],
-                  ],
+                  ),
                 ),
               ),
             ),
@@ -1079,7 +1185,11 @@ extension _HomeDrawerConversationList on HomeDrawerState {
     required String title,
     required bool isEditing,
     FontWeight fontWeight = FontWeight.w500,
+    bool isActive = false,
   }) {
+    final titleColor = isActive
+        ? context.omniPalette.accentPrimary
+        : _drawerTextColor;
     if (isEditing) {
       return TextField(
         controller: _titleEditingController,
@@ -1093,7 +1203,7 @@ extension _HomeDrawerConversationList on HomeDrawerState {
             context,
             fontWeight,
           ),
-          color: _drawerTextColor,
+          color: titleColor,
           height: 1.35,
           fontFamily: 'PingFang SC',
         ),
@@ -1122,7 +1232,7 @@ extension _HomeDrawerConversationList on HomeDrawerState {
           context,
           fontWeight,
         ),
-        color: _drawerTextColor,
+        color: titleColor,
         height: 1.35,
         fontFamily: 'PingFang SC',
       ),

--- a/ui/lib/services/codex_app_server_service.dart
+++ b/ui/lib/services/codex_app_server_service.dart
@@ -76,6 +76,7 @@ class CodexLocalConfig {
     this.remoteCwd = '',
     this.remoteConfigured = false,
     this.runtime,
+    this.contextInjectionEnabled = false,
   });
 
   final String baseUrl;
@@ -88,6 +89,7 @@ class CodexLocalConfig {
   final String remoteCwd;
   final bool remoteConfigured;
   final String? runtime;
+  final bool contextInjectionEnabled;
 
   factory CodexLocalConfig.fromMap(Map<dynamic, dynamic>? map) {
     final source = map ?? const <dynamic, dynamic>{};
@@ -102,6 +104,7 @@ class CodexLocalConfig {
       remoteCwd: _stringOrNull(source['remoteCwd']) ?? '',
       remoteConfigured: source['remoteConfigured'] == true,
       runtime: _stringOrNull(source['runtime']),
+      contextInjectionEnabled: source['contextInjectionEnabled'] == true,
     );
   }
 }
@@ -438,6 +441,7 @@ class CodexAppServerService {
     String remoteBridgeUrl = '',
     String remoteBridgeToken = '',
     String remoteCwd = '',
+    bool? contextInjectionEnabled,
   }) async {
     final result = await _invokeMap('config/local/write', {
       'baseUrl': baseUrl.trim(),
@@ -447,6 +451,8 @@ class CodexAppServerService {
       'remoteBridgeUrl': remoteBridgeUrl.trim(),
       'remoteBridgeToken': remoteBridgeToken.trim(),
       'remoteCwd': remoteCwd.trim(),
+      if (contextInjectionEnabled != null)
+        'contextInjectionEnabled': contextInjectionEnabled,
     });
     return CodexLocalConfig.fromMap(result);
   }

--- a/ui/lib/services/conversation_service.dart
+++ b/ui/lib/services/conversation_service.dart
@@ -128,6 +128,23 @@ class ConversationService {
     }
   }
 
+  static Future<ConversationModel?> getConversationById(
+    int conversationId, {
+    ConversationMode? mode,
+    bool includeArchived = false,
+  }) async {
+    final conversations = await getAllConversations(
+      includeArchived: includeArchived,
+    );
+    for (final conversation in conversations) {
+      if (conversation.id == conversationId &&
+          (mode == null || conversation.mode == mode)) {
+        return conversation;
+      }
+    }
+    return null;
+  }
+
   static Future<bool> updateConversationPromptTokenThreshold({
     required int conversationId,
     required int promptTokenThreshold,
@@ -283,15 +300,10 @@ class ConversationService {
     int conversationId, {
     bool includeArchived = false,
   }) async {
-    final conversations = await getAllConversations(
+    return getConversationById(
+      conversationId,
       includeArchived: includeArchived,
     );
-    for (final conversation in conversations) {
-      if (conversation.id == conversationId) {
-        return conversation;
-      }
-    }
-    return null;
   }
 
   static Future<List<ConversationModel>> _filterHiddenCodexConversations(
@@ -352,6 +364,19 @@ class ConversationService {
           conversationId: conversationId,
           name: newTitle,
         );
+        final localConversation = await getConversationById(
+          conversationId,
+          mode: mode,
+          includeArchived: true,
+        );
+        if (localConversation != null) {
+          final localUpdated = await updateConversation(
+            localConversation.copyWith(title: newTitle),
+          );
+          if (!localUpdated) {
+            debugPrint('同步 Codex 本地对话标题失败');
+          }
+        }
         return true;
       } catch (e) {
         debugPrint('更新 Codex 对话标题失败: $e');

--- a/ui/lib/services/conversation_service.dart
+++ b/ui/lib/services/conversation_service.dart
@@ -112,11 +112,18 @@ class ConversationService {
     }
   }
 
-  static Future<bool> updateConversation(ConversationModel conversation) async {
+  static Future<bool> updateConversation(
+    ConversationModel conversation, {
+    bool preserveUserMetadata = false,
+  }) async {
     try {
       final result = await _assistCore.invokeMethod<dynamic>(
         'updateConversation',
-        {'conversation': conversation.toJson()},
+        {
+          'conversation': conversation.toJson(),
+          if (preserveUserMetadata)
+            'preserveUserMetadata': preserveUserMetadata,
+        },
       );
       return result == 'SUCCESS';
     } on PlatformException catch (e) {

--- a/ui/test/services/codex_app_server_service_test.dart
+++ b/ui/test/services/codex_app_server_service_test.dart
@@ -128,6 +128,7 @@ void main() {
         'model': 'gpt-5.5',
         'apiKey': 'key',
         'codexHome': '/root/.codex',
+        'contextInjectionEnabled': true,
       };
     });
 
@@ -136,12 +137,15 @@ void main() {
       baseUrl: ' https://example.com/v1 ',
       model: ' gpt-5.5 ',
       apiKey: ' key ',
+      contextInjectionEnabled: true,
     );
 
     expect(read.baseUrl, 'https://example.com/v1');
     expect(read.model, 'gpt-5.5');
     expect(read.apiKey, 'key');
+    expect(read.contextInjectionEnabled, isTrue);
     expect(written.codexHome, '/root/.codex');
+    expect(written.contextInjectionEnabled, isTrue);
     expect(calls.map((call) => call.method), [
       'config/local/read',
       'config/local/write',
@@ -154,6 +158,7 @@ void main() {
       'remoteBridgeUrl': '',
       'remoteBridgeToken': '',
       'remoteCwd': '',
+      'contextInjectionEnabled': true,
     });
   });
 


### PR DESCRIPTION
## 变更内容

- 在 Codex 配置中增加上下文注入能力，可按开关注入长期记忆、短期记忆和终端环境变量。
- 补齐 Codex 模式下的终端环境变量编辑入口，并优化 skills / workspace 相关上下文读取。
- 修复会话列表中重命名、置顶等元数据在继续对话后被运行时快照覆盖的问题，并增加当前会话高亮。
- 在聊天页工作目录文件长按菜单中增加“发送至对话”，支持本地工作目录与 Codex 远程工作目录，将文件快速加入当前 Agent/Codex 对话附件。
- Codex 发送消息时会把已添加的 workspace 文件路径注入本次 turn，确保模型能实际读取到对应路径。
- 增加 fork 内用于验证 debug APK 的 GitHub Actions 工作流。

## 验证

- `git diff --check` 通过。
- GitHub Actions `Build Debug APK` 构建通过： https://github.com/lwz762/OpenOmniBot/actions/runs/27500659532
- 已下载并本地安装验证用的 APK：`OpenOmniBot-codex-context-workspace-send-file-to-chat-debug.apk`