### PR TITLE
支持工作目录文件发送至对话

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -1942,6 +1942,16 @@ abstract class _ChatPageStateBase extends State<ChatPage>
 
   Future<void> _pickAttachments();
 
+  Future<void> _sendWorkspaceFileToCurrentConversation(
+    OmnibotResourceMetadata metadata,
+  );
+
+  Future<void> _sendRemoteWorkspaceFileToCurrentConversation(
+    CodexRemoteDirectoryEntry entry,
+  );
+
+  String _messageTextWithLatestAttachmentPrompt(String text);
+
   void _removePendingAttachment(String id);
 
   String _fileNameFromPath(String path);

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -918,10 +918,11 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
           });
         }
       }
+      final turnText = _messageTextWithLatestAttachmentPrompt(messageText);
       final response = await CodexAppServerService.startTurn(
         conversationId: remoteCodex ? null : resolvedConversationId,
         threadId: _activeCodexThreadId,
-        text: messageText,
+        text: turnText,
         approvalPolicy: _codexPermissionMode.approvalPolicy,
         approvalsReviewer: _codexPermissionMode.approvalsReviewer,
         sandboxPolicy: _codexPermissionMode.sandboxPolicy,

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -256,6 +256,174 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
   }
 
   @override
+  Future<void> _sendWorkspaceFileToCurrentConversation(
+    OmnibotResourceMetadata metadata,
+  ) async {
+    if (!mounted) return;
+    final path = metadata.path.trim();
+    if (path.isEmpty || metadata.isDirectory || !File(path).existsSync()) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish ? 'File not found' : '文件不存在',
+      );
+      return;
+    }
+
+    try {
+      final stat = await File(path).stat();
+      await _addWorkspacePathAttachmentToCurrentConversation(
+        name: metadata.title.trim().isNotEmpty
+            ? metadata.title.trim()
+            : _fileNameFromPath(path),
+        path: path,
+        promptPath: metadata.shellPath.trim().isNotEmpty
+            ? metadata.shellPath.trim()
+            : path,
+        size: stat.size > 0 ? stat.size : null,
+        mimeType: metadata.mimeType.trim().isNotEmpty
+            ? metadata.mimeType.trim()
+            : _mimeTypeFromExtension(path),
+        isImage: _isImageFilePath(path, mimeType: metadata.mimeType),
+      );
+    } catch (error) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish
+            ? 'Failed to add file: $error'
+            : '添加文件失败：$error',
+      );
+    }
+  }
+
+  @override
+  Future<void> _sendRemoteWorkspaceFileToCurrentConversation(
+    CodexRemoteDirectoryEntry entry,
+  ) async {
+    if (!mounted) return;
+    if (entry.isDirectory) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish
+            ? 'Only files can be sent to the current chat'
+            : '只能发送文件到当前对话',
+      );
+      return;
+    }
+    final path = entry.path.trim();
+    if (path.isEmpty) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish ? 'File path is empty' : '文件路径为空',
+      );
+      return;
+    }
+    await _addWorkspacePathAttachmentToCurrentConversation(
+      name: entry.name.trim().isNotEmpty
+          ? entry.name.trim()
+          : _fileNameFromPath(path),
+      path: path,
+      promptPath: path,
+      mimeType: _mimeTypeFromExtension(path),
+      isImage: false,
+    );
+  }
+
+  Future<void> _addWorkspacePathAttachmentToCurrentConversation({
+    required String name,
+    required String path,
+    required String promptPath,
+    int? size,
+    String? mimeType,
+    bool isImage = false,
+  }) async {
+    if (!mounted) return;
+    final targetMode = _activeMode;
+    final attachments = _pendingAttachmentsByMode[targetMode]!;
+    final normalizedPath = path.trim();
+    final normalizedPromptPath = promptPath.trim();
+    final exists = attachments.any((item) {
+      if (item.path == normalizedPath) return true;
+      final itemPromptPath = item.promptPath?.trim();
+      return itemPromptPath != null &&
+          itemPromptPath.isNotEmpty &&
+          itemPromptPath == normalizedPromptPath;
+    });
+    if (exists) {
+      _showSnackBar(
+        LegacyTextLocalizer.isEnglish
+            ? 'File is already attached'
+            : '文件已添加到当前对话',
+      );
+      await _switchChatMode(ChatSurfaceMode.normal);
+      return;
+    }
+
+    setState(() {
+      attachments.add(
+        ChatInputAttachment(
+          id: '${normalizedPath}_${DateTime.now().microsecondsSinceEpoch}',
+          name: name.trim().isNotEmpty ? name.trim() : _fileNameFromPath(path),
+          path: normalizedPath,
+          size: size,
+          mimeType: mimeType,
+          isImage: isImage,
+          promptPath: normalizedPromptPath.isNotEmpty
+              ? normalizedPromptPath
+              : normalizedPath,
+        ),
+      );
+    });
+
+    await _switchChatMode(ChatSurfaceMode.normal);
+    if (!mounted) return;
+    _showSnackBar(
+      LegacyTextLocalizer.isEnglish
+          ? 'Added to current chat'
+          : '已添加到当前对话',
+    );
+  }
+
+  @override
+  String _messageTextWithLatestAttachmentPrompt(String text) {
+    final prompt = _latestUserAttachmentPathPrompt();
+    if (prompt.isEmpty) return text;
+    final trimmedText = text.trim();
+    if (trimmedText.isEmpty) return prompt;
+    return '$text\n$prompt';
+  }
+
+  String _latestUserAttachmentPathPrompt() {
+    for (final message in _messages) {
+      if (message.user != 1) continue;
+      final raw = message.content?['attachments'];
+      if (raw is! List) return '';
+      final lines = raw
+          .whereType<Map>()
+          .map(
+            (item) =>
+                item.map((key, value) => MapEntry(key.toString(), value)),
+          )
+          .map((attachment) {
+            final path = _attachmentPromptPath(attachment);
+            if (path.isEmpty) return '';
+            final rawName = attachment['name'];
+            final name = rawName is String ? rawName.trim() : '';
+            return name.isEmpty ? '- $path' : '- $name: $path';
+          })
+          .where((line) => line.isNotEmpty)
+          .toList();
+      if (lines.isEmpty) return '';
+      return '已添加到 workspace，可通过以下路径读取：\n${lines.join('\n')}';
+    }
+    return '';
+  }
+
+  String _attachmentPromptPath(Map<String, dynamic> attachment) {
+    final promptPath = attachment['promptPath']?.toString().trim() ?? '';
+    if (promptPath.isNotEmpty) return promptPath;
+    final workspacePath = attachment['workspacePath']?.toString().trim() ?? '';
+    if (workspacePath.isNotEmpty) return workspacePath;
+    if (_attachmentShouldSendToModel(attachment)) return '';
+    return attachment['path']?.toString().trim() ?? '';
+  }
+
+  @override
   void _removePendingAttachment(String id) {
     if (!mounted) return;
     setState(() {

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -934,6 +934,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
           translucentSurfaces: AppBackgroundService.current.isActive,
           showBreadcrumbHeader: true,
           showHeaderTitle: false,
+          onSendFileToCurrentConversation:
+              _sendWorkspaceFileToCurrentConversation,
           onCanGoUpChanged: (canGoUp) {
             if (_workspaceBrowserCanGoUp == canGoUp || !mounted) return;
             setState(() {
@@ -972,6 +974,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
       translucentSurfaces: translucentSurfaces,
       showBreadcrumbHeader: true,
       showHeaderTitle: false,
+      onSendFileToCurrentConversation:
+          _sendRemoteWorkspaceFileToCurrentConversation,
       onCanGoUpChanged: (canGoUp) {
         if (_workspaceBrowserCanGoUp == canGoUp || !mounted) return;
         setState(() {
@@ -1485,6 +1489,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
           showHeaderTitle: false,
           enableInlineDirectoryExpansion: false,
           inlineFilePreview: true,
+          onSendFileToCurrentConversation:
+              _sendWorkspaceFileToCurrentConversation,
           onCanGoUpChanged: (canGoUp) {
             if (_workspaceBrowserCanGoUp == canGoUp || !mounted) return;
             setState(() {

--- a/ui/lib/features/home/pages/codex/codex_remote_workspace_browser.dart
+++ b/ui/lib/features/home/pages/codex/codex_remote_workspace_browser.dart
@@ -20,7 +20,14 @@ class _RemoteWorkspaceBreadcrumbSegment {
   final bool isCurrent;
 }
 
-enum _RemoteWorkspaceEntryAction { open, edit, rename, delete, copyPath }
+enum _RemoteWorkspaceEntryAction {
+  sendToCurrentConversation,
+  open,
+  edit,
+  rename,
+  delete,
+  copyPath,
+}
 
 class CodexRemoteWorkspaceBrowser extends StatefulWidget {
   const CodexRemoteWorkspaceBrowser({
@@ -33,6 +40,7 @@ class CodexRemoteWorkspaceBrowser extends StatefulWidget {
     this.onCanGoUpChanged,
     this.showBreadcrumbHeader = true,
     this.showHeaderTitle = false,
+    this.onSendFileToCurrentConversation,
   });
 
   final String workspacePath;
@@ -43,6 +51,8 @@ class CodexRemoteWorkspaceBrowser extends StatefulWidget {
   final ValueChanged<bool>? onCanGoUpChanged;
   final bool showBreadcrumbHeader;
   final bool showHeaderTitle;
+  final FutureOr<void> Function(CodexRemoteDirectoryEntry entry)?
+      onSendFileToCurrentConversation;
 
   @override
   State<CodexRemoteWorkspaceBrowser> createState() =>
@@ -225,6 +235,8 @@ class CodexRemoteWorkspaceBrowserState
   Future<void> _showEntryActionSheet(CodexRemoteDirectoryEntry entry) async {
     final palette = context.omniPalette;
     final isDirectory = entry.isDirectory;
+    final canSendToConversation =
+        !isDirectory && widget.onSendFileToCurrentConversation != null;
     final action = await showModalBottomSheet<_RemoteWorkspaceEntryAction>(
       context: context,
       backgroundColor: _surfaceColor(opacity: 0.92),
@@ -259,6 +271,16 @@ class CodexRemoteWorkspaceBrowserState
                   ),
                 ),
                 const SizedBox(height: 12),
+                if (canSendToConversation) ...[
+                  _buildActionTile(
+                    context: sheetContext,
+                    icon: Icons.add_comment_outlined,
+                    label: _isEnglish ? 'Send to chat' : '发送至对话',
+                    action:
+                        _RemoteWorkspaceEntryAction.sendToCurrentConversation,
+                  ),
+                  const SizedBox(height: 8),
+                ],
                 if (!isDirectory) ...[
                   _buildActionTile(
                     context: sheetContext,
@@ -324,6 +346,8 @@ class CodexRemoteWorkspaceBrowserState
     );
     if (!mounted || action == null) return;
     switch (action) {
+      case _RemoteWorkspaceEntryAction.sendToCurrentConversation:
+        await _sendEntryToCurrentConversation(entry);
       case _RemoteWorkspaceEntryAction.open:
         await _openFileEntry(entry);
       case _RemoteWorkspaceEntryAction.edit:
@@ -334,6 +358,30 @@ class CodexRemoteWorkspaceBrowserState
         await _confirmAndDeleteEntry(entry);
       case _RemoteWorkspaceEntryAction.copyPath:
         await _copyRemotePath(entry);
+    }
+  }
+
+  Future<void> _sendEntryToCurrentConversation(
+    CodexRemoteDirectoryEntry entry,
+  ) async {
+    final callback = widget.onSendFileToCurrentConversation;
+    if (callback == null) return;
+    if (entry.isDirectory) {
+      showToast(
+        _isEnglish
+            ? 'Only files can be sent to the current chat'
+            : '只能发送文件到当前对话',
+        type: ToastType.warning,
+      );
+      return;
+    }
+    try {
+      await callback(entry);
+    } catch (error) {
+      showToast(
+        _isEnglish ? 'Failed to send file: $error' : '发送文件失败：$error',
+        type: ToastType.error,
+      );
     }
   }
 

--- a/ui/lib/features/home/pages/omnibot_workspace/widgets/omnibot_workspace_browser.dart
+++ b/ui/lib/features/home/pages/omnibot_workspace/widgets/omnibot_workspace_browser.dart
@@ -27,7 +27,13 @@ class _WorkspaceBreadcrumbSegment {
   final bool isFile;
 }
 
-enum _WorkspaceEntryAction { edit, rename, delete, unmount }
+enum _WorkspaceEntryAction {
+  sendToCurrentConversation,
+  edit,
+  rename,
+  delete,
+  unmount,
+}
 
 class _WorkspaceDragPayload {
   const _WorkspaceDragPayload({
@@ -49,6 +55,8 @@ class OmnibotWorkspaceBrowser extends StatefulWidget {
   final bool showHeaderTitle;
   final bool enableInlineDirectoryExpansion;
   final bool inlineFilePreview;
+  final FutureOr<void> Function(OmnibotResourceMetadata metadata)?
+      onSendFileToCurrentConversation;
 
   const OmnibotWorkspaceBrowser({
     super.key,
@@ -61,6 +69,7 @@ class OmnibotWorkspaceBrowser extends StatefulWidget {
     this.showHeaderTitle = true,
     this.enableInlineDirectoryExpansion = true,
     this.inlineFilePreview = false,
+    this.onSendFileToCurrentConversation,
   });
 
   @override
@@ -1234,6 +1243,9 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
     final name = _entryNameFromPath(entry.path);
     final mountEntry = _workspaceMountEntryFor(entry);
     final editable = _canEditEntry(entry);
+    final canSendToConversation =
+        widget.onSendFileToCurrentConversation != null &&
+        FileSystemEntity.typeSync(entry.path) == FileSystemEntityType.file;
     final action = await showModalBottomSheet<_WorkspaceEntryAction>(
       context: context,
       backgroundColor: _surfaceColor(opacity: 0.92),
@@ -1281,6 +1293,30 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
                   ),
                 ),
                 const SizedBox(height: 12),
+                if (canSendToConversation) ...[
+                  ListTile(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    tileColor: _secondarySurfaceColor(),
+                    leading: Icon(
+                      Icons.add_comment_outlined,
+                      color: palette.textPrimary,
+                    ),
+                    title: Text(
+                      _isEnglish ? 'Send to chat' : '发送至对话',
+                      style: TextStyle(
+                        color: palette.textPrimary,
+                        fontWeight: FontWeight.w600,
+                        fontFamily: 'PingFang SC',
+                      ),
+                    ),
+                    onTap: () => Navigator.of(sheetContext).pop(
+                      _WorkspaceEntryAction.sendToCurrentConversation,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                ],
                 if (mountEntry == null && editable) ...[
                   ListTile(
                     shape: RoundedRectangleBorder(
@@ -1382,6 +1418,10 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
     );
 
     if (!mounted || action == null) return;
+    if (action == _WorkspaceEntryAction.sendToCurrentConversation) {
+      await _sendEntryToCurrentConversation(entry);
+      return;
+    }
     if (action == _WorkspaceEntryAction.unmount) {
       if (mountEntry != null) {
         await _confirmAndUnmountWorkspaceMount(mountEntry);
@@ -1397,6 +1437,36 @@ class OmnibotWorkspaceBrowserState extends State<OmnibotWorkspaceBrowser> {
       return;
     }
     await _confirmAndDeleteEntry(entry);
+  }
+
+  Future<void> _sendEntryToCurrentConversation(FileSystemEntity entry) async {
+    final callback = widget.onSendFileToCurrentConversation;
+    if (callback == null) return;
+
+    final path = _normalizePath(entry.path);
+    if (FileSystemEntity.typeSync(path) != FileSystemEntityType.file) {
+      showToast(
+        _isEnglish
+            ? 'Only files can be sent to the current chat'
+            : '只能发送文件到当前对话',
+        type: ToastType.warning,
+      );
+      return;
+    }
+
+    try {
+      await callback(
+        OmnibotResourceService.describePath(
+          path,
+          title: _entryNameFromPath(path),
+        ),
+      );
+    } catch (error) {
+      showToast(
+        _isEnglish ? 'Failed to send file: $error' : '发送文件失败：$error',
+        type: ToastType.error,
+      );
+    }
   }
 
   bool _canEditEntry(FileSystemEntity entry) {


### PR DESCRIPTION
## 变更内容

- 在聊天页工作目录的文件长按操作窗中增加“发送至对话”选项。
- 支持本地工作目录与 Codex 远程工作目录，仅对文件显示该操作，文件夹不显示。
- 选择后将文件加入当前激活的 Agent/Codex 对话输入框附件队列，并自动回到对话页。
- Codex 发送消息时会把已添加的 workspace 文件路径拼入本次 turn，确保 Codex 能按路径读取文件。

## 验证

- `git diff --check origin/main...workspace-send-file-to-chat` 通过。
- 已在完整测试构建分支中通过 GitHub Actions Debug APK 构建验证： https://github.com/lwz762/OpenOmniBot/actions/runs/27500659532