### PR TITLE
Add Project sandbox component market scaffold

### DIFF
--- a/app/src/main/assets/builtin_skills/manifest.json
+++ b/app/src/main/assets/builtin_skills/manifest.json
@@ -29,6 +29,16 @@
       "hasReferences": false,
       "hasAssets": false,
       "hasEvals": false
+    },
+    {
+      "id": "oob-project-sandbox",
+      "name": "oob-project-sandbox",
+      "description": "Package, review, publish, or install sandboxed Omnibot Project components. Use when the user asks to upload/download/share a Xiaowan component, publish an app to a Project market, or create a no-user-data configurable component package.",
+      "assetPath": "builtin_skills/oob-project-sandbox",
+      "hasScripts": true,
+      "hasReferences": true,
+      "hasAssets": true,
+      "hasEvals": false
     }
   ]
 }

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/SKILL.md
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: oob-project-sandbox
+description: Package, review, publish, or install a sandboxed Omnibot Project component. Use when the user asks to upload/download/share a Xiaowan component, publish an app to a Project market, turn an Omnibot UI/workflow/skill into a configurable component, or create a no-user-data component package.
+---
+
+# OOB Project Sandbox
+
+Use this skill when a user wants to turn one Xiaowan/Omnibot component into a shareable Project package, or wants to install a package from a Project sandbox market.
+
+This is a scaffold skill. It defines the package contract and review flow only. Do not assume a full Workbench runtime, UI market, account system, or remote upload service exists.
+
+## Product Boundary
+
+The unit of sharing is one component, not a full user project.
+
+Good package candidates:
+
+- one skill
+- one configurable widget or display surface
+- one workflow/action card
+- one prompt template plus scripts
+- one pet/component asset bundle
+- one small template app whose state is local-only
+
+Do not package:
+
+- user data
+- chat history
+- runtime logs
+- credentials, API keys, tokens, cookies, keystores, or `.env` files
+- generated cache/build output
+- a full repository dump
+
+## Required References
+
+Read only what is needed:
+
+- `references/component-package-contract.md` for package manifest and file layout
+- `references/market-sandbox-policy.md` for upload/download, data, and review rules
+
+Use `scripts/validate_component_package.py` before recommending upload or install.
+
+## Package Flow
+
+1. Identify the single component boundary.
+2. Classify it as `skill`, `widget`, `workflow`, `template_app`, `asset_bundle`, or `display`.
+3. Create `oob_project_component_manifest.v1.json`.
+4. Include only source/config/assets needed to run the component.
+5. Exclude all data paths listed in `market-sandbox-policy.md`.
+6. Run the validator.
+7. If valid, produce a package archive or market entry.
+
+Default package path:
+
+```text
+/workspace/.omnibot/project-sandbox/packages/<component-id>/
+```
+
+Default install path:
+
+```text
+/workspace/.omnibot/project-sandbox/installed/<component-id>/
+```
+
+## Market Flow
+
+For upload:
+
+1. Validate the component manifest.
+2. Verify `dataPolicy.uploadsUserData` is `false`.
+3. Verify the file list does not include blocked paths.
+4. Create or update a market index entry.
+5. Upload only the package archive and public metadata.
+
+For download:
+
+1. Read the market entry.
+2. Download the manifest/package into the sandbox cache.
+3. Validate before install.
+4. Show capabilities and permissions to the user.
+5. Install into the sandbox path. Do not execute code during install.
+
+## Data Rule
+
+Never upload user data. A component may define a local data schema, but the package must not contain real records.
+
+Allowed:
+
+- `config/defaults.json`
+- `schema/*.json`
+- `README.md`
+- source files
+- sample data only when clearly synthetic and under `examples/`
+
+Blocked:
+
+- `data/**`
+- `logs/**`
+- `cache/**`
+- `.env`
+- `*.jks`
+- `*.keystore`
+- conversation exports
+- screenshot captures containing user content
+
+## Output Shape
+
+When finishing a package/review task, report:
+
+```text
+Project Sandbox Package
+- Component: <id> <version>
+- Type: <type>
+- Files: <count>
+- Data upload: none
+- Capabilities: <list>
+- Validation: PASS|FAIL
+- Next step: upload|install|fix
+```
+
+If validation fails, do not upload or install. Explain the failing field/path and the smallest fix.

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_component_manifest.json
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_component_manifest.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "oob.project.component.v1",
+  "componentId": "daily-review-card",
+  "name": "Daily Review Card",
+  "version": "0.1.0",
+  "type": "widget",
+  "description": "A configurable Xiaowan card for daily review prompts.",
+  "author": {
+    "name": "Omnibot"
+  },
+  "entry": {
+    "kind": "config",
+    "path": "component.json"
+  },
+  "files": [
+    {
+      "path": "component.json",
+      "role": "config",
+      "required": true
+    },
+    {
+      "path": "README.md",
+      "role": "docs",
+      "required": false
+    }
+  ],
+  "capabilities": [
+    "local_config",
+    "prompt_template"
+  ],
+  "permissions": [],
+  "configuration": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "default": "Daily Review"
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Summarize today's important work."
+        }
+      }
+    }
+  },
+  "dataPolicy": {
+    "uploadsUserData": false,
+    "uploadsRuntimeData": false,
+    "storesDataLocally": false,
+    "localDataSchema": null,
+    "excludedPaths": [
+      "data/**",
+      "logs/**",
+      "cache/**",
+      ".env",
+      "*.jks",
+      "*.keystore"
+    ]
+  }
+}

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_market.json
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_market.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "oob.project.market.v1",
+  "items": [
+    {
+      "componentId": "daily-review-card",
+      "name": "Daily Review Card",
+      "version": "0.1.0",
+      "type": "widget",
+      "description": "A configurable Xiaowan card for daily review prompts.",
+      "downloadUrl": "https://example.invalid/components/daily-review-card-0.1.0.zip",
+      "manifestSha256": "",
+      "capabilities": [
+        "local_config",
+        "prompt_template"
+      ],
+      "dataPolicySummary": {
+        "uploadsUserData": false,
+        "uploadsRuntimeData": false
+      }
+    }
+  ]
+}

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package/README.md
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package/README.md
@@ -1,0 +1,9 @@
+# Daily Review Card
+
+This example package is synthetic. It contains only configuration and no user records.
+
+It demonstrates the smallest Project sandbox component shape:
+
+- manifest
+- configurable component JSON
+- documentation

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package/component.json
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package/component.json
@@ -1,0 +1,5 @@
+{
+  "title": "Daily Review",
+  "prompt": "Summarize today's important work.",
+  "showMoodField": false
+}

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package/oob_project_component_manifest.v1.json
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package/oob_project_component_manifest.v1.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "oob.project.component.v1",
+  "componentId": "daily-review-card",
+  "name": "Daily Review Card",
+  "version": "0.1.0",
+  "type": "widget",
+  "description": "A configurable Xiaowan card for daily review prompts.",
+  "author": {
+    "name": "Omnibot"
+  },
+  "entry": {
+    "kind": "config",
+    "path": "component.json"
+  },
+  "files": [
+    {
+      "path": "component.json",
+      "role": "config",
+      "required": true
+    },
+    {
+      "path": "README.md",
+      "role": "docs",
+      "required": true
+    }
+  ],
+  "capabilities": [
+    "local_config",
+    "prompt_template"
+  ],
+  "permissions": [],
+  "configuration": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "default": "Daily Review"
+        },
+        "prompt": {
+          "type": "string",
+          "default": "Summarize today's important work."
+        }
+      }
+    }
+  },
+  "dataPolicy": {
+    "uploadsUserData": false,
+    "uploadsRuntimeData": false,
+    "storesDataLocally": false,
+    "localDataSchema": null,
+    "excludedPaths": [
+      "data/**",
+      "logs/**",
+      "cache/**",
+      ".env",
+      "*.jks",
+      "*.keystore"
+    ]
+  }
+}

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/references/component-package-contract.md
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/references/component-package-contract.md
@@ -1,0 +1,161 @@
+# OOB Project Component Package Contract
+
+This contract defines the smallest mergeable Project scaffold: a component package that can be validated, published to a market index, downloaded, and installed into a sandbox.
+
+It intentionally does not define a full Workbench runtime or remote marketplace backend.
+
+## Component Manifest
+
+Every package must include:
+
+```text
+oob_project_component_manifest.v1.json
+```
+
+Required shape:
+
+```json
+{
+  "schemaVersion": "oob.project.component.v1",
+  "componentId": "daily-review-card",
+  "name": "Daily Review Card",
+  "version": "0.1.0",
+  "type": "widget",
+  "description": "A configurable card for daily review prompts.",
+  "author": {
+    "name": "Omnibot"
+  },
+  "entry": {
+    "kind": "config",
+    "path": "component.json"
+  },
+  "files": [
+    {
+      "path": "component.json",
+      "role": "config",
+      "required": true
+    }
+  ],
+  "capabilities": [
+    "local_config"
+  ],
+  "permissions": [],
+  "configuration": {
+    "schema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  "dataPolicy": {
+    "uploadsUserData": false,
+    "uploadsRuntimeData": false,
+    "storesDataLocally": false,
+    "localDataSchema": null,
+    "excludedPaths": [
+      "data/**",
+      "logs/**",
+      "cache/**",
+      ".env",
+      "*.jks",
+      "*.keystore"
+    ]
+  }
+}
+```
+
+## Required Fields
+
+- `schemaVersion`: must be `oob.project.component.v1`.
+- `componentId`: lowercase letters, digits, and hyphens only.
+- `name`: human-readable name.
+- `version`: semantic version such as `0.1.0`.
+- `type`: one of `skill`, `widget`, `workflow`, `template_app`, `asset_bundle`, `display`.
+- `entry.path`: package-relative entry file.
+- `files[].path`: package-relative file path. It must stay inside the package root.
+- `dataPolicy.uploadsUserData`: must be `false`.
+- `dataPolicy.uploadsRuntimeData`: must be `false`.
+
+## File Layout
+
+Recommended layout:
+
+```text
+<component-id>/
+├── oob_project_component_manifest.v1.json
+├── README.md
+├── component.json
+├── src/
+├── config/
+├── schema/
+├── assets/
+└── examples/
+```
+
+Use only the folders that are needed.
+
+## Configuration Boundary
+
+A market component should be configurable, not stateful.
+
+Configuration examples:
+
+- labels and display text
+- field definitions
+- enabled actions
+- prompt snippets
+- color and icon choices
+- local storage schema
+
+State examples that must not be uploaded:
+
+- user-created records
+- execution logs
+- personal screenshots
+- conversation history
+- API responses containing private content
+
+## Market Index Entry
+
+The market index references packages; it does not embed runtime data.
+
+```json
+{
+  "schemaVersion": "oob.project.market.v1",
+  "items": [
+    {
+      "componentId": "daily-review-card",
+      "name": "Daily Review Card",
+      "version": "0.1.0",
+      "type": "widget",
+      "description": "A configurable card for daily review prompts.",
+      "downloadUrl": "https://example.invalid/components/daily-review-card-0.1.0.zip",
+      "manifestSha256": "optional-sha256",
+      "capabilities": [
+        "local_config"
+      ],
+      "dataPolicySummary": {
+        "uploadsUserData": false,
+        "uploadsRuntimeData": false
+      }
+    }
+  ]
+}
+```
+
+## Versioning
+
+- Increment patch for copy/config-only updates.
+- Increment minor for new optional configuration or capabilities.
+- Increment major when install layout, data schema, or permissions change incompatibly.
+
+## Review Checklist
+
+Before publishing:
+
+- manifest validates
+- all listed files exist
+- no listed file matches blocked data paths
+- no secrets are present
+- no runtime user records are included
+- capabilities and permissions are explicit
+- package can be installed without executing code

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/references/market-sandbox-policy.md
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/references/market-sandbox-policy.md
@@ -1,0 +1,107 @@
+# Project Sandbox Market Policy
+
+The Project sandbox market is a controlled exchange for Omnibot component packages.
+
+It is not a sync service for user data.
+
+## Upload Policy
+
+Only upload:
+
+- component manifest
+- source/config files
+- public assets
+- docs
+- synthetic examples
+
+Never upload:
+
+- user data
+- logs
+- caches
+- chat history
+- screenshots with user content
+- credentials
+- signing files
+- private workspace files unrelated to the component
+
+## Download Policy
+
+Downloaded packages must be treated as untrusted until validation passes.
+
+Install process:
+
+1. Download into a sandbox cache.
+2. Validate manifest and file list.
+3. Show capabilities and permissions.
+4. Copy files into the install sandbox.
+5. Do not auto-run scripts or generated code during install.
+
+## Sandbox Paths
+
+Use these workspace paths:
+
+```text
+/workspace/.omnibot/project-sandbox/cache/
+/workspace/.omnibot/project-sandbox/packages/
+/workspace/.omnibot/project-sandbox/installed/
+/workspace/.omnibot/project-sandbox/market/
+```
+
+Packages must not write outside `/workspace/.omnibot/project-sandbox/` unless a later runtime explicitly asks the user and receives confirmation.
+
+## Data Policy
+
+`dataPolicy.uploadsUserData` and `dataPolicy.uploadsRuntimeData` must both be `false`.
+
+A component may declare `storesDataLocally: true` only when it creates local user state after installation. That local state is not part of the published package.
+
+## Blocked Path Patterns
+
+Packages fail review if any listed file matches:
+
+```text
+data/**
+logs/**
+cache/**
+captures/**
+screenshots/**
+.env
+.env.*
+*.jks
+*.keystore
+*.p12
+*.pem
+*.key
+*secret*
+*token*
+```
+
+## Capability Review
+
+Capabilities should describe what the installed component can do. Keep names stable and narrow.
+
+Examples:
+
+- `local_config`
+- `skill_runtime`
+- `html_display`
+- `flutter_widget`
+- `prompt_template`
+- `workspace_file_read`
+- `android_intent`
+- `notification`
+
+If a component needs network access, Android automation, file writes outside its sandbox, or privileged commands, mark it as requiring explicit user approval. Do not hide those permissions in docs.
+
+## Minimal Main-Branch Scope
+
+The first merge should include only:
+
+- built-in skill
+- package contract
+- validator
+- examples
+- tests/docs proving data is excluded
+
+Do not merge the old Workbench runtime, UI mode, hot reload, or backend executor in this step.

--- a/app/src/main/assets/builtin_skills/oob-project-sandbox/scripts/validate_component_package.py
+++ b/app/src/main/assets/builtin_skills/oob-project-sandbox/scripts/validate_component_package.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Validate an OOB Project sandbox component manifest or market index.
+
+Usage:
+    python3 validate_component_package.py --manifest path/to/oob_project_component_manifest.v1.json --root path/to/package
+    python3 validate_component_package.py --market path/to/market.json
+"""
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+from pathlib import PurePosixPath
+
+
+COMPONENT_SCHEMA_VERSION = "oob.project.component.v1"
+MARKET_SCHEMA_VERSION = "oob.project.market.v1"
+COMPONENT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$")
+SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
+ALLOWED_TYPES = {
+    "skill",
+    "widget",
+    "workflow",
+    "template_app",
+    "asset_bundle",
+    "display",
+}
+BLOCKED_PATH_PATTERNS = [
+    "data/**",
+    "logs/**",
+    "cache/**",
+    "captures/**",
+    "screenshots/**",
+    ".env",
+    ".env.*",
+    "*.jks",
+    "*.keystore",
+    "*.p12",
+    "*.pem",
+    "*.key",
+    "*secret*",
+    "*token*",
+]
+SECRET_TEXT_RE = re.compile(
+    r"(sk-[A-Za-z0-9_-]{20,}|api[_-]?key\s*[:=]\s*['\"][^'\"]+|token\s*[:=]\s*['\"][^'\"]+)",
+    re.IGNORECASE,
+)
+
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def normalize_package_path(path):
+    raw = str(path or "").replace("\\", "/").strip()
+    if not raw:
+        return ""
+    pure = PurePosixPath(raw)
+    if pure.is_absolute():
+        return ""
+    parts = []
+    for part in pure.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            return ""
+        parts.append(part)
+    return "/".join(parts)
+
+
+def blocked_reason(path):
+    normalized = normalize_package_path(path)
+    if not normalized:
+        return "path is empty, absolute, or escapes the package root"
+    lower = normalized.lower()
+    for pattern in BLOCKED_PATH_PATTERNS:
+        if fnmatch.fnmatch(lower, pattern.lower()):
+            return f"matches blocked pattern {pattern}"
+    return ""
+
+
+def read_small_text(path, max_bytes=256 * 1024):
+    try:
+        if os.path.getsize(path) > max_bytes:
+            return ""
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except Exception:
+        return ""
+
+
+class Reporter:
+    def __init__(self):
+        self.failures = []
+        self.warnings = []
+
+    def fail(self, message):
+        self.failures.append(message)
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+    def print(self):
+        for warning in self.warnings:
+            print(f"WARN: {warning}")
+        for failure in self.failures:
+            print(f"FAIL: {failure}")
+        if not self.failures:
+            print("PASS: Project sandbox package validation passed")
+
+
+def validate_component(manifest, root, reporter):
+    if manifest.get("schemaVersion") != COMPONENT_SCHEMA_VERSION:
+        reporter.fail(f"schemaVersion must be {COMPONENT_SCHEMA_VERSION}")
+
+    component_id = manifest.get("componentId")
+    if not isinstance(component_id, str) or not COMPONENT_ID_RE.match(component_id):
+        reporter.fail("componentId must use lowercase letters, digits, and hyphens")
+
+    version = manifest.get("version")
+    if not isinstance(version, str) or not SEMVER_RE.match(version):
+        reporter.fail("version must be semantic version format, for example 0.1.0")
+
+    component_type = manifest.get("type")
+    if component_type not in ALLOWED_TYPES:
+        reporter.fail(f"type must be one of {sorted(ALLOWED_TYPES)}")
+
+    for key in ["name", "description"]:
+        if not str(manifest.get(key, "")).strip():
+            reporter.fail(f"{key} is required")
+
+    data_policy = manifest.get("dataPolicy")
+    if not isinstance(data_policy, dict):
+        reporter.fail("dataPolicy is required")
+        data_policy = {}
+    if data_policy.get("uploadsUserData") is not False:
+        reporter.fail("dataPolicy.uploadsUserData must be false")
+    if data_policy.get("uploadsRuntimeData") is not False:
+        reporter.fail("dataPolicy.uploadsRuntimeData must be false")
+
+    entry = manifest.get("entry")
+    if not isinstance(entry, dict):
+        reporter.fail("entry is required")
+    else:
+        reason = blocked_reason(entry.get("path"))
+        if reason:
+            reporter.fail(f"entry.path {entry.get('path')!r} is invalid: {reason}")
+
+    files = manifest.get("files")
+    if not isinstance(files, list) or not files:
+        reporter.fail("files must be a non-empty list")
+        files = []
+
+    seen = set()
+    for index, item in enumerate(files):
+        if not isinstance(item, dict):
+            reporter.fail(f"files[{index}] must be an object")
+            continue
+        rel_path = normalize_package_path(item.get("path"))
+        if not rel_path:
+            reporter.fail(f"files[{index}].path is invalid")
+            continue
+        if rel_path in seen:
+            reporter.fail(f"duplicate file path: {rel_path}")
+        seen.add(rel_path)
+        reason = blocked_reason(rel_path)
+        if reason:
+            reporter.fail(f"{rel_path} is blocked: {reason}")
+        if root:
+            full_path = os.path.abspath(os.path.join(root, rel_path))
+            root_path = os.path.abspath(root)
+            if not full_path.startswith(root_path + os.sep) and full_path != root_path:
+                reporter.fail(f"{rel_path} escapes package root")
+            elif item.get("required", True) is not False and not os.path.exists(full_path):
+                reporter.fail(f"required file does not exist: {rel_path}")
+            else:
+                text = read_small_text(full_path)
+                if text and SECRET_TEXT_RE.search(text):
+                    reporter.fail(f"{rel_path} appears to contain a secret or token")
+
+
+def validate_market(index, reporter):
+    if index.get("schemaVersion") != MARKET_SCHEMA_VERSION:
+        reporter.fail(f"market schemaVersion must be {MARKET_SCHEMA_VERSION}")
+
+    items = index.get("items")
+    if not isinstance(items, list):
+        reporter.fail("market items must be a list")
+        return
+
+    ids = set()
+    for item in items:
+        component_id = item.get("componentId")
+        if not isinstance(component_id, str) or not COMPONENT_ID_RE.match(component_id):
+            reporter.fail(f"market componentId is invalid: {component_id!r}")
+            continue
+        version = item.get("version")
+        identity = f"{component_id}@{version}"
+        if identity in ids:
+            reporter.fail(f"duplicate market item: {identity}")
+        ids.add(identity)
+        if not isinstance(version, str) or not SEMVER_RE.match(version):
+            reporter.fail(f"{component_id} has invalid version: {version!r}")
+        policy = item.get("dataPolicySummary")
+        if not isinstance(policy, dict):
+            reporter.fail(f"{identity} is missing dataPolicySummary")
+            continue
+        if policy.get("uploadsUserData") is not False:
+            reporter.fail(f"{identity} uploadsUserData must be false")
+        if policy.get("uploadsRuntimeData") is not False:
+            reporter.fail(f"{identity} uploadsRuntimeData must be false")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", help="Component manifest JSON path")
+    parser.add_argument("--root", help="Package root used to verify listed files")
+    parser.add_argument("--market", help="Market index JSON path")
+    args = parser.parse_args(argv)
+
+    if not args.manifest and not args.market:
+        parser.error("provide --manifest or --market")
+
+    reporter = Reporter()
+    if args.manifest:
+        validate_component(load_json(args.manifest), args.root, reporter)
+    if args.market:
+        validate_market(load_json(args.market), reporter)
+
+    reporter.print()
+    return 1 if reporter.failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/app/src/test/java/cn/com/omnimind/bot/agent/SkillRuntimeBehaviorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/SkillRuntimeBehaviorTest.kt
@@ -74,6 +74,65 @@ class SkillRuntimeBehaviorTest {
     }
 
     @Test
+    fun resolveMatchesProjectSandboxForComponentMarketPrompt() {
+        val matches = SkillTriggerMatcher.resolveMatches(
+            userMessage = "把这个小万组件打包上传到 project 沙盒市场，下载时不能包含用户数据",
+            entries = listOf(
+                entry(
+                    id = "oob-project-sandbox",
+                    description = "Package, review, publish, or install sandboxed Omnibot Project components. Use when the user asks to upload/download/share a Xiaowan component, publish an app to a Project market, or create a no-user-data configurable component package."
+                )
+            )
+        )
+
+        assertTrue(matches.any { it.entry.id == "oob-project-sandbox" })
+    }
+
+    @Test
+    fun builtinProjectSandboxSkillKeepsNoUserDataContract() {
+        val skillDir = File("src/main/assets/builtin_skills/oob-project-sandbox")
+        val skillText = File(skillDir, "SKILL.md").readText()
+        val policyText = File(skillDir, "references/market-sandbox-policy.md").readText()
+        val exampleManifest = File(
+            skillDir,
+            "assets/example_package/oob_project_component_manifest.v1.json"
+        ).readText()
+
+        assertTrue(skillText.contains("Never upload user data"))
+        assertTrue(policyText.contains("dataPolicy.uploadsUserData"))
+        assertTrue(policyText.contains("data/**"))
+        assertTrue(policyText.contains("logs/**"))
+        assertTrue(exampleManifest.contains("\"uploadsUserData\": false"))
+        assertTrue(exampleManifest.contains("\"uploadsRuntimeData\": false"))
+        assertFalse(exampleManifest.contains("\"uploadsUserData\": true"))
+        assertTrue(File(skillDir, "scripts/validate_component_package.py").isFile)
+    }
+
+    @Test
+    fun projectSandboxExamplePackageValidates() {
+        val skillDir = File("src/main/assets/builtin_skills/oob-project-sandbox")
+        val script = File(skillDir, "scripts/validate_component_package.py")
+        val packageRoot = File(skillDir, "assets/example_package")
+        val manifest = File(packageRoot, "oob_project_component_manifest.v1.json")
+        val market = File(skillDir, "assets/example_market.json")
+        val process = ProcessBuilder(
+            "python3",
+            script.path,
+            "--manifest",
+            manifest.path,
+            "--root",
+            packageRoot.path,
+            "--market",
+            market.path
+        )
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        assertEquals(output, 0, process.waitFor())
+        assertTrue(output.contains("PASS"))
+    }
+
+    @Test
     fun resolveMatchesHatchPetFromStructuredChinesePetPrompt() {
         val matches = SkillTriggerMatcher.resolveMatches(
             userMessage = """

--- a/docs/reference/OOB_PROJECT_SANDBOX_MARKET.md
+++ b/docs/reference/OOB_PROJECT_SANDBOX_MARKET.md
@@ -1,0 +1,114 @@
+# OOB Project Sandbox Market Plan
+
+## Decision
+
+Do not merge the old `wzw-dev` Workbench implementation directly.
+
+That branch contains a complete Project/Workbench runtime, but it is far behind `main` and mixes UI mode changes, hot reload, agent tools, backend runtime, tests, docs, and unrelated generated artifacts. Pulling it into `main` would create a large regression surface.
+
+Merge a scaffold first.
+
+## Minimal Main-Branch Scope
+
+The smallest useful version is a Project sandbox market contract:
+
+1. A built-in `oob-project-sandbox` skill.
+2. A component package manifest.
+3. A market index manifest.
+4. A validator that blocks user-data upload.
+5. Example package and docs.
+
+This makes Project mode useful as a sharing format before the app has a full marketplace UI.
+
+## Product Shape
+
+The shared unit is one Xiaowan/Omnibot component, not a full user project.
+
+Examples:
+
+- skill
+- action card
+- workflow
+- widget/display surface
+- prompt template plus scripts
+- pet or visual asset bundle
+- small configurable template app
+
+Each component has:
+
+- manifest metadata
+- source/config/assets
+- declared capabilities
+- optional local data schema
+- explicit no-upload data policy
+
+## Data Rule
+
+The market must never upload runtime user data.
+
+Allowed in packages:
+
+- config defaults
+- schemas
+- synthetic examples
+- source files
+- docs and public assets
+
+Blocked:
+
+- `data/**`
+- `logs/**`
+- `cache/**`
+- `.env`
+- keystores and signing files
+- tokens/secrets
+- chat history
+- screenshots with private user content
+
+## Phases
+
+### Phase 1: Scaffold
+
+Merge this PR.
+
+Deliverables:
+
+- built-in skill
+- contract docs
+- JSON schemas
+- validator
+- example package
+
+### Phase 2: Local Sandbox Install
+
+Add local install/import/export commands:
+
+- package a selected component
+- validate package
+- install package into `/workspace/.omnibot/project-sandbox/installed/<component-id>/`
+- list installed components
+
+No remote upload yet.
+
+### Phase 3: Market Surface
+
+Add a UI surface for market index browsing:
+
+- read a trusted market index
+- show capabilities and permissions
+- download into cache
+- validate before install
+- no auto-execution during install
+
+### Phase 4: Author Upload
+
+Add authenticated publishing only after the contract is stable:
+
+- upload package archive and public metadata
+- reject user-data paths server-side
+- require manifest validation
+- keep moderation/review separate from install
+
+## Why This Is Enough
+
+This scaffold gives teams a common artifact shape. People can start producing uploadable components now, while the runtime and UI can evolve later without rewriting the package format.

--- a/schemas/oob_project_component_manifest.v1.json
+++ b/schemas/oob_project_component_manifest.v1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://omnimind.ai/schemas/oob_project_component_manifest.v1.json",
+  "title": "OOB Project Component Manifest",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "componentId",
+    "name",
+    "version",
+    "type",
+    "entry",
+    "files",
+    "dataPolicy"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "oob.project.component.v1"
+    },
+    "componentId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$"
+    },
+    "type": {
+      "enum": [
+        "skill",
+        "widget",
+        "workflow",
+        "template_app",
+        "asset_bundle",
+        "display"
+      ]
+    },
+    "entry": {
+      "type": "object",
+      "required": [
+        "kind",
+        "path"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      }
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "role"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "sha256": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "permissions": {
+      "type": "array"
+    },
+    "configuration": {
+      "type": "object"
+    },
+    "dataPolicy": {
+      "type": "object",
+      "required": [
+        "uploadsUserData",
+        "uploadsRuntimeData"
+      ],
+      "properties": {
+        "uploadsUserData": {
+          "const": false
+        },
+        "uploadsRuntimeData": {
+          "const": false
+        },
+        "storesDataLocally": {
+          "type": "boolean"
+        },
+        "localDataSchema": {},
+        "excludedPaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/oob_project_market.v1.json
+++ b/schemas/oob_project_market.v1.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://omnimind.ai/schemas/oob_project_market.v1.json",
+  "title": "OOB Project Sandbox Market Index",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "items"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "oob.project.market.v1"
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "componentId",
+          "name",
+          "version",
+          "type",
+          "downloadUrl",
+          "dataPolicySummary"
+        ],
+        "properties": {
+          "componentId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "downloadUrl": {
+            "type": "string"
+          },
+          "manifestSha256": {
+            "type": "string"
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dataPolicySummary": {
+            "type": "object",
+            "required": [
+              "uploadsUserData",
+              "uploadsRuntimeData"
+            ],
+            "properties": {
+              "uploadsUserData": {
+                "const": false
+              },
+              "uploadsRuntimeData": {
+                "const": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the minimal mergeable scaffold for the Project-related mode without merging the old full Workbench implementation from `wzw-dev`.

The intent is to make "Project" useful as a configurable component sandbox market first: people can package, validate, share, download, and install an Omnibot/Xiaowan component definition, while user data remains local and must not be uploaded.

## Why not merge `wzw-dev` directly

`wzw-dev` contains a more complete historical Project/Workbench direction, but it is far behind `main` and includes a broad surface area that is risky to merge directly. For `main`, the smallest useful step is a stable package/market contract plus validation rules, not a full runtime or UI.

## What is included

- Adds built-in skill `oob-project-sandbox`
- Adds component package manifest contract and market index contract
- Adds example component package and example market index
- Adds a validator script that rejects user-data and secret-bearing paths
- Adds public reference docs for Project sandbox market behavior
- Adds unit coverage for built-in skill registration and Project scaffold assets

## Data policy

Component packages are configuration artifacts only. The scaffold explicitly rejects user data and local/private material such as:

- `data/**`, `logs/**`, `cache/**`
- `.env`, keystores, token/secret files
- screenshots or chat history containing user content
- arbitrary local state exported from the app

## Out of scope

- No full Workbench runtime
- No remote backend upload implementation
- No app-store UI
- No hot reload or dynamic executor
- No user-data export/import

Those should be added only after the contract is accepted.

## Verification

Passed locally:

- `python3 app/src/main/assets/builtin_skills/oob-project-sandbox/scripts/validate_component_package.py --manifest app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_component_manifest.json --root app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_package --market app/src/main/assets/builtin_skills/oob-project-sandbox/assets/example_market.json`
- `python3 -m json.tool` on the new JSON schema/example files
- `git diff --check`

Attempted but blocked locally:

- `./gradlew --no-daemon :app:testDevelopStandardDebugUnitTest --tests 'cn.com.omnimind.bot.agent.SkillRuntimeBehaviorTest'`
- Blocked before tests because the shell environment does not have a `flutter` command available for `:app:buildFlutterWebBundle`.

## Merge recommendation

Recommended to merge after CI/review if the team agrees that Project mode should start as a component sandbox market scaffold. This PR gives the team a concrete, low-risk contract to iterate on without committing to the old `wzw-dev` Workbench implementation.
