### PR TITLE
fix: 修复全屏聊天页输入框在键盘弹起时可能被输入法遮挡

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -59,6 +59,7 @@ import 'package:ui/features/home/pages/chat/utils/agent_runtime_attachment_paylo
 import 'package:ui/features/home/pages/chat/utils/agent_thinking_card_locator.dart';
 import 'package:ui/features/home/pages/chat/utils/codex_slash_commands.dart';
 import 'package:ui/features/home/pages/chat/utils/deep_thinking_persistence.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_lift_intent_tracker.dart';
 import 'package:ui/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart';
 import 'package:ui/features/home/pages/chat/utils/keyboard_inset_motion_tracker.dart';
 import 'package:ui/features/home/pages/codex/codex_remote_directory_picker.dart';
@@ -201,6 +202,8 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   };
   final KeyboardInsetMotionTracker _emptyGreetingKeyboardLiftTracker =
       KeyboardInsetMotionTracker();
+  final ComposerLiftIntentTracker _composerLiftIntentTracker =
+      ComposerLiftIntentTracker();
   final ComposerKeyboardMetricsTracker _composerKeyboardMetricsTracker =
       ComposerKeyboardMetricsTracker();
   final Map<ChatPageMode, ChatIslandDisplayLayer>

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1755,8 +1755,12 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     final isHdPadLandscape = _isHdPadLandscapeForMediaQuery(mediaQuery);
     final bottomInset = mediaQuery.viewInsets.bottom;
     final viewPaddingBottom = mediaQuery.viewPadding.bottom;
-    final shouldLiftComposerForKeyboard =
+    final hasComposerLiftIntent =
         _inputFocusNode.hasFocus || _editingUserMessageId != null;
+    final shouldLiftComposerForKeyboard = _composerLiftIntentTracker.update(
+      hasInputIntent: hasComposerLiftIntent,
+      bottomInset: bottomInset,
+    );
     final composerKeyboardMetrics = _composerKeyboardMetricsTracker.update(
       shouldLiftComposerForKeyboard: shouldLiftComposerForKeyboard,
       bottomInset: bottomInset,

--- a/ui/lib/features/home/pages/chat/utils/composer_lift_intent_tracker.dart
+++ b/ui/lib/features/home/pages/chat/utils/composer_lift_intent_tracker.dart
@@ -1,0 +1,42 @@
+import 'dart:math' as math;
+
+/// Keeps the full-screen chat composer lifted through transient focus loss
+/// while the IME is still opening or visibly present.
+///
+/// The latch only activates after a real input intent (focus/editing) has
+/// happened. Once focus is gone, it stays active until either:
+/// - the keyboard clearly starts closing, or
+/// - the keyboard has fully settled closed.
+class ComposerLiftIntentTracker {
+  ComposerLiftIntentTracker({
+    this.visibleInsetThreshold = 0.5,
+    this.motionEpsilon = 1.0,
+  });
+
+  final double visibleInsetThreshold;
+  final double motionEpsilon;
+
+  bool _latched = false;
+  double? _lastInset;
+
+  bool update({required bool hasInputIntent, required double bottomInset}) {
+    final inset = bottomInset.isFinite ? math.max(0.0, bottomInset) : 0.0;
+
+    if (hasInputIntent) {
+      _latched = true;
+      _lastInset = inset;
+      return true;
+    }
+
+    final lastInset = _lastInset;
+    if (_latched) {
+      if (inset <= visibleInsetThreshold ||
+          (lastInset != null && inset < lastInset - motionEpsilon)) {
+        _latched = false;
+      }
+    }
+
+    _lastInset = inset;
+    return _latched && inset > visibleInsetThreshold;
+  }
+}

--- a/ui/test/features/home/pages/chat/composer_lift_intent_tracker_test.dart
+++ b/ui/test/features/home/pages/chat/composer_lift_intent_tracker_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_lift_intent_tracker.dart';
+
+void main() {
+  test('keeps lift latched through transient focus loss while IME opens', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: true, bottomInset: 0), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 186), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 301), isTrue);
+  });
+
+  test(
+    'keeps lift latched while IME remains visibly stable after focus loss',
+    () {
+      final tracker = ComposerLiftIntentTracker();
+
+      expect(tracker.update(hasInputIntent: true, bottomInset: 312), isTrue);
+      expect(tracker.update(hasInputIntent: false, bottomInset: 312), isTrue);
+      expect(tracker.update(hasInputIntent: false, bottomInset: 311.4), isTrue);
+    },
+  );
+
+  test('releases latch once keyboard clearly starts closing', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: true, bottomInset: 320), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 320), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 304), isFalse);
+  });
+
+  test('does not lift a visible keyboard without prior input intent', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: false, bottomInset: 288), isFalse);
+  });
+
+  test('clears the latch after the keyboard settles closed', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: true, bottomInset: 260), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 0), isFalse);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 280), isFalse);
+  });
+}


### PR DESCRIPTION
## 变更摘要

本次改动修复了 Flutter 全屏聊天页在部分设备上，输入框可能被输入法遮挡的问题。  
根因是页面把 composer 是否继续跟随键盘上抬，过度依赖 `_inputFocusNode.hasFocus`；当键盘已经弹出但 Flutter 焦点瞬时丢失时，旧逻辑会让 composer 直接掉回底部 resting position。  
修复方案是在现有 `ComposerKeyboardMetricsTracker` 前增加一个很小的 `lift intent latch`，让 composer 在 `IME` 仍可见且只是瞬时失焦时继续保持上抬，直到检测到键盘明确开始收起。

## 变更类型

- [x]  Bug 修复


## 关联 Issue

Closes #391 

## 主要改动

1. 在全屏聊天页引入 `ComposerLiftIntentTracker`，把“用户正在输入的意图”与“当前这一帧是否仍有 Flutter 焦点”拆开处理。
2. 将 `shouldLiftComposerForKeyboard` 从纯 `focus/editing` 判断，改为由 `ComposerLiftIntentTracker.update()` 决定，从而兜住“IME 已可见但 focus 瞬时丢失”的设备时序问题。


## 测试说明
修复后在瞬时失焦情况下，仍保持输入框停在键盘上方，而不是掉在底部。
<img width="1922" height="191" alt="image" src="https://github.com/user-attachments/assets/a517c946-2f73-4063-a06c-1ca8c54c3c25" />


## UI 变更（如有）

无。


## 风险与回滚

潜在风险：

因为我在用户侧并没有复现出这个问题。所以修复是针对用户描述和现有小万代码内部分析。