### PR TITLE
Fix/tool chain leak

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -2,6 +2,8 @@ package cn.com.omnimind.bot.agent
 
 import cn.com.omnimind.baselib.database.AgentConversationEntry
 import cn.com.omnimind.baselib.database.AgentConversationEntryRecord
+import cn.com.omnimind.baselib.llm.AssistantToolCall
+import cn.com.omnimind.baselib.llm.AssistantToolCallFunction
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -604,13 +606,27 @@ internal object AgentConversationHistorySupport {
         val toolName = payload["toolName"]?.toString()?.trim().orEmpty()
         if (toolName.isEmpty()) return emptyList()
 
-        return listOf(
-            ChatCompletionMessage(
-                role = "assistant",
-                content = JsonPrimitive(buildCompactToolReplayContent(entry, payload)),
-                reasoningContent = readReasoningContent(payload)
+        val toolCallId = "restored_${entry.entryId}"
+        val argsJson = payload["argsJson"]?.toString()?.trim()?.ifEmpty { null } ?: "{}"
+        val assistantMessage = ChatCompletionMessage(
+            role = "assistant",
+            reasoningContent = readReasoningContent(payload),
+            toolCalls = listOf(
+                AssistantToolCall(
+                    id = toolCallId,
+                    function = AssistantToolCallFunction(
+                        name = toolName,
+                        arguments = argsJson
+                    )
+                )
             )
         )
+        val toolMessage = ChatCompletionMessage(
+            role = "tool",
+            toolCallId = toolCallId,
+            content = JsonPrimitive(buildCompactToolReplayContent(entry, payload))
+        )
+        return listOf(assistantMessage, toolMessage)
     }
 
     private fun extractAssistantReplayTaskId(entryId: String): String? {

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
@@ -180,24 +180,31 @@ class AgentConversationHistorySupportTest {
             listOf(userEntry, assistantEntry, toolEntry, secondToolEntry)
         )
 
-        assertEquals(4, seed.historyMessages.size)
+        assertEquals(6, seed.historyMessages.size)
         assertEquals(
-            listOf("user", "assistant", "assistant", "assistant"),
+            listOf("user", "assistant", "assistant", "tool", "assistant", "tool"),
             seed.historyMessages.map { it.role }
         )
         assertTrue(seed.historyMessages[0].content.toString().contains("查看 example"))
-        assertNull(seed.historyMessages[2].toolCalls)
-        assertNull(seed.historyMessages[2].toolCallId)
-        assertNull(seed.historyMessages[3].toolCalls)
-        assertNull(seed.historyMessages[3].toolCallId)
+        assertEquals(1, seed.historyMessages[2].toolCalls?.size)
+        assertEquals("browser_use", seed.historyMessages[2].toolCalls?.single()?.function?.name)
+        assertTrue(
+            seed.historyMessages[2].toolCalls
+                ?.single()
+                ?.function
+                ?.arguments
+                .orEmpty()
+                .contains("\"url\":\"https://example.com\"")
+        )
+        assertEquals("terminal_execute", seed.historyMessages[4].toolCalls?.single()?.function?.name)
 
-        val firstToolSummary = seed.historyMessages[2].content!!.jsonPrimitive.content
+        val firstToolSummary = seed.historyMessages[3].content!!.jsonPrimitive.content
         assertTrue(firstToolSummary.contains("浏览器自动化"))
         assertTrue(firstToolSummary.contains("抓取成功"))
         assertTrue(firstToolSummary.contains("previewJson"))
         assertFalse(firstToolSummary.contains("rawResultJson"))
 
-        val secondToolSummary = seed.historyMessages[3].content!!.jsonPrimitive.content
+        val secondToolSummary = seed.historyMessages[5].content!!.jsonPrimitive.content
         assertTrue(secondToolSummary.contains("执行命令"))
         assertTrue(secondToolSummary.contains("执行命令失败"))
         assertTrue(secondToolSummary.contains("terminalOutput"))
@@ -299,13 +306,10 @@ class AgentConversationHistorySupportTest {
 
         val messages = AgentConversationHistorySupport.buildPromptRelevantMessages(listOf(entry))
 
-        assertEquals(1, messages.size)
+        assertEquals(2, messages.size)
         assertEquals("assistant", messages[0].role)
         assertEquals("需要先打开页面确认结构", messages[0].reasoningContent)
-        assertNull(messages[0].toolCalls)
-        assertNull(messages[0].toolCallId)
-        assertTrue(messages[0].content!!.jsonPrimitive.content.contains("\"toolName\":\"browser_use\""))
-        assertTrue(messages[0].content!!.jsonPrimitive.content.contains("\"summary\":\"抓取成功\""))
+        assertEquals("browser_use", messages[0].toolCalls?.single()?.function?.name)
     }
 
     @Test
@@ -721,15 +725,14 @@ class AgentConversationHistorySupportTest {
         val messages = AgentConversationHistorySupport.buildPromptRelevantMessages(entries)
 
         assertEquals(
-            listOf("user", "assistant", "assistant", "user"),
+            listOf("user", "assistant", "tool", "assistant", "user"),
             messages.map { it.role }
         )
-        assertNull(messages[1].toolCalls)
-        assertNull(messages[1].toolCallId)
-        assertTrue(messages[1].content!!.jsonPrimitive.content.contains("\"summary\":\"抓取成功\""))
-        assertFalse(messages[1].content!!.jsonPrimitive.content.contains("rawResultJson"))
-        assertEquals("页面标题是 Example", messages[2].content!!.jsonPrimitive.content)
-        assertEquals("继续下一步", messages[3].content!!.jsonPrimitive.content)
+        assertEquals("browser_use", messages[1].toolCalls?.single()?.function?.name)
+        assertTrue(messages[2].content!!.jsonPrimitive.content.contains("\"summary\":\"抓取成功\""))
+        assertFalse(messages[2].content!!.jsonPrimitive.content.contains("rawResultJson"))
+        assertEquals("页面标题是 Example", messages[3].content!!.jsonPrimitive.content)
+        assertEquals("继续下一步", messages[4].content!!.jsonPrimitive.content)
     }
 
     @Test
@@ -761,7 +764,7 @@ class AgentConversationHistorySupportTest {
         )
 
         val messages = AgentConversationHistorySupport.buildPromptRelevantMessages(listOf(entry))
-        val toolSummary = messages[0].content!!.jsonPrimitive.content
+        val toolSummary = messages[1].content!!.jsonPrimitive.content
 
         assertTrue(toolSummary.contains("\"summary\":\"${"s".repeat(240)}...\""))
         assertTrue(toolSummary.contains("\"terminalOutput\":\"${"t".repeat(1200)}...\""))

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -59,6 +59,7 @@ import 'package:ui/features/home/pages/chat/utils/agent_runtime_attachment_paylo
 import 'package:ui/features/home/pages/chat/utils/agent_thinking_card_locator.dart';
 import 'package:ui/features/home/pages/chat/utils/codex_slash_commands.dart';
 import 'package:ui/features/home/pages/chat/utils/deep_thinking_persistence.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_lift_intent_tracker.dart';
 import 'package:ui/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart';
 import 'package:ui/features/home/pages/chat/utils/keyboard_inset_motion_tracker.dart';
 import 'package:ui/features/home/pages/codex/codex_remote_directory_picker.dart';
@@ -201,6 +202,8 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   };
   final KeyboardInsetMotionTracker _emptyGreetingKeyboardLiftTracker =
       KeyboardInsetMotionTracker();
+  final ComposerLiftIntentTracker _composerLiftIntentTracker =
+      ComposerLiftIntentTracker();
   final ComposerKeyboardMetricsTracker _composerKeyboardMetricsTracker =
       ComposerKeyboardMetricsTracker();
   final Map<ChatPageMode, ChatIslandDisplayLayer>

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1755,8 +1755,12 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     final isHdPadLandscape = _isHdPadLandscapeForMediaQuery(mediaQuery);
     final bottomInset = mediaQuery.viewInsets.bottom;
     final viewPaddingBottom = mediaQuery.viewPadding.bottom;
-    final shouldLiftComposerForKeyboard =
+    final hasComposerLiftIntent =
         _inputFocusNode.hasFocus || _editingUserMessageId != null;
+    final shouldLiftComposerForKeyboard = _composerLiftIntentTracker.update(
+      hasInputIntent: hasComposerLiftIntent,
+      bottomInset: bottomInset,
+    );
     final composerKeyboardMetrics = _composerKeyboardMetricsTracker.update(
       shouldLiftComposerForKeyboard: shouldLiftComposerForKeyboard,
       bottomInset: bottomInset,

--- a/ui/lib/features/home/pages/chat/utils/composer_lift_intent_tracker.dart
+++ b/ui/lib/features/home/pages/chat/utils/composer_lift_intent_tracker.dart
@@ -1,0 +1,42 @@
+import 'dart:math' as math;
+
+/// Keeps the full-screen chat composer lifted through transient focus loss
+/// while the IME is still opening or visibly present.
+///
+/// The latch only activates after a real input intent (focus/editing) has
+/// happened. Once focus is gone, it stays active until either:
+/// - the keyboard clearly starts closing, or
+/// - the keyboard has fully settled closed.
+class ComposerLiftIntentTracker {
+  ComposerLiftIntentTracker({
+    this.visibleInsetThreshold = 0.5,
+    this.motionEpsilon = 1.0,
+  });
+
+  final double visibleInsetThreshold;
+  final double motionEpsilon;
+
+  bool _latched = false;
+  double? _lastInset;
+
+  bool update({required bool hasInputIntent, required double bottomInset}) {
+    final inset = bottomInset.isFinite ? math.max(0.0, bottomInset) : 0.0;
+
+    if (hasInputIntent) {
+      _latched = true;
+      _lastInset = inset;
+      return true;
+    }
+
+    final lastInset = _lastInset;
+    if (_latched) {
+      if (inset <= visibleInsetThreshold ||
+          (lastInset != null && inset < lastInset - motionEpsilon)) {
+        _latched = false;
+      }
+    }
+
+    _lastInset = inset;
+    return _latched && inset > visibleInsetThreshold;
+  }
+}

--- a/ui/test/features/home/pages/chat/composer_lift_intent_tracker_test.dart
+++ b/ui/test/features/home/pages/chat/composer_lift_intent_tracker_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_lift_intent_tracker.dart';
+
+void main() {
+  test('keeps lift latched through transient focus loss while IME opens', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: true, bottomInset: 0), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 186), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 301), isTrue);
+  });
+
+  test(
+    'keeps lift latched while IME remains visibly stable after focus loss',
+    () {
+      final tracker = ComposerLiftIntentTracker();
+
+      expect(tracker.update(hasInputIntent: true, bottomInset: 312), isTrue);
+      expect(tracker.update(hasInputIntent: false, bottomInset: 312), isTrue);
+      expect(tracker.update(hasInputIntent: false, bottomInset: 311.4), isTrue);
+    },
+  );
+
+  test('releases latch once keyboard clearly starts closing', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: true, bottomInset: 320), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 320), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 304), isFalse);
+  });
+
+  test('does not lift a visible keyboard without prior input intent', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: false, bottomInset: 288), isFalse);
+  });
+
+  test('clears the latch after the keyboard settles closed', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(hasInputIntent: true, bottomInset: 260), isTrue);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 0), isFalse);
+    expect(tracker.update(hasInputIntent: false, bottomInset: 280), isFalse);
+  });
+}


### PR DESCRIPTION
## 变更摘要

本次改动修复了 Agent 历史工具回放被错误压成 `assistant.content` 文本摘要后，诱导模型在后续轮次把工具调用协议原文直接输出到 UI 的问题。
因为是之前修缓存优化的其中一部分优化修改，所以修复方式是把历史工具回放恢复为之前版本的 OpenAI 原生协议形态。

## 变更类型

- [x]  Bug 修复

## 关联 Issue

Closes #393 

## 主要改动

1. 在 `AgentConversationHistorySupport.buildToolReplayMessages` 中恢复原生工具回放协议：历史工具调用改为 `assistant.tool_calls` + `role=tool` 两条消息，而不是单条 `assistant.content` 摘要。
2. 回退并更新 `AgentConversationHistorySupportTest` 的 4 处关键断言，确保多工具历史、reasoning 回放、同任务上下文顺序、超长摘要截断这几类场景继续被覆盖。


## 测试说明

回退后，tool_call 已正常被格式化，本地用户端测试也恢复正常。
<img width="2454" height="151" alt="image" src="https://github.com/user-attachments/assets/0637fb4e-5ea9-4f04-9069-d4381944daec" />

```

## UI 变更（如有）

无。

## 风险与回滚

缓存优化率会回落一点。