### PR TITLE
fix: 修复全屏聊天页输入框在输入法弹起时可能被遮挡

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -1717,6 +1717,10 @@ abstract class _ChatPageStateBase extends State<ChatPage>
 
   Future<void> _cancelCompanionMode();
 
+  void _armComposerLiftIntent();
+
+  void _requestComposerFocus({bool showKeyboard});
+
   void _onFocusChange();
 
   void _handleAppUpdateStatusChanged();

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -518,7 +518,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         text: '/model ',
         selection: TextSelection.collapsed(offset: 7),
       );
-      _inputFocusNode.requestFocus();
+      _requestComposerFocus();
       _handleSlashCommandInput();
       await _loadCodexModelOptions();
       return;

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -730,6 +730,9 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
   @override
   void _onFocusChange() {
     if (!mounted) return;
+    if (_inputFocusNode.hasFocus) {
+      _armComposerLiftIntent();
+    }
     setState(() {});
   }
 

--- a/ui/lib/features/home/pages/chat/chat_page_openclaw.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_openclaw.dart
@@ -18,7 +18,7 @@ mixin _ChatPageOpenClawMixin on _ChatPageStateBase {
         offset: currentText.length,
       );
     }
-    _inputFocusNode.requestFocus();
+    _requestComposerFocus();
     _handleSlashCommandInput();
   }
 

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -23,6 +23,20 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
       ? ChatPageMode.codex
       : ChatPageMode.normal;
 
+  @override
+  void _armComposerLiftIntent() {
+    _composerLiftIntentTracker.arm();
+  }
+
+  @override
+  void _requestComposerFocus({bool showKeyboard = false}) {
+    _armComposerLiftIntent();
+    _inputFocusNode.requestFocus();
+    if (showKeyboard) {
+      SystemChannels.textInput.invokeMethod('TextInput.show');
+    }
+  }
+
   void _applyHomeQuickPrompt(HomeQuickPrompt prompt) {
     _suppressNextOutsideTapKeyboardHide = true;
     final text = prompt.resolvePrompt(context).trim();
@@ -36,8 +50,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     _draftMessageByMode[_activeConversationMode] = text;
     _handleSlashCommandInput();
     if (!_inputFocusNode.hasFocus) {
-      _inputFocusNode.requestFocus();
-      SystemChannels.textInput.invokeMethod('TextInput.show');
+      _requestComposerFocus(showKeyboard: true);
     }
   }
 
@@ -114,8 +127,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     if (route == _SlashCommandPanelRoute.effort &&
         _supportsReasoningEffortCommand) {
       final activeEffort = _activeConversationReasoningEffort;
-      final displayActiveEffort =
-          activeEffort == 'xhigh' ? 'max' : activeEffort;
+      final displayActiveEffort = activeEffort == 'xhigh'
+          ? 'max'
+          : activeEffort;
       final query = _slashCommandRouteQuery(route).toLowerCase();
       final efforts = <String>['no', 'low', 'high', 'max']
           .where((effort) {
@@ -188,8 +202,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     }
     if (_supportsReasoningEffortCommand) {
       final activeEffort = _activeConversationReasoningEffort;
-      final displayActiveEffort =
-          activeEffort == 'xhigh' ? 'max' : activeEffort;
+      final displayActiveEffort = activeEffort == 'xhigh'
+          ? 'max'
+          : activeEffort;
       commands.add(<String, dynamic>{
         'cardId': 'slash-command-effort',
         'toolName': '/effort',
@@ -457,7 +472,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
           text: '/effort ',
           selection: TextSelection.collapsed(offset: 8),
         );
-        _inputFocusNode.requestFocus();
+        _requestComposerFocus();
         _handleSlashCommandInput();
         break;
       case 'no':
@@ -1271,6 +1286,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                       inputAreaKey: _chatInputAreaKey,
                       controller: _messageController,
                       focusNode: _inputFocusNode,
+                      onRequestFocus: _armComposerLiftIntent,
                       isProcessing: _isAiResponding,
                       onSendMessage: _sendMessage,
                       onCancelTask: _onCancelTask,
@@ -1755,10 +1771,8 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     final isHdPadLandscape = _isHdPadLandscapeForMediaQuery(mediaQuery);
     final bottomInset = mediaQuery.viewInsets.bottom;
     final viewPaddingBottom = mediaQuery.viewPadding.bottom;
-    final hasComposerLiftIntent =
-        _inputFocusNode.hasFocus || _editingUserMessageId != null;
     final shouldLiftComposerForKeyboard = _composerLiftIntentTracker.update(
-      hasInputIntent: hasComposerLiftIntent,
+      isEditing: _editingUserMessageId != null,
       bottomInset: bottomInset,
     );
     final composerKeyboardMetrics = _composerKeyboardMetricsTracker.update(
@@ -2141,6 +2155,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     }
     final originalText = message.text ?? '';
     setState(() {
+      _armComposerLiftIntent();
       _editingUserMessageId = message.id;
       _editingUserMessageController.value = TextEditingValue(
         text: originalText,

--- a/ui/lib/features/home/pages/chat/utils/composer_lift_intent_tracker.dart
+++ b/ui/lib/features/home/pages/chat/utils/composer_lift_intent_tracker.dart
@@ -11,32 +11,64 @@ class ComposerLiftIntentTracker {
   ComposerLiftIntentTracker({
     this.visibleInsetThreshold = 0.5,
     this.motionEpsilon = 1.0,
+    this.openingGraceFrames = 2,
   });
 
   final double visibleInsetThreshold;
   final double motionEpsilon;
+  final int openingGraceFrames;
 
   bool _latched = false;
+  bool _imeVisibleSinceArm = false;
   double? _lastInset;
+  int _openingGraceFramesRemaining = 0;
 
-  bool update({required bool hasInputIntent, required double bottomInset}) {
+  void arm() {
+    _latched = true;
+    _imeVisibleSinceArm = false;
+    _openingGraceFramesRemaining = openingGraceFrames;
+  }
+
+  bool update({required bool isEditing, required double bottomInset}) {
     final inset = bottomInset.isFinite ? math.max(0.0, bottomInset) : 0.0;
+    final keyboardVisible = inset > visibleInsetThreshold;
 
-    if (hasInputIntent) {
-      _latched = true;
-      _lastInset = inset;
-      return true;
+    if (isEditing && !_latched) {
+      arm();
     }
 
     final lastInset = _lastInset;
     if (_latched) {
-      if (inset <= visibleInsetThreshold ||
-          (lastInset != null && inset < lastInset - motionEpsilon)) {
+      if (keyboardVisible) {
+        _imeVisibleSinceArm = true;
+        _openingGraceFramesRemaining = 0;
+      }
+
+      final keyboardClearlyClosing =
+          _imeVisibleSinceArm &&
+          lastInset != null &&
+          inset < lastInset - motionEpsilon;
+      final keyboardSettledClosed =
+          _imeVisibleSinceArm && inset <= visibleInsetThreshold;
+      final openingExpired =
+          !_imeVisibleSinceArm &&
+          !isEditing &&
+          inset <= visibleInsetThreshold &&
+          _openingGraceFramesRemaining <= 0;
+
+      if (keyboardClearlyClosing || keyboardSettledClosed || openingExpired) {
         _latched = false;
+        _imeVisibleSinceArm = false;
+        _openingGraceFramesRemaining = 0;
+      } else if (!keyboardVisible &&
+          !_imeVisibleSinceArm &&
+          !isEditing &&
+          _openingGraceFramesRemaining > 0) {
+        _openingGraceFramesRemaining -= 1;
       }
     }
 
     _lastInset = inset;
-    return _latched && inset > visibleInsetThreshold;
+    return isEditing || _latched;
   }
 }

--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -2365,6 +2365,7 @@ class ChatInputWrapper extends StatelessWidget {
   final GlobalKey<ChatInputAreaState> inputAreaKey;
   final TextEditingController controller;
   final FocusNode focusNode;
+  final VoidCallback? onRequestFocus;
   final bool isProcessing;
   final Future<void> Function({String? text}) onSendMessage;
   final VoidCallback onCancelTask;
@@ -2400,6 +2401,7 @@ class ChatInputWrapper extends StatelessWidget {
     required this.inputAreaKey,
     required this.controller,
     required this.focusNode,
+    this.onRequestFocus,
     required this.isProcessing,
     required this.onSendMessage,
     required this.onCancelTask,
@@ -2444,6 +2446,7 @@ class ChatInputWrapper extends StatelessWidget {
             key: inputAreaKey,
             controller: controller,
             focusNode: focusNode,
+            onRequestFocus: onRequestFocus,
             isProcessing: isProcessing,
             onSendMessage: onSendMessage,
             onCancelTask: onCancelTask,

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
@@ -113,6 +113,7 @@ class ChatInputAttachment {
 class ChatInputArea extends StatefulWidget {
   final TextEditingController controller;
   final FocusNode focusNode;
+  final VoidCallback? onRequestFocus;
   final bool isProcessing;
   final VoidCallback onSendMessage;
   final VoidCallback onCancelTask;
@@ -148,6 +149,7 @@ class ChatInputArea extends StatefulWidget {
     super.key,
     required this.controller,
     required this.focusNode,
+    this.onRequestFocus,
     required this.isProcessing,
     required this.onSendMessage,
     required this.onCancelTask,

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
@@ -773,40 +773,40 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
 
     return TextFieldTapRegion(
       child: SizedBox(
-      key: _modelPickerButtonKey,
-      width: compact ? 24 : 28,
-      height: compact ? 24 : 28,
-      child: Listener(
-        behavior: HitTestBehavior.opaque,
-        onPointerDown: (_) => settings.onPointerDown?.call(),
-        child: Tooltip(
-        message: modelId.isEmpty
-            ? (english ? 'Select model' : '选择模型')
-            : modelId,
-        waitDuration: const Duration(milliseconds: 400),
-        child: InkWell(
-          key: const ValueKey('chat-input-model-picker-button'),
-          borderRadius: BorderRadius.circular(8),
-          onTap: enabled ? openPicker : null,
-          child: Center(
-            child: RotationTransition(
-              turns: CurvedAnimation(
-                parent: _modelPickerSpinController,
-                curve: Curves.easeOutCubic,
-              ),
-              child: ProviderVendorIcon(
-                vendor: vendor,
-                size: compact ? 20 : 22,
-                disabled: !enabled,
-                forceMonochrome: true,
-                monochromeColor: enabled
-                    ? selectedColor
-                    : palette.textTertiary.withValues(alpha: 0.82),
+        key: _modelPickerButtonKey,
+        width: compact ? 24 : 28,
+        height: compact ? 24 : 28,
+        child: Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: (_) => settings.onPointerDown?.call(),
+          child: Tooltip(
+            message: modelId.isEmpty
+                ? (english ? 'Select model' : '选择模型')
+                : modelId,
+            waitDuration: const Duration(milliseconds: 400),
+            child: InkWell(
+              key: const ValueKey('chat-input-model-picker-button'),
+              borderRadius: BorderRadius.circular(8),
+              onTap: enabled ? openPicker : null,
+              child: Center(
+                child: RotationTransition(
+                  turns: CurvedAnimation(
+                    parent: _modelPickerSpinController,
+                    curve: Curves.easeOutCubic,
+                  ),
+                  child: ProviderVendorIcon(
+                    vendor: vendor,
+                    size: compact ? 20 : 22,
+                    disabled: !enabled,
+                    forceMonochrome: true,
+                    monochromeColor: enabled
+                        ? selectedColor
+                        : palette.textTertiary.withValues(alpha: 0.82),
+                  ),
+                ),
               ),
             ),
           ),
-        ),
-      ),
         ),
       ),
     );
@@ -1178,6 +1178,7 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
     final maxLines = multiline ? 3 : 1;
     return GestureDetector(
       onTap: () {
+        widget.onRequestFocus?.call();
         widget.focusNode.requestFocus();
       },
       child: AbsorbPointer(
@@ -1197,6 +1198,7 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
                   if (widget.controller.text.trim().isNotEmpty) {
                     widget.onSendMessage();
                   } else {
+                    widget.onRequestFocus?.call();
                     widget.focusNode.requestFocus();
                   }
                 },

--- a/ui/test/features/home/pages/chat/composer_lift_chain_test.dart
+++ b/ui/test/features/home/pages/chat/composer_lift_chain_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/chat/chat_page_models.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_keyboard_metrics_tracker.dart';
+import 'package:ui/features/home/pages/chat/utils/composer_lift_intent_tracker.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'page-level composer chain stays lifted when focus blips during IME open',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(390, 844);
+      addTearDown(tester.view.reset);
+
+      final harnessKey = GlobalKey<_ComposerLiftPageHarnessState>();
+      await tester.pumpWidget(_ComposerLiftPageHarness(key: harnessKey));
+      await tester.pump();
+
+      harnessKey.currentState!.tapComposer();
+      await tester.pump();
+
+      harnessKey.currentState!.loseFocus();
+      await tester.pump();
+      expect(find.text('focus:false lift:true'), findsOneWidget);
+
+      harnessKey.currentState!.setBottomInset(2.33);
+      await tester.pump();
+      harnessKey.currentState!.setBottomInset(186);
+      await tester.pump();
+      harnessKey.currentState!.setBottomInset(320);
+      await tester.pump();
+
+      expect(
+        harnessKey.currentState!.composerDistanceFromScreenBottom,
+        greaterThanOrEqualTo(320.0 + kChatKeyboardComposerClearance - 0.01),
+      );
+      expect(
+        harnessKey.currentState!.composerDistanceFromScreenBottom,
+        lessThanOrEqualTo(320.0 + kChatKeyboardComposerClearance + 0.01),
+      );
+      expect(find.text('focus:false lift:true'), findsOneWidget);
+    },
+  );
+}
+
+final _composerKey = UniqueKey();
+
+class _ComposerLiftPageHarness extends StatefulWidget {
+  const _ComposerLiftPageHarness({super.key});
+
+  @override
+  State<_ComposerLiftPageHarness> createState() =>
+      _ComposerLiftPageHarnessState();
+}
+
+class _ComposerLiftPageHarnessState extends State<_ComposerLiftPageHarness> {
+  static const _viewportSize = Size(390, 844);
+  static const _viewPaddingBottom = 24.0;
+
+  final FocusNode _focusNode = FocusNode();
+  final ComposerLiftIntentTracker _liftTracker = ComposerLiftIntentTracker();
+  final ComposerKeyboardMetricsTracker _metricsTracker =
+      ComposerKeyboardMetricsTracker();
+
+  double _bottomInset = 0;
+  double _composerDistanceFromScreenBottom = 0;
+
+  double get _safeAreaBottomPadding => _bottomInset >= _viewPaddingBottom
+      ? 0
+      : _viewPaddingBottom - _bottomInset;
+  double get composerDistanceFromScreenBottom =>
+      _composerDistanceFromScreenBottom;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_handleFocusChanged);
+  }
+
+  void tapComposer() {
+    _liftTracker.arm();
+    _focusNode.requestFocus();
+    setState(() {});
+  }
+
+  void loseFocus() {
+    _focusNode.unfocus();
+    setState(() {});
+  }
+
+  void setBottomInset(double value) {
+    setState(() {
+      _bottomInset = value;
+    });
+  }
+
+  void _handleFocusChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_handleFocusChanged);
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final shouldLift = _liftTracker.update(
+      isEditing: false,
+      bottomInset: _bottomInset,
+    );
+    final metrics = _metricsTracker.update(
+      shouldLiftComposerForKeyboard: shouldLift,
+      bottomInset: _bottomInset,
+      viewPaddingBottom: _viewPaddingBottom,
+      safeAreaBottomPadding: _safeAreaBottomPadding,
+    );
+    final composerBottomOffset =
+        metrics.inputBottomPadding + metrics.keyboardSpacer;
+    _composerDistanceFromScreenBottom =
+        _safeAreaBottomPadding + composerBottomOffset;
+
+    return MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(
+          size: _viewportSize,
+          viewInsets: EdgeInsets.only(bottom: _bottomInset),
+          viewPadding: const EdgeInsets.only(bottom: _viewPaddingBottom),
+          padding: EdgeInsets.only(bottom: _safeAreaBottomPadding),
+        ),
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: SafeArea(
+            top: false,
+            left: false,
+            right: false,
+            child: SizedBox.expand(
+              child: Stack(
+                children: [
+                  Positioned(
+                    top: 16,
+                    left: 16,
+                    child: Text(
+                      'focus:${_focusNode.hasFocus} lift:$shouldLift',
+                    ),
+                  ),
+                  Positioned(
+                    left: 24,
+                    right: 24,
+                    bottom: composerBottomOffset,
+                    child: Focus(
+                      focusNode: _focusNode,
+                      child: Container(
+                        key: _composerKey,
+                        height: 56,
+                        decoration: BoxDecoration(
+                          color: Colors.blueGrey,
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/ui/test/features/home/pages/chat/composer_lift_intent_tracker_test.dart
+++ b/ui/test/features/home/pages/chat/composer_lift_intent_tracker_test.dart
@@ -5,9 +5,11 @@ void main() {
   test('keeps lift latched through transient focus loss while IME opens', () {
     final tracker = ComposerLiftIntentTracker();
 
-    expect(tracker.update(hasInputIntent: true, bottomInset: 0), isTrue);
-    expect(tracker.update(hasInputIntent: false, bottomInset: 186), isTrue);
-    expect(tracker.update(hasInputIntent: false, bottomInset: 301), isTrue);
+    tracker.arm();
+
+    expect(tracker.update(isEditing: false, bottomInset: 0), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 186), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 301), isTrue);
   });
 
   test(
@@ -15,31 +17,55 @@ void main() {
     () {
       final tracker = ComposerLiftIntentTracker();
 
-      expect(tracker.update(hasInputIntent: true, bottomInset: 312), isTrue);
-      expect(tracker.update(hasInputIntent: false, bottomInset: 312), isTrue);
-      expect(tracker.update(hasInputIntent: false, bottomInset: 311.4), isTrue);
+      tracker.arm();
+
+      expect(tracker.update(isEditing: false, bottomInset: 312), isTrue);
+      expect(tracker.update(isEditing: false, bottomInset: 312), isTrue);
+      expect(tracker.update(isEditing: false, bottomInset: 311.4), isTrue);
     },
   );
 
   test('releases latch once keyboard clearly starts closing', () {
     final tracker = ComposerLiftIntentTracker();
 
-    expect(tracker.update(hasInputIntent: true, bottomInset: 320), isTrue);
-    expect(tracker.update(hasInputIntent: false, bottomInset: 320), isTrue);
-    expect(tracker.update(hasInputIntent: false, bottomInset: 304), isFalse);
+    tracker.arm();
+
+    expect(tracker.update(isEditing: false, bottomInset: 320), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 320), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 304), isFalse);
   });
 
   test('does not lift a visible keyboard without prior input intent', () {
     final tracker = ComposerLiftIntentTracker();
 
-    expect(tracker.update(hasInputIntent: false, bottomInset: 288), isFalse);
+    expect(tracker.update(isEditing: false, bottomInset: 288), isFalse);
   });
 
   test('clears the latch after the keyboard settles closed', () {
     final tracker = ComposerLiftIntentTracker();
 
-    expect(tracker.update(hasInputIntent: true, bottomInset: 260), isTrue);
-    expect(tracker.update(hasInputIntent: false, bottomInset: 0), isFalse);
-    expect(tracker.update(hasInputIntent: false, bottomInset: 280), isFalse);
+    tracker.arm();
+
+    expect(tracker.update(isEditing: false, bottomInset: 260), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 0), isFalse);
+    expect(tracker.update(isEditing: false, bottomInset: 280), isFalse);
+  });
+
+  test('releases a pending arm after the keyboard never becomes visible', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    tracker.arm();
+
+    expect(tracker.update(isEditing: false, bottomInset: 0), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 0), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 0), isFalse);
+  });
+
+  test('editing state keeps lift armed without focus snapshot input', () {
+    final tracker = ComposerLiftIntentTracker();
+
+    expect(tracker.update(isEditing: true, bottomInset: 0), isTrue);
+    expect(tracker.update(isEditing: true, bottomInset: 320), isTrue);
+    expect(tracker.update(isEditing: false, bottomInset: 320), isTrue);
   });
 }


### PR DESCRIPTION
## 变更摘要

本次修复针对群里的Jason大佬全屏聊天页在它的设备下，输入框可能被输入法遮挡的问题。  
根因不是 `adjustResize` 或模型选择 `Overlay`，而是 composer lift 链路仍然依赖 `build` 当帧的 focus snapshot；当 `IME` 已开始弹出但 focus 短暂抖动时，页面会误判为不该继续上抬。  
修复方式是把 composer lift intent 从 build-time focus snapshot 改成 event-time armed latch，同时保留现有 `ComposerKeyboardMetricsTracker`。

## 变更类型

- [x]  Bug 修复

## 关联 Issue

Closes #391 

## 主要改动

1. 在全屏聊天页引入 event-time armed latch：在 composer 点击、显式 `requestFocus()`、`FocusNode` 获得焦点、进入消息编辑态时先 arm，再由后续帧消费该 intent。
2. 保留 `ComposerKeyboardMetricsTracker` 和 `resizeToAvoidBottomInset: false`，只替换上游 `shouldLiftComposerForKeyboard` 的供给方式，不改模型选择 `Overlay` 逻辑，也不改成“`IME > 0` 就一直 lift”。

## 测试说明

测试后zhuabao抓包日志符合修改预期：focus 已丢，但 IME 仍可见时 composer 继续保持 lift
<img width="1088" height="71" alt="image" src="https://github.com/user-attachments/assets/6608cf46-1583-474a-adc4-1a52f24b47cb" />
<img width="1084" height="70" alt="image" src="https://github.com/user-attachments/assets/63bd2fec-38f8-48b5-ac02-c4f26f0e660a" />


```

## UI 变更（如有）

无

## 风险与回滚

无
