### PR TITLE
修复 OpenAI-compatible 流中 choice.text 重复合并

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -326,14 +326,17 @@ class AgentLlmStreamAccumulator(
     private fun consumeChoice(choice: JsonObject): Boolean {
         choice["finish_reason"]?.jsonPrimitive?.contentOrNull?.let { finishReason = it }
         var hasPayload = false
+        var hasChatContentPayload = false
 
         val delta = choice["delta"] as? JsonObject
         if (delta != null) {
+            hasChatContentPayload = hasTextPayload(delta["content"])
             hasPayload = consumeMessageLike(delta, isDelta = true) || hasPayload
         }
 
         val message = choice["message"] as? JsonObject
         if (message != null) {
+            hasChatContentPayload = hasTextPayload(message["content"]) || hasChatContentPayload
             hasPayload = consumeMessageLike(message, isDelta = false) || hasPayload
         }
 
@@ -355,8 +358,13 @@ class AgentLlmStreamAccumulator(
             hasPayload = true
         }
 
-        // 某些 OpenAI-compat 实现会返回 completion 风格的 choice.text
-        hasPayload = appendTextPayload(choice["text"]) || hasPayload
+        // Some OpenAI-compatible streams include completion-style choice.text
+        // alongside chat-style delta/message content in the same choice. Treat
+        // choice.text as a text fallback, otherwise the same token is appended
+        // twice before it reaches Flutter.
+        if (!hasChatContentPayload) {
+            hasPayload = appendTextPayload(choice["text"]) || hasPayload
+        }
         return hasPayload
     }
 
@@ -520,6 +528,10 @@ class AgentLlmStreamAccumulator(
         val text = extractText(element) ?: return false
         appendTextChunk(text)
         return text.isNotEmpty()
+    }
+
+    private fun hasTextPayload(element: JsonElement?): Boolean {
+        return !extractText(element).isNullOrEmpty()
     }
 
     private fun appendTextChunk(text: String) {

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentLlmStreamAccumulatorTest.kt
@@ -168,6 +168,31 @@ class AgentLlmStreamAccumulatorTest {
 
         assertEquals("前缀后缀", turn.message.contentText())
     }
+
+    @Test
+    fun `does not append choice text when delta content already supplied payload`() {
+        val accumulator = AgentLlmStreamAccumulator(json = json)
+
+        accumulator.consume(
+            """{"choices":[{"delta":{"content":"The build finished."},"text":"The build finished."}]}"""
+        )
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("The build finished.", turn.message.contentText())
+    }
+
+    @Test
+    fun `keeps completion style choice text when no chat payload exists`() {
+        val accumulator = AgentLlmStreamAccumulator(json = json)
+
+        accumulator.consume("""{"choices":[{"text":"The build finished."}]}""")
+
+        val turn = accumulator.buildTurn()
+
+        assertEquals("The build finished.", turn.message.contentText())
+    }
+
     @Test
     fun `route-gated leading buffer reclassifies text before close tag for non local providers`() {
         val accumulator = AgentLlmStreamAccumulator(


### PR DESCRIPTION
这个 PR 修复 completion / OpenAI-compatible 流式回复最终显示成两份的问题：服务端返回的正常结果是 `A`，但主程序最终会把内容合成 `A + A`。

## 定位过程

在改主程序前，我们先用临时运行时验证版做过四层探测。这里的 L1 到 L4 只是排查时的内部编号：

- L1：拦 `CodexAppServerManager.setEventListener` 的 listener payload，检查 native 事件回调入口。
- L2：拦 Flutter `EventChannel.EventSink.success`，检查 native 向 Flutter 推事件的边界。
- L3：拦 Flutter `StandardMessageCodec.writeValue`，检查平台通道对象编码前的边界。
- L4：拦 SQLite `insert/update`，检查是否是落库或历史消息回放导致。

结果是：L1、L2 没有成为有效修复点；L4 装上但没有重写命中；真正稳定命中并能让显示恢复正常的是 L3。这个结果说明重复不是最后一层 Widget 简单 append 两次，也不像是 SQLite 回放导致，而是在平台通道编码前，payload 里的文本已经可能被主程序合成成了重复内容。

继续往上看主程序代码后，重复点落在 `AgentLlmStreamAccumulator.consumeChoice()`：它先消费 `choice.delta` / `choice.message`，随后又无条件消费 completion 风格的 `choice.text`。部分 OpenAI-compatible 服务会在同一个 choice 中同时给出 chat 风格的 `delta.content` 和 completion 风格的 `text`；如果两者内容相同，当前逻辑会把同一份文本追加两次，最终传到 Flutter 时就已经是 `A + A`。

## 修复方式

这次没有把临时 L3 验证版里的“半段折叠”搬进主程序。正式修复是把上游合并规则改正确：

- 如果同一个 choice 已经包含 `delta.content` 或 `message.content`，就把 `choice.text` 视为重复的 completion 兼容字段，不再追加。
- 如果 choice 没有 chat 文本 payload，仍然保留 `choice.text` fallback，兼容只返回 completion 风格 text 的服务商。
- tool call、function call、finish_reason、usage 等逻辑不变。

## 测试

新增了两个 accumulator 单测：

- 同一帧同时包含 `delta.content=A` 和 `text=A` 时，最终内容仍为 `A`。
- 只有 `choice.text=A`、没有 chat 文本 payload 时，仍然能正常得到 `A`。

## 验证

- `git diff --check origin/main` 通过。
- 尝试运行 `./gradlew.bat :app:testDevelopStandardDebugUnitTest --tests cn.com.omnimind.bot.agent.AgentLlmStreamAccumulatorTest`，但当前仓库缺少 `gradle/wrapper/gradle-wrapper.jar`，本机无法启动 Gradle wrapper：`ClassNotFoundException: org.gradle.wrapper.GradleWrapperMain`。