### PR TITLE
feat: 新增每轮对话后的统计指标(context、输入输出、缓存命中)以及API错误后的resume恢复机制

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/AgentStreamEvent.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/AgentStreamEvent.kt
@@ -18,6 +18,7 @@ data class AgentStreamEvent(
     val hasUserVisibleOutput: Boolean? = null,
     val latestPromptTokens: Int? = null,
     val promptTokenThreshold: Int? = null,
+    val turnUsage: Map<String, Any?>? = null,
     val error: String? = null,
     val question: String? = null,
     val missingFields: List<String>? = null,
@@ -53,6 +54,7 @@ data class AgentStreamEvent(
         hasUserVisibleOutput?.let { payload["hasUserVisibleOutput"] = it }
         latestPromptTokens?.let { payload["latestPromptTokens"] = it }
         promptTokenThreshold?.let { payload["promptTokenThreshold"] = it }
+        turnUsage?.let { payload["turnUsage"] = it }
         error?.takeIf { it.isNotBlank() }?.let { payload["error"] = it }
         question?.takeIf { it.isNotBlank() }?.let { payload["question"] = it }
         missingFields?.takeIf { it.isNotEmpty() }?.let { payload["missingFields"] = it }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -47,6 +47,7 @@ class AgentConversationHistoryRepository(
         entryId: String,
         text: String,
         attachments: List<Map<String, Any?>> = emptyList(),
+        turnUsage: Map<String, Any?>? = null,
         createdAt: Long = System.currentTimeMillis()
     ) {
         val payload = AgentConversationHistorySupport.buildTextMessagePayload(
@@ -56,6 +57,7 @@ class AgentConversationHistoryRepository(
             attachments = attachments,
             isError = false,
             streamMeta = null,
+            turnUsage = turnUsage,
             createdAt = createdAt
         )
         upsertMessageEntry(
@@ -79,6 +81,7 @@ class AgentConversationHistoryRepository(
         isError: Boolean = false,
         attachments: List<Map<String, Any?>> = emptyList(),
         streamMeta: Map<String, Any?>? = null,
+        turnUsage: Map<String, Any?>? = null,
         createdAt: Long = System.currentTimeMillis()
     ) {
         val payload = AgentConversationHistorySupport.buildTextMessagePayload(
@@ -89,6 +92,7 @@ class AgentConversationHistoryRepository(
             reasoningContent = reasoningContent,
             isError = isError,
             streamMeta = streamMeta,
+            turnUsage = turnUsage,
             createdAt = createdAt
         )
         upsertMessageEntry(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -72,6 +72,7 @@ internal object AgentConversationHistorySupport {
         reasoningContent: String? = null,
         isError: Boolean,
         streamMeta: Map<String, Any?>?,
+        turnUsage: Map<String, Any?>? = null,
         createdAt: Long
     ): Map<String, Any?> {
         val safeText = AgentTextSanitizer.sanitizeUtf16(text)
@@ -98,6 +99,7 @@ internal object AgentConversationHistorySupport {
             "isError" to isError,
             "isSummarizing" to false,
             "streamMeta" to streamMeta,
+            "turnUsage" to turnUsage,
             "createAt" to Instant.ofEpochMilli(createdAt).toString()
         ).apply {
             if (user == 2 && safeReasoning != null) {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentModels.kt
@@ -27,7 +27,10 @@ data class AgentFinalResponse(
     val content: String = "",
     val finishReason: String? = null,
     val latestPromptTokens: Int? = null,
-    val promptTokenThreshold: Int? = null
+    val promptTokenThreshold: Int? = null,
+    val completionTokens: Int? = null,
+    val cachedTokens: Int? = null,
+    val totalTokens: Int? = null
 )
 
 /**
@@ -40,7 +43,10 @@ sealed class AgentResult {
         val outputKind: String = AgentOutputKind.NONE.value,
         val hasUserVisibleOutput: Boolean = false,
         val latestPromptTokens: Int? = null,
-        val promptTokenThreshold: Int? = null
+        val promptTokenThreshold: Int? = null,
+        val completionTokens: Int? = null,
+        val cachedTokens: Int? = null,
+        val totalTokens: Int? = null
     ) : AgentResult()
     
     data class Error(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -21,6 +21,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 class AgentOrchestrator(
@@ -38,6 +40,11 @@ class AgentOrchestrator(
     )
 
     private class ExhaustedRetryableTurnFailure(
+        val errorMessage: String,
+        cause: Throwable
+    ) : RuntimeException(errorMessage, cause)
+
+    private class TerminalTurnRequestFailure(
         val errorMessage: String,
         cause: Throwable
     ) : RuntimeException(errorMessage, cause)
@@ -70,8 +77,36 @@ class AgentOrchestrator(
     private val maxTurnRequestRetries = 3
     private val turnRetryDelaysMs = listOf(500L, 1500L, 3000L)
 
+    private data class TurnUsage(
+        val promptTokens: Int? = null,
+        val completionTokens: Int? = null,
+        val totalTokens: Int? = null,
+        val cachedTokens: Int? = null
+    )
+
     private fun t(zh: String, en: String): String {
         return if (AppLocaleManager.isEnglish()) en else zh
+    }
+
+    private fun resolveTurnUsage(turn: ChatCompletionTurn): TurnUsage {
+        val usage = turn.usage
+        val promptTokens = usage?.promptTokens
+        val completionTokens = usage?.completionTokens
+        val totalTokens = usage?.totalTokens
+        val cachedTokens = usage?.promptTokensDetails
+            ?.let { detail ->
+                (detail as? kotlinx.serialization.json.JsonObject)
+                    ?.get("cached_tokens")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                    ?.toIntOrNull()
+            }
+        return TurnUsage(
+            promptTokens = promptTokens,
+            completionTokens = completionTokens,
+            totalTokens = totalTokens,
+            cachedTokens = cachedTokens
+        )
     }
 
     suspend fun run(input: Input): AgentResult {
@@ -86,6 +121,7 @@ class AgentOrchestrator(
         var lastFinishReason: String? = null
         var latestPromptTokens: Int? = null
         var latestPromptTokenThreshold: Int? = null
+        var lastTurnUsage: TurnUsage? = null
         var lastPrefillTokensPerSecond: Double? = null
         var lastDecodeTokensPerSecond: Double? = null
         var completedModelRounds = 0
@@ -133,8 +169,15 @@ class AgentOrchestrator(
                     terminalError = AgentResult.Error(e.errorMessage, e)
                     terminated = true
                     break@roundLoop
+                } catch (e: TerminalTurnRequestFailure) {
+                    callback.onError(e.errorMessage, true)
+                    terminalError = AgentResult.Error(e.errorMessage, e)
+                    terminated = true
+                    break@roundLoop
                 }
 
+                val turnUsage = resolveTurnUsage(turn)
+                lastTurnUsage = turnUsage
                 lastFinishReason = turn.finishReason
                 lastPrefillTokensPerSecond =
                     turn.usage?.prefillTokensPerSecond ?: lastPrefillTokensPerSecond
@@ -163,7 +206,7 @@ class AgentOrchestrator(
                             ?.takeIf { it.isNotBlank() }
                     )
                 )
-                latestPromptTokens = turn.usage?.promptTokens
+                latestPromptTokens = turnUsage.promptTokens
                 latestPromptTokenThreshold =
                     input.contextCompactor?.resolvePromptTokenThreshold(input.conversationId)
                 latestPromptTokens?.let { promptTokens ->
@@ -501,13 +544,19 @@ class AgentOrchestrator(
                 content = lastAssistantContent,
                 finishReason = lastFinishReason,
                 latestPromptTokens = latestPromptTokens,
-                promptTokenThreshold = latestPromptTokens?.let { latestPromptTokenThreshold }
+                promptTokenThreshold = latestPromptTokenThreshold,
+                completionTokens = lastTurnUsage?.completionTokens,
+                cachedTokens = lastTurnUsage?.cachedTokens,
+                totalTokens = lastTurnUsage?.totalTokens
             ),
             executedTools = executedTools,
             outputKind = outputKind.value,
             hasUserVisibleOutput = hasUserFacingOutput,
             latestPromptTokens = latestPromptTokens,
-            promptTokenThreshold = latestPromptTokens?.let { latestPromptTokenThreshold }
+            promptTokenThreshold = latestPromptTokenThreshold,
+            completionTokens = lastTurnUsage?.completionTokens,
+            cachedTokens = lastTurnUsage?.cachedTokens,
+            totalTokens = lastTurnUsage?.totalTokens
         )
         callback.onComplete(finalResult)
         return finalResult
@@ -552,7 +601,10 @@ class AgentOrchestrator(
                             cause = e
                         )
                     }
-                    throw e
+                    throw TerminalTurnRequestFailure(
+                        errorMessage = decision.reason,
+                        cause = e
+                    )
                 }
 
                 retryCount += 1

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
@@ -130,7 +130,8 @@ class OmniAgentExecutor(
         reasoningEffort: String?,
         terminalEnvironment: Map<String, String>,
         callback: AgentCallback,
-        runControl: AgentRunControl = NoOpAgentRunControl
+        runControl: AgentRunControl = NoOpAgentRunControl,
+        continueMode: Boolean = false
     ): AgentResult {
         var toolRouter: AgentToolRouter? = null
         return try {
@@ -191,6 +192,7 @@ class OmniAgentExecutor(
                 ),
                 userMessage = userMessage,
                 attachments = attachments,
+                continueMode = continueMode,
                 workspaceDescriptor = workspaceDescriptor,
                 installedSkills = installedSkills,
                 skillsRootShellPath = workspaceManager.shellPathForAndroid(workspaceManager.skillsRoot())
@@ -300,6 +302,7 @@ class OmniAgentExecutor(
         promptSeed: AgentConversationHistoryRepository.PromptSeed,
         userMessage: String,
         attachments: List<Map<String, Any?>>,
+        continueMode: Boolean,
         workspaceDescriptor: AgentWorkspaceDescriptor,
         installedSkills: List<SkillIndexEntry>,
         skillsRootShellPath: String,
@@ -331,7 +334,9 @@ class OmniAgentExecutor(
         messages.add(buildCachedTimeContextMessage(AppLocaleManager.resolvePromptLocale(context)))
         messages.addAll(historyMessages)
         buildPrefetchedMemoryAttachment(prefetchedMemoryHits)?.let { messages.add(it) }
-        messages.add(buildCurrentUserMessage(userMessage, attachments))
+        if (!continueMode) {
+            messages.add(buildCurrentUserMessage(userMessage, attachments))
+        }
         return messages
     }
 

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -286,6 +286,73 @@ private fun sanitizeInteropMap(payload: Map<String, Any?>): Map<String, Any?> {
     }
 }
 
+internal data class AgentTurnUsageSnapshot(
+    val ctxTokens: Int,
+    val inputTokens: Int,
+    val outputTokens: Int,
+    val cacheTokens: Int,
+    val promptTokens: Int,
+    val completionTokens: Int,
+    val totalTokens: Int,
+    val promptTokenThreshold: Int?
+) {
+    fun toPayload(): Map<String, Any?> {
+        return linkedMapOf(
+            "ctx" to ctxTokens,
+            "in" to inputTokens,
+            "out" to outputTokens,
+            "cache" to cacheTokens,
+            "promptTokens" to promptTokens,
+            "completionTokens" to completionTokens,
+            "totalTokens" to totalTokens,
+            "promptTokenThreshold" to promptTokenThreshold
+        )
+    }
+}
+
+internal fun buildTurnUsageSnapshot(
+    latestPromptTokens: Int?,
+    promptTokenThreshold: Int?,
+    result: AgentResult.Success?
+): AgentTurnUsageSnapshot? {
+    val promptTokens = latestPromptTokens ?: result?.latestPromptTokens ?: return null
+    val completionTokens = result?.completionTokens ?: 0
+    val cacheTokens = result?.cachedTokens ?: 0
+    val totalTokens = result?.totalTokens ?: (promptTokens + completionTokens)
+    val ctxTokens = (promptTokens + cacheTokens).coerceAtLeast(promptTokens)
+    return AgentTurnUsageSnapshot(
+        ctxTokens = ctxTokens,
+        inputTokens = promptTokens,
+        outputTokens = completionTokens,
+        cacheTokens = cacheTokens,
+        promptTokens = promptTokens,
+        completionTokens = completionTokens,
+        totalTokens = totalTokens,
+        promptTokenThreshold = promptTokenThreshold ?: result?.promptTokenThreshold
+    )
+}
+
+internal fun buildTurnUsageSnapshot(
+    latestPromptTokens: Int?,
+    promptTokenThreshold: Int?,
+    completionTokens: Int,
+    cachedTokens: Int
+): AgentTurnUsageSnapshot? {
+    val promptTokens = latestPromptTokens ?: return null
+    val totalTokens = promptTokens + completionTokens
+    val ctxTokens = (promptTokens + cachedTokens).coerceAtLeast(promptTokens)
+    return AgentTurnUsageSnapshot(
+        ctxTokens = ctxTokens,
+        inputTokens = promptTokens,
+        outputTokens = completionTokens,
+        cacheTokens = cachedTokens,
+        promptTokens = promptTokens,
+        completionTokens = completionTokens,
+        totalTokens = totalTokens,
+        promptTokenThreshold = promptTokenThreshold
+    )
+}
+
 internal const val AGENT_MANUAL_CANCELLATION_SEQUENCE = 1_000_000_000L
 internal const val AGENT_MANUAL_CANCELLATION_ROUND = 1_000_000_000
 
@@ -406,6 +473,26 @@ internal fun extractChatTaskPromptTokens(content: String): Int? {
         return null
     }
     return Regex("\"prompt_tokens\"\\s*:\\s*(\\d+)")
+        .find(normalized)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toIntOrNull()
+}
+
+internal fun extractChatTaskCompletionTokens(content: String): Int? {
+    val normalized = content.trim()
+    if (normalized.isEmpty() || normalized == "[DONE]") return null
+    return Regex("\"completion_tokens\"\\s*:\\s*(\\d+)")
+        .find(normalized)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.toIntOrNull()
+}
+
+internal fun extractChatTaskCachedTokens(content: String): Int? {
+    val normalized = content.trim()
+    if (normalized.isEmpty() || normalized == "[DONE]") return null
+    return Regex("\"cached_tokens\"\\s*:\\s*(\\d+)")
         .find(normalized)
         ?.groupValues
         ?.getOrNull(1)
@@ -573,10 +660,16 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val assistantBuffer: StringBuilder = StringBuilder(),
         var isError: Boolean = false,
         var latestPromptTokens: Int? = null,
-        var promptTokenThreshold: Int? = null
+        var promptTokenThreshold: Int? = null,
+        var completionTokens: Int? = null,
+        var cachedTokens: Int? = null
     )
 
     private data class FailedAgentRetryContext(
+        val arguments: Map<String, Any?>
+    )
+
+    private data class FailedAgentContinueContext(
         val arguments: Map<String, Any?>
     )
 
@@ -740,6 +833,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
     private val activeAgentRuns: MutableMap<String, ActiveAgentRunContext> = mutableMapOf()
     private val failedAgentRetryContexts: MutableMap<String, FailedAgentRetryContext> = mutableMapOf()
+    private val failedAgentContinueContexts: MutableMap<String, FailedAgentContinueContext> = mutableMapOf()
     private val chatTaskPersistenceStates: MutableMap<String, ChatTaskPersistenceState> =
         mutableMapOf()
     private val conversationDomainService by lazy { ConversationDomainService(context) }
@@ -766,15 +860,33 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         }
     }
 
+    private fun registerFailedAgentContinueContext(taskId: String, context: FailedAgentContinueContext) {
+        synchronized(activeAgentLock) {
+            failedAgentContinueContexts[taskId] = context
+        }
+    }
+
     private fun getFailedAgentRetryContext(taskId: String): FailedAgentRetryContext? {
         return synchronized(activeAgentLock) {
             failedAgentRetryContexts[taskId]
         }
     }
 
+    private fun getFailedAgentContinueContext(taskId: String): FailedAgentContinueContext? {
+        return synchronized(activeAgentLock) {
+            failedAgentContinueContexts[taskId]
+        }
+    }
+
     private fun removeFailedAgentRetryContext(taskId: String): FailedAgentRetryContext? {
         return synchronized(activeAgentLock) {
             failedAgentRetryContexts.remove(taskId)
+        }
+    }
+
+    private fun removeFailedAgentContinueContext(taskId: String): FailedAgentContinueContext? {
+        return synchronized(activeAgentLock) {
+            failedAgentContinueContexts.remove(taskId)
         }
     }
 
@@ -1577,6 +1689,120 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         }
     }
 
+    fun continueAgentTask(
+        call: MethodCall,
+        result: MethodChannel.Result
+    ) {
+        mainJob.launch {
+            try {
+                val taskId = call.argument<String>("taskId")?.trim().orEmpty()
+                if (taskId.isBlank()) {
+                    withContext(Dispatchers.Main) {
+                        result.error("INVALID_ARGUMENTS", "taskId is required", null)
+                    }
+                    return@launch
+                }
+                val continueContext = getFailedAgentContinueContext(taskId)
+                if (continueContext != null) {
+                    handleCreateOrContinueAgentTask(
+                        MethodCall("createAgentTask", continueContext.arguments),
+                        result,
+                        isContinue = true
+                    )
+                    return@launch
+                }
+                val retryContext = getFailedAgentRetryContext(taskId)
+                if (retryContext != null) {
+                    val continueArgs = retryContext.arguments.toMutableMap()
+                    continueArgs["continueMode"] = true
+                    continueArgs["continueResumeMode"] = "approximate"
+                    handleCreateOrContinueAgentTask(
+                        MethodCall("createAgentTask", continueArgs),
+                        result,
+                        isContinue = true
+                    )
+                    return@launch
+                }
+                val currentRun = synchronized(activeAgentLock) { activeAgentRuns[taskId] }
+                val conversationId = currentRun?.conversationId
+                    ?: call.argument<Number>("conversationId")?.toLong()
+                    ?: 0L
+                val conversationMode = normalizeConversationMode(
+                    call.argument<String>("conversationMode") ?: currentRun?.conversationMode
+                )
+                if (conversationId <= 0L) {
+                    withContext(Dispatchers.Main) {
+                        result.error("NO_CONTINUE_CONTEXT", "No conversation context found", null)
+                    }
+                    return@launch
+                }
+                val repository = conversationHistoryRepository()
+                val messages = repository.listConversationMessages(
+                    conversationId = conversationId,
+                    conversationMode = conversationMode
+                )
+                val assistantEntries = messages.filter { entry ->
+                    (entry["user"] as? Number)?.toInt() == 2 &&
+                        (entry["type"] as? Number)?.toInt() != 2
+                }
+                val lastAssistant = assistantEntries.lastOrNull() ?: run {
+                    withContext(Dispatchers.Main) {
+                        result.error(
+                            "NO_CONTINUE_CONTEXT",
+                            "No resumable assistant turn found for taskId=$taskId",
+                            null
+                        )
+                    }
+                    return@launch
+                }
+                val lastUser = messages.lastOrNull { entry ->
+                    (entry["user"] as? Number)?.toInt() == 1
+                } ?: run {
+                    withContext(Dispatchers.Main) {
+                        result.error(
+                            "NO_CONTINUE_CONTEXT",
+                            "No user message found for continuation",
+                            null
+                        )
+                    }
+                    return@launch
+                }
+                val userMessage = (lastUser["content"] as? Map<*, *>)
+                    ?.get("text")
+                    ?.toString()
+                    ?.trim()
+                    .orEmpty()
+                val continueArgs = linkedMapOf<String, Any?>(
+                    "taskId" to taskId,
+                    "userMessage" to userMessage,
+                    "conversationId" to conversationId,
+                    "conversationMode" to conversationMode,
+                    "continueMode" to true,
+                    "continueResumeMode" to "approximate",
+                    "continueFromAssistantEntryId" to lastAssistant["id"]?.toString(),
+                    "continueFromAssistantText" to (lastAssistant["content"] as? Map<*, *>)?.get("text")
+                        ?.toString()
+                        .orEmpty(),
+                    "continueTurnUsage" to (lastAssistant["turnUsage"] as? Map<*, *>)?.let(::sanitizeInteropValue)
+                )
+                registerFailedAgentContinueContext(
+                    taskId,
+                    FailedAgentContinueContext(arguments = sanitizeInteropMap(continueArgs))
+                )
+                handleCreateOrContinueAgentTask(
+                    MethodCall("createAgentTask", continueArgs),
+                    result,
+                    isContinue = true
+                )
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "continueAgentTask error: ${e.message}")
+                withContext(Dispatchers.Main) {
+                    result.error("CONTINUE_AGENT_TASK_ERROR", e.message, null)
+                }
+            }
+        }
+    }
+
     /**
      * 取消聊天任务
      */
@@ -1785,6 +2011,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     )
                     state.latestPromptTokens = promptTokens
                     state.promptTokenThreshold = promptTokenThreshold
+                    extractChatTaskCompletionTokens(content)?.let { state.completionTokens = it }
+                    extractChatTaskCachedTokens(content)?.let { state.cachedTokens = it }
                     repository.updatePromptTokenUsage(
                         conversationId = state.conversationId,
                         promptTokens = promptTokens,
@@ -1886,6 +2114,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             taskID,
             persistenceState
         )
+        val turnUsagePayload = persistenceState?.let { state ->
+            buildTurnUsageSnapshot(
+                latestPromptTokens = state.latestPromptTokens,
+                promptTokenThreshold = state.promptTokenThreshold,
+                completionTokens = state.completionTokens ?: 0,
+                cachedTokens = state.cachedTokens ?: 0
+            )?.toPayload()
+        }
         withContext(Dispatchers.Main) {
             try {
                 val isSummary = isSummaryTask(taskID)
@@ -1894,7 +2130,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 if (isSummary && mainChannel != null && mainChannel != channel) {
                     mainChannel.invokeMethod(
                         "onChatMessageEnd", mapOf(
-                            "taskID" to taskID
+                            "taskID" to taskID,
+                            "turnUsage" to turnUsagePayload
                         )
                     )
                     // 如果当前不是主引擎通道，避免在半屏重复展示
@@ -1903,7 +2140,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
                 channel.invokeMethod(
                     "onChatMessageEnd", mapOf(
-                        "taskID" to taskID
+                        "taskID" to taskID,
+                        "turnUsage" to turnUsagePayload
                     )
                 )
             } catch (e: Exception) {
@@ -4078,6 +4316,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
     }
 
     fun createAgentTask(call: MethodCall, result: MethodChannel.Result) {
+        handleCreateOrContinueAgentTask(call, result, isContinue = false)
+    }
+
+    private fun handleCreateOrContinueAgentTask(
+        call: MethodCall,
+        result: MethodChannel.Result,
+        isContinue: Boolean
+    ) {
         val rawCallArguments = (call.arguments as? Map<*, *>)
             ?.entries
             ?.filter { it.key != null }
@@ -4123,11 +4369,26 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         val terminalEnvironment = parseTerminalEnvironmentMap(
             call.argument<Map<String, Any?>>("terminalEnvironment")
         )
+        val continueMode = isContinue || call.argument<Boolean>("continueMode") == true
+        val continueResumeMode = call.argument<String>("continueResumeMode")
+            ?.trim()
+            ?.ifEmpty { null }
+            ?: (if (continueMode) "approximate" else null)
+        val continueFromAssistantEntryId = call.argument<String>("continueFromAssistantEntryId")
+            ?.trim()
+            ?.ifEmpty { null }
+        val continueFromAssistantText = call.argument<String>("continueFromAssistantText")
+            ?.let(AgentTextSanitizer::sanitizeUtf16)
+            ?.trim()
+            ?.ifEmpty { null }
+        val continueTurnUsage = call.argument<Map<String, Any?>>("continueTurnUsage")
+            ?.let(::sanitizeInteropMap)
         if (taskId.isBlank()) {
             result.error("INVALID_ARGUMENTS", "taskId is empty", null)
             return
         }
         removeFailedAgentRetryContext(taskId)
+        removeFailedAgentContinueContext(taskId)
         if (legacyConversationHistory.isNotEmpty()) {
             OmniLog.d(
                 TAG,
@@ -4143,7 +4404,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 "conversationId" to conversationId,
                 "conversationMode" to resolvedConversationMode,
                 "reasoningEffort" to reasoningEffort,
-                "terminalEnvironment" to terminalEnvironment
+                "terminalEnvironment" to terminalEnvironment,
+                "continueMode" to continueMode,
+                "continueResumeMode" to continueResumeMode,
+                "continueFromAssistantEntryId" to continueFromAssistantEntryId,
+                "continueFromAssistantText" to continueFromAssistantText,
+                "continueTurnUsage" to continueTurnUsage
             )
         )
         val agentRunJob = SupervisorJob()
@@ -4165,6 +4431,12 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 val runtimeContextRepository = AgentRuntimeContextRepository(context)
                 historyRepository = conversationHistoryRepository()
                 val repository = historyRepository ?: return@launch
+                if (continueMode) {
+                    registerFailedAgentContinueContext(
+                        taskId,
+                        FailedAgentContinueContext(arguments = retryArguments)
+                    )
+                }
 
                 val scheduleBridge = object : AgentScheduleToolBridge {
                     override suspend fun createTask(arguments: Map<String, Any?>): Map<String, Any?> {
@@ -4456,7 +4728,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     roundIndex: Int,
                     text: String,
                     isError: Boolean,
-                    streamKind: String = "text_snapshot"
+                    streamKind: String = "text_snapshot",
+                    usageSnapshot: AgentTurnUsageSnapshot? = null
                 ) {
                     val normalizedConversationId = conversationId ?: return
                     val normalizedText = AgentTextSanitizer.sanitizeUtf16(text).trim()
@@ -4479,6 +4752,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                                 roundIndex = roundIndex,
                                 kind = streamKind
                             ),
+                            turnUsage = usageSnapshot?.toPayload(),
                             createdAt = createdAt
                         )
                     }
@@ -4625,6 +4899,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                     question: String? = null,
                     missingFields: List<String>? = null,
                     missing: List<String>? = null,
+                    turnUsage: Map<String, Any?>? = null,
                     extras: Map<String, Any?> = emptyMap()
                 ) {
                     val effectiveThinking = thinking
@@ -4655,6 +4930,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         question = question,
                         missingFields = missingFields,
                         missing = missing,
+                        turnUsage = turnUsage,
                         extras = extras
                     ).toPayload(
                         conversationId = conversationId,
@@ -4678,7 +4954,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 }
 
                 conversationId?.let { normalizedConversationId ->
-                    if (userMessage.isNotBlank() || historyAttachments.isNotEmpty()) {
+                    if (!continueMode && (userMessage.isNotBlank() || historyAttachments.isNotEmpty())) {
                         persistConversationMutation("upsert user message") {
                             repository.upsertUserMessage(
                                 conversationId = normalizedConversationId,
@@ -4977,6 +5253,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
 
                     override suspend fun onComplete(result: AgentResult) {
                         removeFailedAgentRetryContext(taskId)
+                        removeFailedAgentContinueContext(taskId)
                         val isSuccess = result is AgentResult.Success
                         val outputKind = (result as? AgentResult.Success)?.outputKind ?: "none"
                         val hasUserVisibleOutput =
@@ -4984,6 +5261,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                         val latestPromptTokens = (result as? AgentResult.Success)?.latestPromptTokens
                         val promptTokenThreshold =
                             (result as? AgentResult.Success)?.promptTokenThreshold
+                        val turnUsageSnapshot = buildTurnUsageSnapshot(
+                            latestPromptTokens = latestPromptTokens,
+                            promptTokenThreshold = promptTokenThreshold,
+                            result = result as? AgentResult.Success
+                        )
                         val streamed = scheduledAssistantBuffer.toString().trim()
                         val fallback = (result as? AgentResult.Success)
                             ?.response
@@ -5023,14 +5305,16 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                                     roundIndex = roundIndex,
                                     text = finalText,
                                     isError = !isSuccess,
-                                    streamKind = "text_snapshot"
+                                    streamKind = "text_snapshot",
+                                    usageSnapshot = turnUsageSnapshot
                                 )
                                 sendStreamEvent(
                                     kind = "text_snapshot",
                                     entryId = entryId,
                                     roundIndex = roundIndex,
                                     isFinal = true,
-                                    text = finalText
+                                    text = finalText,
+                                    turnUsage = turnUsageSnapshot?.toPayload()
                                 )
                             }
                         }
@@ -5071,7 +5355,8 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             outputKind = outputKind,
                             hasUserVisibleOutput = hasUserVisibleOutput,
                             latestPromptTokens = latestPromptTokens,
-                            promptTokenThreshold = promptTokenThreshold
+                            promptTokenThreshold = promptTokenThreshold,
+                            turnUsage = turnUsageSnapshot?.toPayload()
                         )
                     }
 
@@ -5135,6 +5420,11 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             )
                         }
                         val finalText = resolution.text
+                        val errorTurnUsageSnapshot = buildTurnUsageSnapshot(
+                            latestPromptTokens = (result as? AgentResult.Success)?.latestPromptTokens,
+                            promptTokenThreshold = (result as? AgentResult.Success)?.promptTokenThreshold,
+                            result = result as? AgentResult.Success
+                        )
                         finalizeThinkingCardIfNeeded(publish = finalText.isBlank())
                         var errorEntryId: String? = activeAssistantEntryId
                         var errorRoundIndex = assistantRound
@@ -5155,16 +5445,41 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                                     roundIndex = roundIndex,
                                     text = finalText,
                                     isError = resolution.persistAsError,
-                                    streamKind = "text_snapshot"
+                                    streamKind = "text_snapshot",
+                                    usageSnapshot = errorTurnUsageSnapshot
                                 )
                                 sendStreamEvent(
                                     kind = "text_snapshot",
                                     entryId = entryId,
                                     roundIndex = roundIndex,
                                     isFinal = true,
-                                    text = finalText
+                                    text = finalText,
+                                    turnUsage = errorTurnUsageSnapshot?.toPayload()
                                 )
                             }
+                        }
+                        val continueResumeModeValue = continueResumeMode ?: "approximate"
+                        val continuePayload = errorTurnUsageSnapshot?.toPayload() ?: continueTurnUsage
+                        val continueable = conversationId != null &&
+                            errorEntryId?.isNotBlank() == true &&
+                            finalText.isNotBlank()
+                        if (continueable) {
+                            registerFailedAgentContinueContext(
+                                taskId,
+                                FailedAgentContinueContext(
+                                    arguments = sanitizeInteropMap(
+                                        retryArguments + mapOf(
+                                            "continueMode" to true,
+                                            "continueResumeMode" to continueResumeModeValue,
+                                            "continueFromAssistantEntryId" to errorEntryId,
+                                            "continueFromAssistantText" to finalText,
+                                            "continueTurnUsage" to continuePayload
+                                        )
+                                    )
+                                )
+                            )
+                        } else if (!continueMode) {
+                            removeFailedAgentContinueContext(taskId)
                         }
                         scheduledSubagentMeta?.let { meta ->
                             runCatching {
@@ -5182,10 +5497,13 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                             entryId = errorEntryId,
                             roundIndex = errorRoundIndex,
                             error = error,
+                            turnUsage = continuePayload,
                             extras = mapOf(
                                 "persistAsError" to resolution.persistAsError,
                                 "willRetry" to false,
                                 "retryable" to retryable,
+                                "continueable" to continueable,
+                                "continueResumeMode" to if (continueable) continueResumeModeValue else null,
                                 "retryCount" to if (retryable) 3 else 0,
                                 "maxRetries" to 3,
                                 "errorText" to errorText

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
@@ -210,6 +210,9 @@ class AssistsCoreChannel {
                 "retryAgentTask" -> {
                     assistsCoreManager!!.retryAgentTask(call, result)
                 }
+                "continueAgentTask" -> {
+                    assistsCoreManager!!.continueAgentTask(call, result)
+                }
                 "isCompanionTaskRunning" -> {
                     assistsCoreManager!!.isCompanionTaskRunning( call, result)
                 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -914,6 +914,38 @@ class AgentOrchestratorTest {
         assertTrue(callback.finalChatMessages().isEmpty())
     }
 
+    @Test
+    fun `surfaces non transient api error as manually resumable terminal error`() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = emptyList(),
+            failures = listOf(
+                AgentStreamRequestException(
+                    statusCode = 400,
+                    reason = "invalid request payload",
+                    responseBody = null
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(
+            llmClient = llmClient,
+            toolExecutor = FakeToolExecutor()
+        ).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("缁х画鎵ц缃戦〉鏌ヨ"),
+                executionEnv = FakeExecutionEnvironment("缁х画鎵ц缃戦〉鏌ヨ")
+            )
+        )
+
+        assertTrue(result is AgentResult.Error)
+        assertTrue(callback.retryingEvents.isEmpty())
+        assertEquals("invalid request payload", callback.errors.single())
+        assertTrue(callback.lastErrorRetryable)
+        assertTrue(callback.finalChatMessages().isEmpty())
+    }
+
     private fun createOrchestrator(
         llmClient: FakeLlmClient,
         toolExecutor: FakeToolExecutor,

--- a/app/src/test/java/cn/com/omnimind/bot/manager/AssistsCoreManagerAgentFinalizationTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/manager/AssistsCoreManagerAgentFinalizationTest.kt
@@ -2,8 +2,11 @@ package cn.com.omnimind.bot.manager
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import cn.com.omnimind.bot.agent.AgentFinalResponse
+import cn.com.omnimind.bot.agent.AgentResult
 
 class AssistsCoreManagerAgentFinalizationTest {
     @Test
@@ -58,5 +61,34 @@ class AssistsCoreManagerAgentFinalizationTest {
         assertEquals("agent-task", meta["parentTaskId"])
         assertEquals("agent-task-cancelled", meta["entryId"])
         assertEquals(true, meta["isFinal"])
+    }
+
+    @Test
+    fun `buildTurnUsageSnapshot maps per-turn usage fields onto ui payload`() {
+        val success = AgentResult.Success(
+            response = AgentFinalResponse(content = "done"),
+            executedTools = emptyList(),
+            outputKind = "text",
+            hasUserVisibleOutput = true,
+            latestPromptTokens = 10_000,
+            promptTokenThreshold = 128_000,
+            completionTokens = 87,
+            cachedTokens = 10_000,
+            totalTokens = 10_087
+        )
+
+        val snapshot = buildTurnUsageSnapshot(
+            latestPromptTokens = success.latestPromptTokens,
+            promptTokenThreshold = success.promptTokenThreshold,
+            result = success
+        )
+
+        assertNotNull(snapshot)
+        assertEquals(20_000, snapshot?.ctxTokens)
+        assertEquals(10_000, snapshot?.inputTokens)
+        assertEquals(87, snapshot?.outputTokens)
+        assertEquals(10_000, snapshot?.cacheTokens)
+        assertEquals(10_087, snapshot?.totalTokens)
+        assertEquals(128_000, snapshot?.promptTokenThreshold)
     }
 }

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -17,6 +17,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
   static const double _kHdPadPaneCollapseWidthRatio = 0.12;
   static const double _kHdPadPaneCollapseMinWidthFactor = 0.72;
   final Set<String> _pendingManualAgentRetryTaskIds = <String>{};
+  final Set<String> _pendingManualAgentContinueTaskIds = <String>{};
 
   ChatPageMode get _primaryChatMessagePageMode =>
       _activeMode == ChatPageMode.codex
@@ -871,6 +872,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
       messages: resolvedMessages,
       activeAgentTaskIds: activeAgentTaskIds,
       onRetryAgentMessage: _retryFailedAgentTurn,
+      onContinueAgentMessage: _continueFailedAgentTurn,
       expandedAgentRunTaskIds: _expandedAgentRunTaskIdsForMode(mode),
       onExpandedAgentRunTaskIdsChanged: (taskIds) {
         _updateExpandedAgentRunTaskIds(mode, taskIds);
@@ -2360,6 +2362,71 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     }
   }
 
+  Future<void> _continueFailedAgentTurn(ChatMessageModel message) async {
+    final taskId = _resolveContinueableAgentTaskId(message);
+    if (taskId == null) {
+      showToast(
+        LegacyTextLocalizer.isEnglish
+            ? 'This reply can no longer continue from the current turn'
+            : '这条回复当前无法从本轮继续',
+        type: ToastType.warning,
+      );
+      return;
+    }
+    if (_pendingManualAgentContinueTaskIds.contains(taskId) ||
+        message.content?['agentContinuing'] == true) {
+      return;
+    }
+    if (_isAiResponding) {
+      showToast(
+        LegacyTextLocalizer.isEnglish
+            ? 'Wait for the current response to finish first'
+            : '请先等待当前回复结束',
+        type: ToastType.warning,
+      );
+      return;
+    }
+
+    final messageIndex = _messages.indexWhere((item) => item.id == message.id);
+    final previousMessage = messageIndex == -1 ? null : _messages[messageIndex];
+    _pendingManualAgentContinueTaskIds.add(taskId);
+    if (previousMessage != null && mounted) {
+      setState(() {
+        _messages[messageIndex] = _buildPendingManualContinueMessage(
+          previousMessage,
+          taskId: taskId,
+        );
+      });
+    }
+
+    final success = await AssistsMessageService.continueAgentTask(
+      taskId: taskId,
+    );
+    _pendingManualAgentContinueTaskIds.remove(taskId);
+    if (!mounted) {
+      return;
+    }
+    if (!success) {
+      if (previousMessage != null) {
+        final restoreIndex = _messages.indexWhere(
+          (item) => item.id == previousMessage.id,
+        );
+        if (restoreIndex != -1) {
+          setState(() {
+            _messages[restoreIndex] = previousMessage;
+          });
+        }
+      }
+      showToast(
+        LegacyTextLocalizer.isEnglish
+            ? 'Continue failed. Please try again.'
+            : '继续失败，请稍后再试',
+        type: ToastType.error,
+      );
+      return;
+    }
+  }
+
   List<Map<String, dynamic>> _extractRetryAttachments(
     ChatMessageModel message,
   ) {
@@ -2372,6 +2439,20 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
   }
 
   String? _resolveRetryableAgentTaskId(ChatMessageModel message) {
+    if (message.content?['agentRetryable'] != true) {
+      return null;
+    }
+    return _resolveAgentTaskId(message);
+  }
+
+  String? _resolveContinueableAgentTaskId(ChatMessageModel message) {
+    if (message.content?['agentContinueable'] != true) {
+      return null;
+    }
+    return _resolveAgentTaskId(message);
+  }
+
+  String? _resolveAgentTaskId(ChatMessageModel message) {
     final contentTaskId = (message.content?['agentTaskId'] ?? '')
         .toString()
         .trim();
@@ -2394,6 +2475,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     final content = Map<String, dynamic>.from(message.content ?? const {});
     content['agentTaskId'] = taskId;
     content['agentRetrying'] = true;
+    content['agentContinuing'] = false;
     content['agentRetryStatusText'] = LegacyTextLocalizer.isEnglish
         ? 'Retrying connection...'
         : '连接中断，正在重试…';
@@ -2403,6 +2485,32 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     content['agentRetryDelayMs'] = 0;
     content.remove('agentRetryReason');
     content.remove('agentRetryable');
+    content.remove('agentContinueable');
+    content.remove('agentContinueResumeMode');
+    content.remove('agentContinueStatusText');
+    content.remove('agentErrorText');
+    return message.copyWith(content: content, isError: false);
+  }
+
+  ChatMessageModel _buildPendingManualContinueMessage(
+    ChatMessageModel message, {
+    required String taskId,
+  }) {
+    final content = Map<String, dynamic>.from(message.content ?? const {});
+    content['agentTaskId'] = taskId;
+    content['agentRetrying'] = false;
+    content['agentContinuing'] = true;
+    content['agentContinueStatusText'] = LegacyTextLocalizer.isEnglish
+        ? 'Continuing from current turn...'
+        : '正在从当前轮继续…';
+    content.remove('agentRetryStatusText');
+    content.remove('agentRetryCount');
+    content.remove('agentMaxRetries');
+    content.remove('agentRetryDelayMs');
+    content.remove('agentRetryReason');
+    content.remove('agentRetryable');
+    content.remove('agentContinueable');
+    content.remove('agentContinueResumeMode');
     content.remove('agentErrorText');
     return message.copyWith(content: content, isError: false);
   }

--- a/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
+++ b/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
@@ -335,7 +335,9 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
           lockCompleted: false,
         );
       } else {
-        final messageId = entryId.isNotEmpty ? entryId : _nextAgentTextMessageId(event.taskId);
+        final messageId = entryId.isNotEmpty
+            ? entryId
+            : _nextAgentTextMessageId(event.taskId);
         final index = messages.indexWhere((msg) => msg.id == messageId);
         if (index == -1) {
           final content = <String, dynamic>{'text': '', 'id': messageId};
@@ -473,7 +475,9 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
   }) {
     final entryId = (event.entryId ?? '').trim();
     final shouldMarkError = event.raw['persistAsError'] == true;
-    final errorText = (event.raw['errorText'] ?? event.errorMessage).toString().trim();
+    final errorText = (event.raw['errorText'] ?? event.errorMessage)
+        .toString()
+        .trim();
     setState(() {
       currentThinkingStage = ThinkingStage.complete.value;
       isDeepThinking = false;
@@ -492,6 +496,7 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
               entryId: entryId,
               isFinal: true,
             ),
+            turnUsage: event.turnUsage ?? existing.turnUsage,
           );
         }
       }
@@ -620,6 +625,10 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     content['agentMaxRetries'] = event.maxRetries;
     content['agentRetryDelayMs'] = event.retryDelayMs;
     content['agentRetryReason'] = event.retryReason;
+    content['agentContinuing'] = false;
+    content.remove('agentContinueStatusText');
+    content.remove('agentContinueable');
+    content.remove('agentContinueResumeMode');
     content.remove('agentErrorText');
     content.remove('agentRetryable');
   }
@@ -636,7 +645,11 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     content['agentMaxRetries'] = event.maxRetries;
     content['agentRetryDelayMs'] = 0;
     content['agentRetryReason'] = event.retryReason;
+    content['agentContinuing'] = false;
+    content['agentContinueStatusText'] = '';
     content['agentRetryable'] = event.retryable;
+    content['agentContinueable'] = event.continueable;
+    content['agentContinueResumeMode'] = event.continueResumeMode;
     content['agentErrorText'] = errorText;
   }
 
@@ -648,6 +661,10 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
     content.remove('agentRetryDelayMs');
     content.remove('agentRetryReason');
     content.remove('agentRetryable');
+    content.remove('agentContinuing');
+    content.remove('agentContinueStatusText');
+    content.remove('agentContinueable');
+    content.remove('agentContinueResumeMode');
     content.remove('agentErrorText');
   }
 

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -1175,6 +1175,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     bool isFinal = false,
     bool isError = false,
     Map<String, dynamic>? streamMeta,
+    Map<String, dynamic>? turnUsage,
     double? prefillTokensPerSecond,
     double? decodeTokensPerSecond,
     String? reasoningContent,
@@ -1210,6 +1211,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
           content: content,
           isError: isError,
           streamMeta: resolvedStreamMeta,
+          turnUsage: turnUsage,
           reasoningContent: _normalizeReasoningContent(reasoningContent),
         ),
       );
@@ -1241,6 +1243,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         entryId: messageId,
         isFinal: isFinal,
       ),
+      turnUsage: turnUsage ?? existing.turnUsage,
       reasoningContent:
           _normalizeReasoningContent(reasoningContent) ??
           existing.reasoningContent,
@@ -1381,6 +1384,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     bool isSummarizing;
     var shouldUpdateAiMessage = false;
     var didSchedulePersistence = false;
+    var hadPartialText = false;
 
     if (isRateLimited) {
       _flushPureChatReplyBatch(runtime, taskId, emitVoiceUpdate: true);
@@ -1396,6 +1400,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       );
       shouldUpdateAiMessage = true;
     } else if (isErrorMessage) {
+      hadPartialText =
+          (runtime.currentAiMessages[taskId]?.isNotEmpty ?? false) ||
+          _visiblePureChatReplyText(runtime, taskId).isNotEmpty;
       _flushPureChatReplyBatch(runtime, taskId, emitVoiceUpdate: true);
       messageText = kNetworkErrorMessage;
       isError = true;
@@ -1508,6 +1515,16 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         )) {
       didSchedulePersistence = true;
     }
+    if (isError && isErrorMessage) {
+      final errIdx = runtime.messages.indexWhere((m) => m.id == taskId);
+      if (errIdx != -1) {
+        final errMsg = runtime.messages[errIdx];
+        final errContent = Map<String, dynamic>.from(errMsg.content ?? {});
+        errContent['agentRetryable'] = true;
+        if (hadPartialText) errContent['agentContinueable'] = true;
+        runtime.messages[errIdx] = errMsg.copyWith(content: errContent);
+      }
+    }
     runtime.isAiResponding = true;
     notifyListeners();
     if (!didSchedulePersistence &&
@@ -1519,7 +1536,10 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     }
   }
 
-  void _handleChatTaskMessageEnd(String taskId) {
+  void _handleChatTaskMessageEnd(
+    String taskId, {
+    Map<String, dynamic>? turnUsage,
+  }) {
     final binding = _taskBindings[taskId];
     final runtime = _runtimeForTask(taskId);
     if (binding == null || runtime == null) return;
@@ -1554,7 +1574,10 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
 
     if (messageText.isNotEmpty && index != -1) {
       final existing = runtime.messages[index];
-      runtime.messages[index] = existing.copyWith(content: existing.content);
+      runtime.messages[index] = existing.copyWith(
+        content: existing.content,
+        turnUsage: turnUsage ?? existing.turnUsage,
+      );
       _syncMessageLinkPreviews(runtime, taskId);
     }
     if (!isErrorMessage && messageText.trim().isNotEmpty) {
@@ -1739,7 +1762,8 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     if (runtime.messages.any((m) => m.id == entryId)) return;
 
     final text = (data['text'] ?? '').toString();
-    final createdAtMs = _asPositiveInt(data['createdAt']) ??
+    final createdAtMs =
+        _asPositiveInt(data['createdAt']) ??
         DateTime.now().millisecondsSinceEpoch;
     final createdAt = DateTime.fromMillisecondsSinceEpoch(createdAtMs);
     final rawAttachments = data['attachments'];
@@ -1785,12 +1809,13 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       _ => ConversationMode.normal,
     };
     try {
-      final result = await ConversationHistoryService.getConversationMessagesPaged(
-        conversationId,
-        mode: conversationMode,
-        limit: 100,
-        offset: 0,
-      );
+      final result =
+          await ConversationHistoryService.getConversationMessagesPaged(
+            conversationId,
+            mode: conversationMode,
+            limit: 100,
+            offset: 0,
+          );
       final stillMissingFromRuntime = _runtimes[runtimeKey];
       if (stillMissingFromRuntime == null) return;
       if (stillMissingFromRuntime.messages.any((m) => m.id == userEntryId)) {
@@ -1956,6 +1981,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       renderMarkdown: true,
       isFinal: event.isFinal,
       streamMeta: _streamMetaFromEvent(event),
+      turnUsage: event.turnUsage,
       prefillTokensPerSecond: event.prefillTokensPerSecond,
       decodeTokensPerSecond: event.decodeTokensPerSecond,
       reasoningContent: event.thinking,
@@ -2041,7 +2067,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     );
     final isThinkingCardTarget =
         entryId.isNotEmpty &&
-        runtime.messages.any((message) => message.id == entryId && message.type == 2);
+        runtime.messages.any(
+          (message) => message.id == entryId && message.type == 2,
+        );
     if (!isThinkingCardTarget) {
       _finalizeThinkingCard(
         runtime,
@@ -2061,8 +2089,12 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         lockCompleted: false,
       );
     } else {
-      final messageId = entryId.isNotEmpty ? entryId : _nextAgentTextMessageId(runtime, event.taskId);
-      final index = runtime.messages.indexWhere((message) => message.id == messageId);
+      final messageId = entryId.isNotEmpty
+          ? entryId
+          : _nextAgentTextMessageId(runtime, event.taskId);
+      final index = runtime.messages.indexWhere(
+        (message) => message.id == messageId,
+      );
       if (index == -1) {
         final content = <String, dynamic>{'text': '', 'id': messageId};
         _applyAgentRetryPresentation(content, event, retryText);
@@ -2114,6 +2146,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         renderMarkdown: true,
         isFinal: true,
         streamMeta: _streamMetaFromEvent(event),
+        turnUsage: event.turnUsage,
         reasoningContent: event.thinking,
       );
     }
@@ -2185,7 +2218,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
   }) {
     final entryId = (event.entryId ?? '').trim();
     final shouldMarkError = event.raw['persistAsError'] == true;
-    final errorText = (event.raw['errorText'] ?? event.errorMessage).toString().trim();
+    final errorText = (event.raw['errorText'] ?? event.errorMessage)
+        .toString()
+        .trim();
     if (entryId.isNotEmpty) {
       final index = runtime.messages.indexWhere(
         (message) => message.id == entryId,
@@ -2202,6 +2237,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
             entryId: entryId,
             isFinal: true,
           ),
+          turnUsage: event.turnUsage ?? existing.turnUsage,
         );
       }
     }
@@ -2248,6 +2284,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
         renderMarkdown: true,
         isFinal: true,
         streamMeta: _streamMetaFromEvent(event),
+        turnUsage: event.turnUsage,
         reasoningContent: event.thinking,
       );
     }
@@ -2340,6 +2377,10 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     content['agentMaxRetries'] = event.maxRetries;
     content['agentRetryDelayMs'] = event.retryDelayMs;
     content['agentRetryReason'] = event.retryReason;
+    content['agentContinuing'] = false;
+    content.remove('agentContinueStatusText');
+    content.remove('agentContinueable');
+    content.remove('agentContinueResumeMode');
     content.remove('agentErrorText');
     content.remove('agentRetryable');
   }
@@ -2356,7 +2397,11 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     content['agentMaxRetries'] = event.maxRetries;
     content['agentRetryDelayMs'] = 0;
     content['agentRetryReason'] = event.retryReason;
+    content['agentContinuing'] = false;
+    content['agentContinueStatusText'] = '';
     content['agentRetryable'] = event.retryable;
+    content['agentContinueable'] = event.continueable;
+    content['agentContinueResumeMode'] = event.continueResumeMode;
     content['agentErrorText'] = errorText;
   }
 
@@ -2368,6 +2413,10 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     content.remove('agentRetryDelayMs');
     content.remove('agentRetryReason');
     content.remove('agentRetryable');
+    content.remove('agentContinuing');
+    content.remove('agentContinueStatusText');
+    content.remove('agentContinueable');
+    content.remove('agentContinueResumeMode');
     content.remove('agentErrorText');
   }
 

--- a/ui/lib/features/home/pages/chat/widgets/agent_run_group_message.dart
+++ b/ui/lib/features/home/pages/chat/widgets/agent_run_group_message.dart
@@ -22,6 +22,7 @@ class AgentRunGroupMessage extends StatefulWidget {
     required this.onBeforeTaskExecute,
     this.onCancelTask,
     this.onRetryAgentMessage,
+    this.onContinueAgentMessage,
     this.parentScrollController,
     this.onParentScrollHandoff,
     this.onRequestAuthorize,
@@ -36,6 +37,7 @@ class AgentRunGroupMessage extends StatefulWidget {
   final OnBeforeTaskExecute onBeforeTaskExecute;
   final void Function(String taskId)? onCancelTask;
   final ValueChanged<ChatMessageModel>? onRetryAgentMessage;
+  final ValueChanged<ChatMessageModel>? onContinueAgentMessage;
   final ScrollController? parentScrollController;
   final VoidCallback? onParentScrollHandoff;
   final OnRequestAuthorize? onRequestAuthorize;
@@ -161,6 +163,8 @@ class _AgentRunGroupMessageState extends State<AgentRunGroupMessage>
             onCancelTask: widget.onCancelTask,
             onRetryAgentMessage: () =>
                 widget.onRetryAgentMessage?.call(message),
+            onContinueAgentMessage: () =>
+                widget.onContinueAgentMessage?.call(message),
             enableThinkingCollapse: false,
             parentScrollController: widget.parentScrollController,
             onParentScrollHandoff: widget.onParentScrollHandoff,
@@ -283,6 +287,8 @@ class _AgentRunGroupMessageState extends State<AgentRunGroupMessage>
       onBeforeTaskExecute: widget.onBeforeTaskExecute,
       onCancelTask: widget.onCancelTask,
       onRetryAgentMessage: () => widget.onRetryAgentMessage?.call(message),
+      onContinueAgentMessage: () =>
+          widget.onContinueAgentMessage?.call(message),
       enableThinkingCollapse: true,
       thinkingAutoCollapseOnComplete: true,
       showThinkingAvatarOverride: hideAvatar ? false : null,
@@ -548,7 +554,9 @@ class _AgentRunSummaryHeader extends StatelessWidget {
     // a duration (single instant), we just show "已处理".
     final baseLabel = isEnglish ? 'Processed' : '已处理';
     final elapsedLabel = _agentRunElapsedLabel(group);
-    final label = elapsedLabel.isEmpty ? baseLabel : '$baseLabel  $elapsedLabel';
+    final label = elapsedLabel.isEmpty
+        ? baseLabel
+        : '$baseLabel  $elapsedLabel';
     final labelColor = expanded ? palette.textSecondary : palette.textTertiary;
     final lineColor = expanded
         ? palette.textSecondary.withValues(

--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -1420,6 +1420,7 @@ class ChatMessageList extends StatefulWidget {
   final Future<void> Function() onBeforeTaskExecute;
   final void Function(String taskId)? onCancelTask;
   final ValueChanged<ChatMessageModel>? onRetryAgentMessage;
+  final ValueChanged<ChatMessageModel>? onContinueAgentMessage;
   final void Function(List<String> requiredPermissionIds)? onRequestAuthorize;
   final double bottomOverlayInset;
   final void Function(ChatMessageModel message, LongPressStartDetails details)?
@@ -1450,6 +1451,7 @@ class ChatMessageList extends StatefulWidget {
     required this.onBeforeTaskExecute,
     this.onCancelTask,
     this.onRetryAgentMessage,
+    this.onContinueAgentMessage,
     this.onRequestAuthorize,
     this.bottomOverlayInset = 0,
     this.onUserMessageLongPressStart,
@@ -1984,6 +1986,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
         onBeforeTaskExecute: widget.onBeforeTaskExecute,
         onCancelTask: widget.onCancelTask,
         onRetryAgentMessage: widget.onRetryAgentMessage,
+        onContinueAgentMessage: widget.onContinueAgentMessage,
         parentScrollController: widget.scrollController,
         onParentScrollHandoff: _handleParentScrollHandoff,
         editingUserMessageRevealKey: _editingRevealKeyForMessage(
@@ -2161,6 +2164,7 @@ class _ChatTimelineListRow extends StatelessWidget {
     this.onUserMessageEditSaved,
     this.onCancelTask,
     this.onRetryAgentMessage,
+    this.onContinueAgentMessage,
     this.parentScrollController,
     this.onParentScrollHandoff,
     this.editingUserMessageRevealKey,
@@ -2183,6 +2187,7 @@ class _ChatTimelineListRow extends StatelessWidget {
   final ValueChanged<ChatMessageModel>? onUserMessageEditSaved;
   final void Function(String taskId)? onCancelTask;
   final ValueChanged<ChatMessageModel>? onRetryAgentMessage;
+  final ValueChanged<ChatMessageModel>? onContinueAgentMessage;
   final ScrollController? parentScrollController;
   final VoidCallback? onParentScrollHandoff;
   final GlobalKey? editingUserMessageRevealKey;
@@ -2210,6 +2215,7 @@ class _ChatTimelineListRow extends StatelessWidget {
         onBeforeTaskExecute: onBeforeTaskExecute,
         onCancelTask: onCancelTask,
         onRetryAgentMessage: onRetryAgentMessage,
+        onContinueAgentMessage: onContinueAgentMessage,
         parentScrollController: parentScrollController,
         onParentScrollHandoff: onParentScrollHandoff,
         onRequestAuthorize: onRequestAuthorize,
@@ -2235,6 +2241,8 @@ class _ChatTimelineListRow extends StatelessWidget {
       onBeforeTaskExecute: onBeforeTaskExecute,
       onCancelTask: onCancelTask,
       onRetryAgentMessage: () => onRetryAgentMessage?.call(currentMessage),
+      onContinueAgentMessage: () =>
+          onContinueAgentMessage?.call(currentMessage),
       enableThinkingCollapse: true,
       parentScrollController: parentScrollController,
       onParentScrollHandoff: onParentScrollHandoff,

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -284,7 +284,7 @@ class _ChatBotSheetState extends State<ChatBotSheet>
       _handleAiMessage(taskId, content, type);
     });
 
-    _aiService.setOnMessageEndCallback((taskId) {
+    _aiService.setOnMessageEndCallback((taskId, {Map<String, dynamic>? turnUsage}) {
       _handleAiMessageEnd(taskId);
     });
 

--- a/ui/lib/features/home/pages/command_overlay/widgets/message_bubble.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/message_bubble.dart
@@ -61,6 +61,7 @@ class MessageBubble extends StatelessWidget {
   final void Function(ChatMessageModel message, LongPressStartDetails details)?
   onUserMessageLongPressStart;
   final VoidCallback? onRetryAgentMessage;
+  final VoidCallback? onContinueAgentMessage;
   final bool isUserMessageEditing;
   final TextEditingController? userMessageEditController;
   final VoidCallback? onCancelUserEdit;
@@ -82,6 +83,7 @@ class MessageBubble extends StatelessWidget {
     this.onRequestAuthorize,
     this.onUserMessageLongPressStart,
     this.onRetryAgentMessage,
+    this.onContinueAgentMessage,
     this.isUserMessageEditing = false,
     this.userMessageEditController,
     this.onCancelUserEdit,
@@ -279,14 +281,16 @@ class MessageBubble extends StatelessWidget {
 
     if (attachments.isEmpty && linkPreviews.isEmpty) {
       // AI消息：简单文本样式，无背景
-      return _buildAiTextWithSpeed(context, text);
+      return _buildAiTextWithSpeed(context, text, includeTurnUsageFooter: true);
     }
 
     // AI 消息按“正文 -> 附件 -> 链接预览”顺序分块展示。
+    final turnUsageFooter = _buildTurnUsageFooter(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (text.isNotEmpty) _buildAiTextWithSpeed(context, text),
+        if (text.isNotEmpty)
+          _buildAiTextWithSpeed(context, text, includeTurnUsageFooter: false),
         if (attachments.isNotEmpty) ...[
           if (text.isNotEmpty) const SizedBox(height: 8),
           _buildUserAttachmentList(context, attachments),
@@ -300,6 +304,13 @@ class MessageBubble extends StatelessWidget {
             compactStyle: true,
             isUserMessage: false,
           ),
+        ],
+        if (turnUsageFooter != null) ...[
+          if (text.isNotEmpty ||
+              attachments.isNotEmpty ||
+              linkPreviews.isNotEmpty)
+            const SizedBox(height: 8),
+          turnUsageFooter,
         ],
       ],
     );
@@ -1116,7 +1127,11 @@ class MessageBubble extends StatelessWidget {
   }
 
   /// AI text with optional inference speed label
-  Widget _buildAiTextWithSpeed(BuildContext context, String text) {
+  Widget _buildAiTextWithSpeed(
+    BuildContext context,
+    String text, {
+    required bool includeTurnUsageFooter,
+  }) {
     final speed = _decodeTokensPerSecond;
     final showVoiceButton = VoicePlaybackCoordinator.instance
         .shouldShowVoiceButton(
@@ -1129,9 +1144,14 @@ class MessageBubble extends StatelessWidget {
       text,
       trailing: showVoiceButton ? _buildVoiceAction(context, text) : null,
     );
+    final continueStatus = _buildAgentContinueStatus(context);
     final retryingStatus = _buildAgentRetryingStatus(context);
     final errorFooter = _buildAgentErrorFooter(context, text);
-    final showPrimaryText = text.isNotEmpty || message.isLoading || message.isSummarizing;
+    final turnUsageFooter = includeTurnUsageFooter
+        ? _buildTurnUsageFooter(context)
+        : null;
+    final showPrimaryText =
+        text.isNotEmpty || message.isLoading || message.isSummarizing;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1150,14 +1170,31 @@ class MessageBubble extends StatelessWidget {
             ),
           ),
         ],
-        if (retryingStatus != null) ...[
+        if (continueStatus != null) ...[
           if (showPrimaryText || speed != null) const SizedBox(height: 8),
+          continueStatus,
+        ],
+        if (retryingStatus != null) ...[
+          if (showPrimaryText || speed != null || continueStatus != null)
+            const SizedBox(height: 8),
           retryingStatus,
         ],
         if (errorFooter != null) ...[
-          if (showPrimaryText || speed != null || retryingStatus != null)
+          if (showPrimaryText ||
+              speed != null ||
+              continueStatus != null ||
+              retryingStatus != null)
             const SizedBox(height: 8),
           errorFooter,
+        ],
+        if (turnUsageFooter != null) ...[
+          if (showPrimaryText ||
+              speed != null ||
+              continueStatus != null ||
+              retryingStatus != null ||
+              errorFooter != null)
+            const SizedBox(height: 8),
+          turnUsageFooter,
         ],
       ],
     );
@@ -1167,8 +1204,46 @@ class MessageBubble extends StatelessWidget {
     if (message.content?['agentRetrying'] != true) {
       return null;
     }
-    final statusText =
-        (message.content?['agentRetryStatusText'] ?? '').toString().trim();
+    final statusText = (message.content?['agentRetryStatusText'] ?? '')
+        .toString()
+        .trim();
+    if (statusText.isEmpty) {
+      return null;
+    }
+    final secondaryColor = _resolvedAiSecondaryTextColor(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(
+            strokeWidth: 1.8,
+            valueColor: AlwaysStoppedAnimation<Color>(secondaryColor),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Flexible(
+          child: Text(
+            statusText,
+            style: TextStyle(
+              fontSize: 12 * _chatTextScale,
+              color: secondaryColor,
+              height: 1.4,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget? _buildAgentContinueStatus(BuildContext context) {
+    if (message.content?['agentContinuing'] != true) {
+      return null;
+    }
+    final statusText = (message.content?['agentContinueStatusText'] ?? '')
+        .toString()
+        .trim();
     if (statusText.isEmpty) {
       return null;
     }
@@ -1200,15 +1275,19 @@ class MessageBubble extends StatelessWidget {
   }
 
   Widget? _buildAgentErrorFooter(BuildContext context, String text) {
-    final errorText =
-        (message.content?['agentErrorText'] ?? '').toString().trim();
+    final errorText = (message.content?['agentErrorText'] ?? '')
+        .toString()
+        .trim();
     final retryable = message.content?['agentRetryable'] == true;
+    final continueable = message.content?['agentContinueable'] == true;
     final showRetryButton = retryable && onRetryAgentMessage != null;
+    final showContinueButton = continueable && onContinueAgentMessage != null;
     final showErrorText = errorText.isNotEmpty && errorText != text.trim();
-    if (!showErrorText && !showRetryButton) {
+    if (!showErrorText && !showRetryButton && !showContinueButton) {
       return null;
     }
     final warningColor = Theme.of(context).colorScheme.error;
+    final continueColor = const Color(0xFFFF9F1A);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1228,15 +1307,57 @@ class MessageBubble extends StatelessWidget {
               ),
             ),
           ),
+        if (showContinueButton) ...[
+          if (showErrorText) const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: continueColor.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    LegacyTextLocalizer.isEnglish
+                        ? 'Interrupted. Continue from this turn.'
+                        : '已中断，点击「继续」从当前轮恢复',
+                    style: TextStyle(
+                      fontSize: 12 * _chatTextScale,
+                      color: continueColor.withValues(alpha: 0.96),
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                FilledButton.tonalIcon(
+                  onPressed: onContinueAgentMessage,
+                  icon: const Icon(Icons.play_arrow_rounded, size: 16),
+                  label: Text(
+                    LegacyTextLocalizer.isEnglish ? 'Continue' : '继续',
+                  ),
+                  style: FilledButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    backgroundColor: continueColor,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
         if (showRetryButton)
           Align(
             alignment: Alignment.centerLeft,
             child: TextButton.icon(
               onPressed: onRetryAgentMessage,
               icon: const Icon(Icons.refresh_rounded, size: 16),
-              label: Text(
-                LegacyTextLocalizer.isEnglish ? 'Retry' : '重试本轮',
-              ),
+              label: Text(LegacyTextLocalizer.isEnglish ? 'Retry' : '重试本轮'),
               style: TextButton.styleFrom(
                 padding: EdgeInsets.zero,
                 visualDensity: VisualDensity.compact,
@@ -1246,6 +1367,76 @@ class MessageBubble extends StatelessWidget {
           ),
       ],
     );
+  }
+
+  Widget? _buildTurnUsageFooter(BuildContext context) {
+    final usage = message.turnUsage;
+    if (usage == null || usage.isEmpty) {
+      return null;
+    }
+    final ctx = _readIntValue(usage['ctx']);
+    final input = _readIntValue(usage['in']);
+    final output = _readIntValue(usage['out']);
+    final cache = _readIntValue(usage['cache']);
+    if (ctx == null && input == null && output == null && cache == null) {
+      return null;
+    }
+    final textColor = _resolvedAiSecondaryTextColor(
+      context,
+    ).withValues(alpha: 0.72);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(
+          context,
+        ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.32),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.av_timer_rounded, size: 12, color: textColor),
+          const SizedBox(width: 6),
+          Text(
+            'ctx:${_formatUsageValue(ctx)}  '
+            'in:${_formatUsageValue(input)}  '
+            'out:${_formatUsageValue(output)}  '
+            'cache:${_formatUsageValue(cache)}',
+            style: TextStyle(
+              fontSize: 11 * _chatTextScale,
+              color: textColor,
+              height: 1.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  int? _readIntValue(dynamic raw) {
+    if (raw is int) return raw;
+    if (raw is num) return raw.toInt();
+    if (raw is String) return int.tryParse(raw.trim());
+    return null;
+  }
+
+  String _formatUsageValue(int? value) {
+    if (value == null || value <= 0) {
+      return '0';
+    }
+    if (value >= 1000000) {
+      final formatted = (value / 1000000).toStringAsFixed(
+        value % 1000000 == 0 ? 0 : 1,
+      );
+      return '${formatted.replaceAll(RegExp(r'\.0$'), '')}m';
+    }
+    if (value >= 1000) {
+      final formatted = (value / 1000).toStringAsFixed(
+        value % 1000 == 0 ? 0 : 1,
+      );
+      return '${formatted.replaceAll(RegExp(r'\.0$'), '')}k';
+    }
+    return value.toString();
   }
 
   Widget _buildVoiceAction(BuildContext context, String text) {

--- a/ui/lib/models/agent_stream_event.dart
+++ b/ui/lib/models/agent_stream_event.dart
@@ -59,9 +59,12 @@ class AgentStreamEvent {
     this.hasUserVisibleOutput = false,
     this.latestPromptTokens,
     this.promptTokenThreshold,
+    this.turnUsage,
     this.errorMessage = '',
     this.willRetry = false,
     this.retryable = false,
+    this.continueable = false,
+    this.continueResumeMode = '',
     this.retryCount = 0,
     this.maxRetries = 0,
     this.retryDelayMs = 0,
@@ -90,9 +93,12 @@ class AgentStreamEvent {
   final bool hasUserVisibleOutput;
   final int? latestPromptTokens;
   final int? promptTokenThreshold;
+  final Map<String, dynamic>? turnUsage;
   final String errorMessage;
   final bool willRetry;
   final bool retryable;
+  final bool continueable;
+  final String continueResumeMode;
   final int retryCount;
   final int maxRetries;
   final int retryDelayMs;
@@ -141,8 +147,7 @@ class AgentStreamEvent {
       roundIndex: _asInt(raw['roundIndex']) ?? 0,
       isFinal: raw['isFinal'] == true,
       text: (raw['text'] ?? raw['message'] ?? '').toString(),
-      thinking:
-          (raw['thinking'] ?? raw['reasoning_content'] ?? '').toString(),
+      thinking: (raw['thinking'] ?? raw['reasoning_content'] ?? '').toString(),
       stage: _asInt(raw['stage']) ?? 1,
       prefillTokensPerSecond: _asDouble(raw['prefillTokensPerSecond']),
       decodeTokensPerSecond: _asDouble(raw['decodeTokensPerSecond']),
@@ -151,9 +156,15 @@ class AgentStreamEvent {
       hasUserVisibleOutput: raw['hasUserVisibleOutput'] == true,
       latestPromptTokens: _asInt(raw['latestPromptTokens']),
       promptTokenThreshold: _asInt(raw['promptTokenThreshold']),
+      turnUsage: raw['turnUsage'] is Map
+          ? Map<String, dynamic>.from(raw['turnUsage'] as Map)
+          : null,
       errorMessage: (raw['error'] ?? '').toString(),
       willRetry: raw['willRetry'] == true,
       retryable: raw['retryable'] == true,
+      continueable: raw['continueable'] == true,
+      continueResumeMode: (raw['continueResumeMode'] ?? raw['resumeMode'] ?? '')
+          .toString(),
       retryCount: _asInt(raw['retryCount']) ?? 0,
       maxRetries: _asInt(raw['maxRetries']) ?? 0,
       retryDelayMs: _asInt(raw['retryDelayMs']) ?? 0,

--- a/ui/lib/models/chat_message_model.dart
+++ b/ui/lib/models/chat_message_model.dart
@@ -34,6 +34,7 @@ class ChatMessageModel {
 
   /// 原生流式排序元数据
   final Map<String, dynamic>? streamMeta;
+  final Map<String, dynamic>? turnUsage;
   final String? reasoningContent;
 
   /// 创建时间
@@ -49,6 +50,7 @@ class ChatMessageModel {
     this.isError = false,
     this.isSummarizing = false,
     this.streamMeta,
+    this.turnUsage,
     this.reasoningContent,
     DateTime? createAt,
   }) : createAt = createAt ?? DateTime.now();
@@ -116,6 +118,9 @@ class ChatMessageModel {
       streamMeta: _normalizeDynamic(json['streamMeta']) is Map<String, dynamic>
           ? _normalizeDynamic(json['streamMeta']) as Map<String, dynamic>
           : null,
+      turnUsage: _normalizeDynamic(json['turnUsage']) is Map<String, dynamic>
+          ? _normalizeDynamic(json['turnUsage']) as Map<String, dynamic>
+          : null,
       reasoningContent: _normalizeOptionalString(
         json['reasoning_content'] ?? json['reasoningContent'],
       ),
@@ -135,6 +140,7 @@ class ChatMessageModel {
       'isError': isError,
       'isSummarizing': isSummarizing,
       if (streamMeta != null) 'streamMeta': streamMeta,
+      if (turnUsage != null) 'turnUsage': turnUsage,
       if (reasoningContent != null) 'reasoning_content': reasoningContent,
       'createAt': createAt.toIso8601String(),
     };
@@ -196,6 +202,7 @@ class ChatMessageModel {
     bool? isError,
     bool? isSummarizing,
     Map<String, dynamic>? streamMeta,
+    Map<String, dynamic>? turnUsage,
     String? reasoningContent,
     DateTime? createAt,
   }) {
@@ -209,6 +216,7 @@ class ChatMessageModel {
       isError: isError ?? this.isError,
       isSummarizing: isSummarizing ?? this.isSummarizing,
       streamMeta: streamMeta ?? this.streamMeta,
+      turnUsage: turnUsage ?? this.turnUsage,
       reasoningContent: reasoningContent ?? this.reasoningContent,
       createAt: createAt ?? this.createAt,
     );

--- a/ui/lib/services/ai_chat_service.dart
+++ b/ui/lib/services/ai_chat_service.dart
@@ -6,7 +6,7 @@ class AiChatService {
   Function(String taskId, String content, String? type)? _onMessageCallback;
 
   /// 消息结束回调
-  Function(String taskId)? _onMessageEndCallback;
+  Function(String taskId, {Map<String, dynamic>? turnUsage})? _onMessageEndCallback;
 
   AiChatService() {
     _initializeService();
@@ -35,8 +35,8 @@ class AiChatService {
     }
   }
 
-  void _handleChatMessageEndCallback(String taskId) {
-    _onMessageEndCallback?.call(taskId);
+  void _handleChatMessageEndCallback(String taskId, {Map<String, dynamic>? turnUsage}) {
+    _onMessageEndCallback?.call(taskId, turnUsage: turnUsage);
   }
 
   /// 设置消息回调
@@ -47,7 +47,7 @@ class AiChatService {
   }
 
   /// 设置消息结束回调
-  void setOnMessageEndCallback(Function(String taskId) callback) {
+  void setOnMessageEndCallback(Function(String taskId, {Map<String, dynamic>? turnUsage}) callback) {
     _onMessageEndCallback = callback;
   }
 

--- a/ui/lib/services/assists_core_service.dart
+++ b/ui/lib/services/assists_core_service.dart
@@ -14,7 +14,10 @@ typedef TaskFinishCallback = void Function();
 typedef ChatTaskMessageCallBack =
     void Function(String taskID, String content, String? type);
 //消息回执结束
-typedef ChatTaskMessageEndCallBack = void Function(String taskID);
+typedef ChatTaskMessageEndCallBack = void Function(
+  String taskID, {
+  Map<String, dynamic>? turnUsage,
+});
 //VLM任务结束
 typedef VLMTaskFinishEndCallBack = void Function(String? taskId);
 //普通任务结束
@@ -404,9 +407,15 @@ class AssistsMessageService {
           final Map<String, dynamic> data = Map<String, dynamic>.from(
             call.arguments,
           );
-          _onChatTaskMessageEndCallBack?.call(data['taskID']);
+          final endTurnUsage = data['turnUsage'] != null
+              ? Map<String, dynamic>.from(data['turnUsage'] as Map)
+              : null;
+          _onChatTaskMessageEndCallBack?.call(
+            data['taskID'],
+            turnUsage: endTurnUsage,
+          );
           for (final callback in _onChatTaskMessageEndCallBacks) {
-            callback(data['taskID']);
+            callback(data['taskID'], turnUsage: endTurnUsage);
           }
           break;
         case 'onVLMRequestUserInput':
@@ -758,6 +767,19 @@ class AssistsMessageService {
       return result == "SUCCESS";
     } on PlatformException catch (e) {
       print('retryAgentTask failed: ${e.message}');
+      return false;
+    }
+  }
+
+  static Future<bool> continueAgentTask({required String taskId}) async {
+    try {
+      final result = await assistCore.invokeMethod(
+        'continueAgentTask',
+        <String, String>{'taskId': taskId},
+      );
+      return result == "SUCCESS";
+    } on PlatformException catch (e) {
+      print('continueAgentTask failed: ${e.message}');
       return false;
     }
   }

--- a/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
+++ b/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
@@ -573,6 +573,64 @@ void main() {
   });
 
   test(
+    'binds turn usage and continue metadata to the failed assistant turn',
+    () async {
+      const conversationId = 10041;
+      const taskId = 'agent-task-continueable-error';
+      const entryId = '$taskId-text';
+
+      final runtime = coordinator.ensureRuntime(
+        conversationId: conversationId,
+        mode: kChatRuntimeModeNormal,
+      );
+      coordinator.registerTask(
+        taskId: taskId,
+        conversationId: conversationId,
+        mode: kChatRuntimeModeNormal,
+      );
+
+      await emitPlatformEvent('onAgentStreamEvent', <String, dynamic>{
+        'taskId': taskId,
+        'conversationId': conversationId,
+        'conversationMode': ConversationMode.normal.storageValue,
+        'seq': 1,
+        'kind': 'text_snapshot',
+        'entryId': entryId,
+        'roundIndex': 1,
+        'isFinal': true,
+        'text': 'partial reply',
+        'turnUsage': {'ctx': 20000, 'in': 10000, 'out': 87, 'cache': 10000},
+      });
+
+      await emitPlatformEvent('onAgentStreamEvent', <String, dynamic>{
+        'taskId': taskId,
+        'conversationId': conversationId,
+        'conversationMode': ConversationMode.normal.storageValue,
+        'seq': 2,
+        'kind': 'error',
+        'entryId': entryId,
+        'roundIndex': 1,
+        'error': 'network interrupted',
+        'errorText': 'network interrupted',
+        'continueable': true,
+        'continueResumeMode': 'approximate',
+        'retryable': true,
+        'persistAsError': false,
+        'turnUsage': {'ctx': 20000, 'in': 10000, 'out': 87, 'cache': 10000},
+      });
+
+      expect(runtime.messages, hasLength(1));
+      final message = runtime.messages.single;
+      expect(message.id, entryId);
+      expect(message.turnUsage?['ctx'], 20000);
+      expect(message.turnUsage?['in'], 10000);
+      expect(message.content?['agentContinueable'], isTrue);
+      expect(message.content?['agentContinueResumeMode'], 'approximate');
+      expect(message.content?['agentRetryable'], isTrue);
+    },
+  );
+
+  test(
     'shows an error bubble when agent fails before any visible text',
     () async {
       const conversationId = 1005;

--- a/ui/test/features/home/pages/command_overlay/widgets/message_bubble_voice_test.dart
+++ b/ui/test/features/home/pages/command_overlay/widgets/message_bubble_voice_test.dart
@@ -12,10 +12,16 @@ void main() {
   Future<void> pumpBubble(
     WidgetTester tester, {
     required ChatMessageModel message,
+    VoidCallback? onContinueAgentMessage,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        home: Scaffold(body: MessageBubble(message: message)),
+        home: Scaffold(
+          body: MessageBubble(
+            message: message,
+            onContinueAgentMessage: onContinueAgentMessage,
+          ),
+        ),
       ),
     );
     await tester.pump();
@@ -154,5 +160,39 @@ void main() {
     expect((previewDecoration.border! as Border).left.width, 3);
     expect(previewTitle.style?.fontSize, 12);
     expect(find.byKey(const ValueKey('link-preview-card-0')), findsOneWidget);
+  });
+
+  testWidgets('shows per-turn usage pill and continue action separately', (
+    tester,
+  ) async {
+    var continueTapped = 0;
+    final message = ChatMessageModel(
+      id: 'assistant-continue',
+      type: 1,
+      user: 2,
+      content: {
+        'text': 'partial reply',
+        'id': 'assistant-continue',
+        'agentContinueable': true,
+        'agentErrorText': 'network interrupted',
+      },
+      turnUsage: {'ctx': 20000, 'in': 10000, 'out': 87, 'cache': 10000},
+    );
+
+    await pumpBubble(
+      tester,
+      message: message,
+      onContinueAgentMessage: () {
+        continueTapped += 1;
+      },
+    );
+
+    expect(find.text('ctx:20k  in:10k  out:87  cache:10k'), findsOneWidget);
+    expect(find.byType(FilledButton), findsOneWidget);
+
+    await tester.tap(find.byType(FilledButton));
+    await tester.pump();
+
+    expect(continueTapped, 1);
   });
 }

--- a/ui/test/models/chat_message_model_test.dart
+++ b/ui/test/models/chat_message_model_test.dart
@@ -119,4 +119,31 @@ void main() {
       expect(message.text, 'Hello, world!');
     },
   );
+
+  test('ChatMessageModel preserves turn usage payload', () {
+    final message = ChatMessageModel.fromJson({
+      'id': 'assistant-turn-usage',
+      'type': 1,
+      'user': 2,
+      'content': {'text': 'done'},
+      'turnUsage': {
+        'ctx': 20000.0,
+        'in': 10000.0,
+        'out': 87.0,
+        'cache': 10000.0,
+      },
+      'createAt': '1774600557281',
+    });
+
+    expect(message.turnUsage?['ctx'], 20000);
+    expect(message.turnUsage?['in'], 10000);
+    expect(message.turnUsage?['out'], 87);
+    expect(message.turnUsage?['cache'], 10000);
+    expect(message.toJson()['turnUsage'], <String, dynamic>{
+      'ctx': 20000,
+      'in': 10000,
+      'out': 87,
+      'cache': 10000,
+    });
+  });
 }


### PR DESCRIPTION
## 变更摘要

本次改动为每个 assistant turn 绑定并展示 `ctx / in / out / cache` 统计信息；在 Agent/Chat 流式请求失败后，支持从当前 assistant turn 继续执行，而不是只能重新发送用户消息或重跑整轮请求。

## 变更类型

- [x] 新功能


## 关联 Issue

Closes #407 

## 主要改动

1. 为单条 assistant turn 增加 `turnUsage` 数据链路，Native 侧归一 `ctx / in / out / cache / promptTokens / completionTokens / totalTokens / promptTokenThreshold`，Flutter 侧直接从消息模型读取并渲染，避免依赖全局时间窗口聚合。
2. Agent 失败时保存可恢复上下文，包含 task/conversation 信息、assistant entry、已生成文本、turn usage、model override、reasoning effort 等，并通过 stream error event 下发 `continueable`、`continueResumeMode`、`turnUsage`。
3. Flutter 将失败事件绑定回当前 assistant message，在失败气泡底部展示 Continue/Resume 入口；点击继续时复用当前 assistant turn，不新增重复 user bubble。

## 测试说明

在用户侧证明两个新功能的有效。

## UI 变更（如有）

有。
<img width="864" height="1920" alt="3dfae6255e4e50da9dc52d5dd4f18aa9" src="https://github.com/user-attachments/assets/e2a0de0f-1a56-4dfa-ace3-67579fc7744a" />

<img width="864" height="1920" alt="83368802692cf970fdd68bca0e11d7cc" src="https://github.com/user-attachments/assets/937caecf-d42a-4c97-b67f-5e2b848f4957" />


## 风险与回滚

- `ctx` 当前计算方式是 `promptTokens + cachedTokens`。


