### PR TITLE
修读了搜索模型时Overlay会关闭的问题

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -485,6 +485,13 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
         profiles: _modelProviderProfiles,
         providerModelsByProfileId: _modelOptionsByProfileId,
         currentSelection: _activeDispatchSceneSelection,
+        // 软键盘"确定"提交搜索时:先打开 popup 的"一次性键盘隐藏豁免",再 unfocus
+        // —— 这样 IME 塌陷不会被 DismissOverlayOnKeyboardHide 当作"用户想关 popup"
+        // 误关掉,搜索结果列表得以保留。
+        onSearchSubmitted: () {
+          handle.keepOpenOnNextKeyboardHide();
+          FocusManager.instance.primaryFocus?.unfocus();
+        },
         // dismiss 内部会立刻 complete future,让下面 await 的逻辑并行起跑;
         // 收起动画在后台跑完,UI 更响应。
         onSelect: (selection) => unawaited(handle.dismiss(selection)),
@@ -1078,6 +1085,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
     required this.profiles,
     required this.providerModelsByProfileId,
     required this.currentSelection,
+    this.onSearchSubmitted,
     this.onSelect,
   });
 
@@ -1086,6 +1094,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
   final List<ModelProviderProfileSummary> profiles;
   final Map<String, List<ProviderModelOption>> providerModelsByProfileId;
   final _ChatModelOverrideSelection? currentSelection;
+  final VoidCallback? onSearchSubmitted;
 
   /// 非空时由调用方决定怎么消费选择(例如关闭外层 [OverlayEntry] + 触发后续逻辑)；
   /// 为空时回退到 [Navigator.of(context).pop(selection)],兼容老的 route 调用方。
@@ -1345,6 +1354,8 @@ class _ConversationModelSelectorContentState
                 controller: _searchController,
                 autofocus: false,
                 scrollPadding: EdgeInsets.zero,
+                textInputAction: TextInputAction.search,
+                onSubmitted: (_) => widget.onSearchSubmitted?.call(),
                 cursorColor: isDark ? palette.accentPrimary : null,
                 style: TextStyle(
                   fontSize: 13,
@@ -1771,3 +1782,6 @@ class _ConversationModelSelectorContentState
 
 // DismissOverlayOnKeyboardHide 已提取到 lib/widgets/glass_popup.dart,
 // 给 chat_input_area.dart 里的 context-usage tooltip 一起复用。
+// PR #410 引入的 shouldDismissOnKeyboardHide 一次性豁免 + bottomInset<=0 复位
+// 修复也都搬到了那里;调用方通过 [OverlayGlassPopupHandle.keepOpenOnNextKeyboardHide]
+// 触发豁免(本文件 _openConversationModelSelector 的 onSearchSubmitted 即用法)。

--- a/ui/lib/features/home/pages/scene_model_setting/scene_model_setting_page.dart
+++ b/ui/lib/features/home/pages/scene_model_setting/scene_model_setting_page.dart
@@ -1209,6 +1209,8 @@ class _SceneSelectionPopupEntryState extends State<_SceneSelectionPopupEntry> {
               controller: _searchController,
               autofocus: false,
               scrollPadding: EdgeInsets.zero,
+              textInputAction: TextInputAction.search,
+              onSubmitted: (_) => FocusManager.instance.primaryFocus?.unfocus(),
               style: TextStyle(
                 fontSize: 13,
                 color: _primaryTextColor,

--- a/ui/lib/widgets/glass_popup.dart
+++ b/ui/lib/widgets/glass_popup.dart
@@ -635,6 +635,7 @@ class OverlayGlassPopupHandle<T> {
       GlobalKey<GlassPopupOverlayContentState>();
   OverlayEntry? _entry;
   bool _dismissing = false;
+  bool _keepOpenOnNextKeyboardHide = false;
 
   /// 等待 dismiss 携带的返回值。被取消(tap-outside / back / keyboard hide /
   /// 调用方主动 dismiss 不传 result) 时 resolve 为 `null`。
@@ -642,6 +643,25 @@ class OverlayGlassPopupHandle<T> {
 
   /// popup 是否还挂在 overlay 上(尚未走完关闭动画 + remove)。
   bool get isOpen => _entry != null;
+
+  /// 标记"接下来的这一次键盘隐藏不要关 popup"——豁免一次性。典型用法:popup 内部
+  /// 有搜索框,用户按软键盘的"确定"提交搜索时主动 unfocus,IME 会塌陷,但我们
+  /// 希望 popup 还留着展示搜索结果。调用方先打开这个标志再 unfocus 即可。
+  ///
+  /// 内部由 [showOverlayGlassPopup] 在挂的 [DismissOverlayOnKeyboardHide] 上
+  /// 通过 [_consumeKeepOpenForNextKeyboardHide] 消费,消费完即复位,下一次键盘
+  /// 隐藏(如系统返回手势先关 IME) 仍然会正常关 popup。
+  void keepOpenOnNextKeyboardHide() {
+    _keepOpenOnNextKeyboardHide = true;
+  }
+
+  bool _consumeKeepOpenForNextKeyboardHide() {
+    if (_keepOpenOnNextKeyboardHide) {
+      _keepOpenOnNextKeyboardHide = false;
+      return true;
+    }
+    return false;
+  }
 
   /// 主动关闭 popup。可重复调用(后续调用是 no-op)。
   ///
@@ -720,6 +740,11 @@ OverlayGlassPopupHandle<T> showOverlayGlassPopup<T>({
       );
       if (dismissOnKeyboardHide) {
         tree = DismissOverlayOnKeyboardHide(
+          // popup 内有搜索框时,调用方按下软键盘"确定"会先调
+          // [OverlayGlassPopupHandle.keepOpenOnNextKeyboardHide] 然后 unfocus,
+          // IME 塌陷的这一次会被这里"消费豁免",popup 保留可见。
+          shouldDismissOnKeyboardHide: () =>
+              !handle._consumeKeepOpenForNextKeyboardHide(),
           onKeyboardHide: () => unawaited(handle.dismiss()),
           child: tree,
         );
@@ -753,10 +778,19 @@ class DismissOverlayOnKeyboardHide extends StatefulWidget {
     super.key,
     required this.onKeyboardHide,
     required this.child,
+    this.shouldDismissOnKeyboardHide,
   });
 
   final VoidCallback onKeyboardHide;
   final Widget child;
+
+  /// 可选谓词。返回 `false` 时本次键盘隐藏不触发 [onKeyboardHide],但 `_firedOnce`
+  /// 仍标记为已触发——也就是说"这一次豁免"是把这次键盘隐藏整个跳过去,而不是
+  /// 推迟到下次键盘再落时补触发。
+  ///
+  /// 典型用法:popup 内嵌搜索框,按软键盘"确定"主动 unfocus 时希望保留 popup;
+  /// 由调用方提前打开一次性豁免标志位,这里就会读到 `false`、跳过本次 dismiss。
+  final bool Function()? shouldDismissOnKeyboardHide;
 
   @override
   State<DismissOverlayOnKeyboardHide> createState() =>
@@ -778,6 +812,14 @@ class _DismissOverlayOnKeyboardHideState
   void didChangeDependencies() {
     super.didChangeDependencies();
     final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    // 键盘从未弹起(或已经完全收起)时把 peak/firedOnce 复位。否则:用户打开 popup
+    // → 键盘弹一次塌一次 → _firedOnce 永远停在 true → 此后键盘再弹起再收起,
+    // 这个 widget 不会再触发 dismiss,Overlay 看起来"豁免错了次"。
+    if (bottomInset <= 0) {
+      _peakInset = 0;
+      _firedOnce = false;
+      return;
+    }
     if (bottomInset > _peakInset) {
       _peakInset = bottomInset;
     }
@@ -794,6 +836,11 @@ class _DismissOverlayOnKeyboardHideState
         _peakInset > _kKeyboardPeakMinimum &&
         bottomInset < _peakInset * 0.9) {
       _firedOnce = true;
+      // 豁免本次键盘隐藏:谓词返回 false 就跳过整个 dismiss 路径,_firedOnce
+      // 仍保持 true 直到下次键盘从无到有再 reset。
+      if (widget.shouldDismissOnKeyboardHide?.call() == false) {
+        return;
+      }
       // 不能在 didChangeDependencies 同步调 callback——callback 可能 setState,
       // 而本帧正在 build。延到下一帧。
       WidgetsBinding.instance.addPostFrameCallback((_) {


### PR DESCRIPTION
## 变更摘要

修复了搜索模型之后点击键盘确定键会导致选择面板一起关闭的问题

## 变更类型

- [x] Bug 修复

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 修复聊天页模型选择搜索框按键盘“确定”后 Overlay 被关闭的问题。
2. 搜索提交时主动收起键盘，并对本次键盘隐藏事件做一次性豁免，保持模型选择 Overlay 可见。
3. 为场景模型设置页的同类搜索框补充搜索提交行为，按“确定”后收起键盘。

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [x] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [x] 已执行相关测试
- [x] 已手动验证关键路径

## UI 变更（如有）

无

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
