### PR TITLE
修复本地 Codex 重连后恢复为新对话

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -671,9 +671,18 @@ abstract class _ChatPageStateBase extends State<ChatPage>
       }
       return _newThreadTargetForConversationMode(conversationMode);
     }
+    final localCodexThreadId = _activeMode == ChatPageMode.codex
+        ? _activeCodexThreadId?.trim()
+        : null;
     return ConversationThreadTarget.existing(
       conversationId: conversationId,
       mode: conversationMode,
+      codexThreadId: localCodexThreadId == null || localCodexThreadId.isEmpty
+          ? null
+          : localCodexThreadId,
+      codexRuntime: localCodexThreadId == null || localCodexThreadId.isEmpty
+          ? null
+          : 'local',
     );
   }
 

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -676,6 +676,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
       _activeCodexThreadId = resolvedThreadId ?? _activeCodexThreadId;
       _activeCodexTurnId =
           _asCodexString(response['turnId']) ?? _activeCodexTurnId;
+      if (!remoteCodex) {
+        await _persistVisibleThreadTargetIfNeeded();
+      }
       await _writeCodexCommandPreferencesForCurrentConversation();
     } catch (error) {
       if (!mounted) return;
@@ -959,6 +962,9 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
             'instead of mismatched native conversation $localConversationId',
           );
         }
+      }
+      if (!remoteCodex) {
+        await _persistVisibleThreadTargetIfNeeded();
       }
       await _writeCodexCommandPreferencesForCurrentConversation();
     } catch (error) {

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -146,10 +146,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (normalizedPreferredMode == null) {
       final lastVisible =
           await ConversationHistoryService.getLastVisibleThreadTarget();
-      final normalizedLastVisible = _normalizeVisibleThreadTarget(
-        lastVisible,
-        freshCodexOnImplicitRestore: true,
-      );
+      final normalizedLastVisible = _normalizeVisibleThreadTarget(lastVisible);
       if (normalizedLastVisible != null) {
         return normalizedLastVisible;
       }
@@ -177,17 +174,13 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
   }
 
   ConversationThreadTarget? _normalizeVisibleThreadTarget(
-    ConversationThreadTarget? target, {
-    bool freshCodexOnImplicitRestore = false,
-  }) {
+    ConversationThreadTarget? target,
+  ) {
     if (target == null) {
       return null;
     }
     if (target.mode == ConversationMode.openclaw) {
       return null;
-    }
-    if (freshCodexOnImplicitRestore && target.mode == ConversationMode.codex) {
-      return _newCodexThreadTarget();
     }
     return target;
   }
@@ -268,6 +261,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       _isSurfacePageScrolling = false;
     });
     _resetLocalConversationState(targetMode);
+    _restoreLocalCodexThreadIdFromTarget(effectiveTarget);
     _vlmAnswerController.clear();
     _applyDraftForConversationMode(targetMode);
     if (effectiveTarget.isRemoteCodexSessionTarget) {
@@ -288,6 +282,18 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (syncPage) {
       _jumpToCurrentModePage(animate: false);
     }
+  }
+
+  void _restoreLocalCodexThreadIdFromTarget(ConversationThreadTarget target) {
+    if (target.mode != ConversationMode.codex ||
+        target.isRemoteCodexSessionTarget) {
+      return;
+    }
+    final threadId = target.codexThreadId?.trim();
+    if (threadId == null || threadId.isEmpty) {
+      return;
+    }
+    _activeCodexThreadId = threadId;
   }
 
   @override

--- a/ui/test/services/conversation_history_service_test.dart
+++ b/ui/test/services/conversation_history_service_test.dart
@@ -184,6 +184,32 @@ void main() {
     expect(restored.codexThreadActive, isTrue);
   });
 
+  test('round-trips local codex conversation target thread metadata', () async {
+    const target = ConversationThreadTarget.existing(
+      conversationId: 42,
+      mode: ConversationMode.codex,
+      codexThreadId: '019f12d6-16a0-7f01-9537-275ff25b9f79',
+      codexRuntime: 'local',
+    );
+
+    await ConversationHistoryService.saveCurrentConversationTarget(
+      target,
+      mode: ConversationMode.codex,
+    );
+    await ConversationHistoryService.saveLastVisibleThreadTarget(target);
+
+    expect(
+      await ConversationHistoryService.getCurrentConversationTarget(
+        mode: ConversationMode.codex,
+      ),
+      target,
+    );
+    expect(
+      await ConversationHistoryService.getLastVisibleThreadTarget(),
+      target,
+    );
+  });
+
   test(
     'falls back to current thread target when last visible is absent',
     () async {


### PR DESCRIPTION
## 变更说明

修复本地 Codex 会话在应用后台断开/重连后被恢复成新对话的问题。

主要改动：
- 启动恢复时保留上次可见的 Codex thread target，不再隐式强制创建新 Codex 会话。
- 本地 Codex 已有 conversationId 时，将 active codex threadId/codexRuntime 一起写入当前 thread target。
- 应用恢复本地 Codex target 时回填 _activeCodexThreadId，后续 turn 会继续传入原 threadId。
- 本地 Codex /review 和普通 turn 启动成功后立即持久化当前 target，降低刚拿到 threadId 后后台断开导致状态丢失的概率。
- 增加本地 Codex target metadata 的 round-trip 测试。

## 验证

- [x] git diff --check
- [ ] flutter test test/services/conversation_history_service_test.dart（当前执行环境缺少 flutter/dart/fvm，未能运行）