### PR TITLE
修复 Codex 多个“正在思考”卡片同时加载

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -2718,7 +2718,89 @@ List<ChatMessageModel> _mergeRemoteCodexSnapshotMessages({
   }
   final merged = mergedById.values.toList(growable: false)
     ..sort((a, b) => b.createAt.compareTo(a.createAt));
-  return merged;
+  return _normalizeCodexLoadingThinkingCards(
+    merged,
+    activeTaskId: activeTaskId,
+    isAiResponding: isAiResponding,
+  );
+}
+
+List<ChatMessageModel> _normalizeCodexLoadingThinkingCards(
+  List<ChatMessageModel> messages, {
+  required String? activeTaskId,
+  required bool isAiResponding,
+}) {
+  final activeTask = activeTaskId?.trim() ?? '';
+  final keptLoadingTaskIds = <String>{};
+  final normalized = <ChatMessageModel>[];
+  for (final message in messages) {
+    final cardData = message.cardData;
+    if (cardData?['type'] != 'deep_thinking') {
+      normalized.add(message);
+      continue;
+    }
+    final taskId = _messageTaskId(message);
+    final normalizedTaskId = taskId?.trim() ?? '';
+    final isLoading = cardData?['isLoading'] == true;
+    final keepLoading =
+        isLoading &&
+        isAiResponding &&
+        activeTask.isNotEmpty &&
+        normalizedTaskId == activeTask &&
+        !keptLoadingTaskIds.contains(normalizedTaskId);
+    if (keepLoading) {
+      keptLoadingTaskIds.add(normalizedTaskId);
+      normalized.add(message);
+      continue;
+    }
+    final shouldFinalize =
+        isLoading ||
+        cardData?['stage'] == ThinkingStage.thinking.value ||
+        cardData?['isCollapsible'] == false;
+    normalized.add(
+      shouldFinalize
+          ? _completeCodexThinkingSnapshotMessage(message, taskId: taskId)
+          : message,
+    );
+  }
+  return normalized;
+}
+
+ChatMessageModel _completeCodexThinkingSnapshotMessage(
+  ChatMessageModel message, {
+  required String? taskId,
+}) {
+  final cardData = Map<String, dynamic>.from(
+    message.cardData ?? const <String, dynamic>{},
+  );
+  final resolvedTaskId =
+      taskId ??
+      _asCodexString(cardData['taskID']) ??
+      _asCodexString(message.streamMeta?['parentTaskId']);
+  final startTime =
+      _asCodexInt(cardData['startTime']) ??
+      message.createAt.millisecondsSinceEpoch;
+  cardData['isLoading'] = false;
+  cardData['stage'] = ThinkingStage.complete.value;
+  if (resolvedTaskId != null) {
+    cardData['taskID'] = resolvedTaskId;
+  }
+  cardData['cardId'] = _asCodexString(cardData['cardId']) ?? message.id;
+  cardData['startTime'] = startTime;
+  cardData['endTime'] ??= DateTime.now().millisecondsSinceEpoch;
+  cardData['isCollapsible'] = true;
+  cardData['thinkingContent'] = (cardData['thinkingContent'] ?? '')
+      .toString();
+  return message.copyWith(
+    content: {'cardData': cardData, 'id': message.id},
+    streamMeta: ensureAgentStreamMessageMeta(
+      message.streamMeta,
+      kind: 'thinking_snapshot',
+      parentTaskId: resolvedTaskId,
+      entryId: message.id,
+      isFinal: true,
+    ),
+  );
 }
 
 bool _shouldPreferExistingRemoteMessage({
@@ -3257,7 +3339,12 @@ List<ChatMessageModel> _codexMessagesFromThreadResponse(
       }
     }
   }
-  return chronological.reversed.toList(growable: false);
+  final messages = chronological.reversed.toList(growable: false);
+  return _normalizeCodexLoadingThinkingCards(
+    messages,
+    activeTaskId: effectiveActiveTurnId,
+    isAiResponding: active,
+  );
 }
 
 @visibleForTesting

--- a/ui/lib/services/codex_event_reducer.dart
+++ b/ui/lib/services/codex_event_reducer.dart
@@ -1314,7 +1314,9 @@ class CodexEventReducer {
         ? ''
         : (runtime.messages[index].cardData?['thinkingContent'] ?? '')
               .toString();
-    final cachedThinking = runtime.currentThinkingMessages[parentTaskId];
+    final cachedThinking = runtime.activeThinkingCardId == cardId
+        ? runtime.currentThinkingMessages[parentTaskId]
+        : null;
     final baseContent = cachedThinking ?? existingContent;
     final effectiveDelta = _deduplicateReplayDelta(
       runtime,
@@ -1329,6 +1331,7 @@ class CodexEventReducer {
     _touchActiveTurn(runtime, parentTaskId);
     runtime.isDeepThinking = true;
     runtime.currentThinkingStage = ThinkingStage.thinking.value;
+    runtime.activeThinkingCardId = cardId;
     final nextContent = baseContent + effectiveDelta;
     runtime.codexReplayDeltaOffsets.remove(cardId);
     runtime.currentThinkingMessages[parentTaskId] = nextContent;
@@ -1359,6 +1362,14 @@ class CodexEventReducer {
     required int stage,
     required Map<String, dynamic> streamMeta,
   }) {
+    if (isLoading) {
+      _finalizeOtherLoadingThinkingCardsForTask(
+        runtime,
+        parentTaskId: taskId,
+        activeCardId: cardId,
+      );
+      runtime.activeThinkingCardId = cardId;
+    }
     final index = runtime.messages.indexWhere(
       (message) => message.id == cardId,
     );
@@ -1983,6 +1994,7 @@ class CodexEventReducer {
     runtime.currentThinkingMessages.remove(taskId);
     runtime.deepThinkingContent = '';
     runtime.isDeepThinking = false;
+    runtime.activeThinkingCardId = null;
     runtime.currentThinkingStage = ThinkingStage.complete.value;
     _markAssistantMessagesFinalForTask(runtime, taskId);
     _finalizeThinkingCardsForTask(runtime, taskId);
@@ -2157,6 +2169,33 @@ class CodexEventReducer {
         .where((message) {
           final cardData = message.cardData;
           if (cardData?['type'] != 'deep_thinking') {
+            return false;
+          }
+          final cardTaskId =
+              _string(cardData?['taskID']) ??
+              _string(message.streamMeta?['parentTaskId']);
+          return cardTaskId == parentTaskId;
+        })
+        .map((message) => message.id)
+        .toList(growable: false);
+    for (final cardId in cardIds) {
+      _finalizeThinkingCard(runtime, parentTaskId, cardId);
+    }
+  }
+
+  void _finalizeOtherLoadingThinkingCardsForTask(
+    ChatConversationRuntimeState runtime, {
+    required String parentTaskId,
+    required String activeCardId,
+  }) {
+    final cardIds = runtime.messages
+        .where((message) {
+          if (message.id == activeCardId) {
+            return false;
+          }
+          final cardData = message.cardData;
+          if (cardData?['type'] != 'deep_thinking' ||
+              cardData?['isLoading'] != true) {
             return false;
           }
           final cardTaskId =

--- a/ui/test/services/codex_event_reducer_test.dart
+++ b/ui/test/services/codex_event_reducer_test.dart
@@ -1537,6 +1537,56 @@ diff --git a/lib/main.dart b/lib/main.dart
     },
   );
 
+  test('merge finalizes stale local thinking cards for the active codex turn', () {
+    final now = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+    final merged = mergeRemoteCodexSnapshotMessagesForTesting(
+      snapshotMessages: [
+        ChatMessageModel.cardMessage({
+          'type': 'deep_thinking',
+          'taskID': 'turn-1',
+          'cardId': 'reason-2-codex-thinking',
+          'isLoading': true,
+          'isCollapsible': false,
+          'stage': ThinkingStage.thinking.value,
+          'thinkingContent': 'latest',
+          'startTime': now
+              .add(const Duration(seconds: 2))
+              .millisecondsSinceEpoch,
+        }, id: 'reason-2-codex-thinking').copyWith(
+          createAt: now.add(const Duration(seconds: 2)),
+        ),
+      ],
+      existingMessages: [
+        ChatMessageModel.cardMessage({
+          'type': 'deep_thinking',
+          'taskID': 'turn-1',
+          'cardId': 'reason-1-codex-thinking',
+          'isLoading': true,
+          'isCollapsible': false,
+          'stage': ThinkingStage.thinking.value,
+          'thinkingContent': 'older',
+          'startTime': now.millisecondsSinceEpoch,
+        }, id: 'reason-1-codex-thinking').copyWith(createAt: now),
+      ],
+      activeTaskId: 'turn-1',
+      isAiResponding: true,
+    );
+
+    final thinkingCards = merged
+        .where((message) => message.cardData?['type'] == 'deep_thinking')
+        .toList();
+    expect(thinkingCards, hasLength(2));
+    final latest = thinkingCards.firstWhere(
+      (message) => message.id == 'reason-2-codex-thinking',
+    );
+    final older = thinkingCards.firstWhere(
+      (message) => message.id == 'reason-1-codex-thinking',
+    );
+    expect(latest.cardData!['isLoading'], isTrue);
+    expect(older.cardData!['isLoading'], isFalse);
+    expect(older.cardData!['stage'], ThinkingStage.complete.value);
+  });
+
   test('finalizes assistant item without duplicating completed text', () {
     reducer.reduce(
       runtime: runtime,
@@ -1873,6 +1923,71 @@ diff --git a/lib/main.dart b/lib/main.dart
     },
   );
 
+  test('new reasoning item finalizes previous loading thinking card', () {
+    reducer.reduce(
+      runtime: runtime,
+      event: {
+        'message': {
+          'method': 'turn/started',
+          'params': {'threadId': 'thread-1', 'turnId': 'turn-1'},
+        },
+      },
+    );
+    reducer.reduce(
+      runtime: runtime,
+      event: {
+        'message': {
+          'method': 'item/reasoning/textDelta',
+          'params': {
+            'threadId': 'thread-1',
+            'turnId': 'turn-1',
+            'itemId': 'reason-1',
+            'delta': 'first thought',
+          },
+        },
+      },
+    );
+    reducer.reduce(
+      runtime: runtime,
+      event: {
+        'message': {
+          'method': 'item/completed',
+          'params': {
+            'threadId': 'thread-1',
+            'turnId': 'turn-1',
+            'itemId': 'reason-1',
+            'item': {'id': 'reason-1', 'type': 'reasoning'},
+          },
+        },
+      },
+    );
+    reducer.reduce(
+      runtime: runtime,
+      event: {
+        'message': {
+          'method': 'item/reasoning/textDelta',
+          'params': {
+            'threadId': 'thread-1',
+            'turnId': 'turn-1',
+            'itemId': 'reason-2',
+            'delta': 'second thought',
+          },
+        },
+      },
+    );
+
+    final first = runtime.messages.firstWhere(
+      (message) => message.id == 'reason-1-codex-thinking',
+    );
+    final second = runtime.messages.firstWhere(
+      (message) => message.id == 'reason-2-codex-thinking',
+    );
+    expect(first.cardData!['isLoading'], isFalse);
+    expect(first.cardData!['stage'], ThinkingStage.complete.value);
+    expect(second.cardData!['isLoading'], isTrue);
+    expect(second.cardData!['thinkingContent'], 'second thought');
+  });
+
   test('turn/completed finalizes the thinking card after reasoning ends', () {
     reducer.reduce(
       runtime: runtime,
@@ -2052,6 +2167,50 @@ diff --git a/lib/main.dart b/lib/main.dart
       expect(cardData['stage'], ThinkingStage.thinking.value);
     },
   );
+
+  test('snapshot keeps only the latest reasoning card loading for active turn', () {
+    final messages = codexMessagesFromThreadResponseForTesting(
+      {
+        'thread': {
+          'id': 'thread-1',
+          'status': {'type': 'active'},
+          'turns': [
+            {
+              'id': 'turn-1',
+              'status': 'inProgress',
+              'items': [
+                {
+                  'id': 'reason-1',
+                  'type': 'reasoning',
+                  'status': 'completed',
+                  'summary': ['older reasoning'],
+                },
+                {
+                  'id': 'reason-2',
+                  'type': 'reasoning',
+                  'status': 'completed',
+                  'summary': ['latest reasoning'],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      active: true,
+      activeTurnId: 'turn-1',
+    );
+
+    final first = messages.firstWhere(
+      (message) => message.id == 'reason-1-codex-thinking',
+    );
+    final second = messages.firstWhere(
+      (message) => message.id == 'reason-2-codex-thinking',
+    );
+    expect(first.cardData!['isLoading'], isFalse);
+    expect(first.cardData!['stage'], ThinkingStage.complete.value);
+    expect(second.cardData!['isLoading'], isTrue);
+    expect(second.cardData!['stage'], ThinkingStage.thinking.value);
+  });
 
   test(
     'codex protocol exec_command_begin with parsed_cmd read renders as workspace card',


### PR DESCRIPTION
## 问题
调试版中恢复/同步 Codex 会话时，旧的 deep_thinking/reasoning 卡片可能一直保持 isLoading=true，导致同一个 turn 出现多个“正在思考”。

## 修复
- reducer 在新的 reasoning 卡开始加载时收尾同 task 的旧 loading 思考卡
- snapshot/merge 归一化 Codex 思考卡，同一 active task 只保留最新一张 loading
- turn 完成后清理 activeThinkingCardId，避免新的 reasoning 卡复用上一张缓存

## 验证
- git diff --check origin/main..HEAD
- 已补充 codex_event_reducer_test.dart 回归测试
- 本地环境缺少 flutter/dart/fvm，Flutter 单测交由 GitHub Actions 跑