### PR TITLE
feat: 聊天页模型选择器改为自定义选择模型(从供应商管理页面设置选择的模型)

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -1157,14 +1157,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   }
 
   bool get _hasSelectableNormalChatModels {
-    return _modelProviderProfiles.any((profile) {
-      if (!profile.configured) {
-        return false;
-      }
-      final models =
-          _modelOptionsByProfileId[profile.id] ?? const <ProviderModelOption>[];
-      return models.isNotEmpty;
-    });
+    return _modelProviderProfiles.any((profile) => profile.configured);
   }
 
   _ChatModelOverrideSelection? get _activeDispatchSceneSelection {

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -5,7 +5,7 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
   Future<void> _loadNormalChatModelContext() async {
     try {
       final results = await Future.wait<dynamic>([
-        ModelProviderConfigService.loadModelGroups(),
+        ModelProviderConfigService.loadChatModelGroups(),
         SceneModelConfigService.getSceneCatalog(),
       ]);
       if (!mounted) return;
@@ -447,7 +447,7 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
       return;
     }
     if (_conversationModelSelectorOverlayEntry != null) {
-      // 已经开着,不重开。
+      // 宸茬粡寮€鐫€,涓嶉噸寮€銆?
       return;
     }
     if (_showSlashCommandPanel ||
@@ -462,15 +462,15 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     if (!_hasSelectableNormalChatModels) {
       return;
     }
-    // 关键：不能调 `_inputFocusNode.unfocus()`，也不能用 `showGlassPopup`
-    // (push Navigator route)。两条路径都会让 TextField 失焦 → 软键盘塌陷 →
-    // 输入栏下沉 → popup 锚点错位(锚点是 popup 弹出瞬间按按钮在屏幕上的位置算的，
-    // 键盘塌陷后按钮位置已经变了)。
+    // 鍏抽敭锛氫笉鑳借皟 `_inputFocusNode.unfocus()`锛屼篃涓嶈兘鐢?`showGlassPopup`
+    // (push Navigator route)銆備袱鏉¤矾寰勯兘浼氳 TextField 澶辩劍 鈫?杞敭鐩樺闄?鈫?
+    // 杈撳叆鏍忎笅娌?鈫?popup 閿氱偣閿欎綅(閿氱偣鏄?popup 寮瑰嚭鐬棿鎸夋寜閽湪灞忓箷涓婄殑浣嶇疆绠楃殑锛?
+    // 閿洏濉岄櫡鍚庢寜閽綅缃凡缁忓彉浜?銆?
     //
-    // Flutter 框架细节(重要)：`Route.requestFocus = false` **不能** 阻止 push
-    // 时的焦点迁移——`ModalRoute.didPush` 里检查的是 `navigator.widget.requestFocus`
-    // (Navigator 的 requestFocus),不是 Route 的。详见 routes.dart:1668。要彻底
-    // 跳过这条焦点迁移路径，唯一干净的办法是不走 Navigator 路由——直接挂到 Overlay。
+    // Flutter 妗嗘灦缁嗚妭(閲嶈)锛歚Route.requestFocus = false` **涓嶈兘** 闃绘 push
+    // 鏃剁殑鐒︾偣杩佺Щ鈥斺€擿ModalRoute.didPush` 閲屾鏌ョ殑鏄?`navigator.widget.requestFocus`
+    // (Navigator 鐨?requestFocus),涓嶆槸 Route 鐨勩€傝瑙?routes.dart:1668銆傝褰诲簳
+    // 璺宠繃杩欐潯鐒︾偣杩佺Щ璺緞锛屽敮涓€骞插噣鐨勫姙娉曟槸涓嶈蛋 Navigator 璺敱鈥斺€旂洿鎺ユ寕鍒?Overlay銆?
     final anchorBox = anchorContext.findRenderObject() as RenderBox?;
     final anchorRect = glassPopupAnchorFromContext(anchorContext);
     if (anchorBox == null || !anchorBox.hasSize || anchorRect == null) {
@@ -491,8 +491,8 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
       if (dismissing) return;
       dismissing = true;
       if (!completer.isCompleted) {
-        // 立刻 resolve caller,让 _applyDispatchSceneModelSelection 可以并行启动；
-        // 收起动画在背景里跑完即可,UI 更响应。
+        // 绔嬪埢 resolve caller,璁?_applyDispatchSceneModelSelection 鍙互骞惰鍚姩锛?
+        // 鏀惰捣鍔ㄧ敾鍦ㄨ儗鏅噷璺戝畬鍗冲彲,UI 鏇村搷搴斻€?
         completer.complete(result);
       }
       final wrapper = wrapperKey.currentState;
@@ -511,13 +511,13 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
             unawaited(finish(null));
             return true;
           },
-          // 系统返回手势在 Android 上的处理顺序:
-          //   1. 软键盘开着时,平台层先 hide IME,Flutter 收不到 back 事件;
-          //   2. IME 关掉后再按返回才会传到 Flutter 的 BackButtonListener / PopScope。
-          // 我们的 fix 让模型 popup 打开时键盘保持可见,所以第一击会被
-          // 平台吃掉变成"只关键盘",popup 留在原地。这里用一个 listener
-          // 观察 MediaQuery.viewInsets.bottom,从 >0 跳到 0 就主动关掉 popup,
-          // 这样从用户视角一次返回就把键盘和 popup 一起收掉。
+          // 绯荤粺杩斿洖鎵嬪娍鍦?Android 涓婄殑澶勭悊椤哄簭:
+          //   1. 杞敭鐩樺紑鐫€鏃?骞冲彴灞傚厛 hide IME,Flutter 鏀朵笉鍒?back 浜嬩欢;
+          //   2. IME 鍏虫帀鍚庡啀鎸夎繑鍥炴墠浼氫紶鍒?Flutter 鐨?BackButtonListener / PopScope銆?
+          // 鎴戜滑鐨?fix 璁╂ā鍨?popup 鎵撳紑鏃堕敭鐩樹繚鎸佸彲瑙?鎵€浠ョ涓€鍑讳細琚?
+          // 骞冲彴鍚冩帀鍙樻垚"鍙叧閿洏",popup 鐣欏湪鍘熷湴銆傝繖閲岀敤涓€涓?listener
+          // 瑙傚療 MediaQuery.viewInsets.bottom,浠?>0 璺冲埌 0 灏变富鍔ㄥ叧鎺?popup,
+          // 杩欐牱浠庣敤鎴疯瑙掍竴娆¤繑鍥炲氨鎶婇敭鐩樺拰 popup 涓€璧锋敹鎺夈€?
           child: _DismissOverlayOnKeyboardHide(
             onKeyboardHide: () => unawaited(finish(null)),
             child: Material(
@@ -540,6 +540,13 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
                       providerModelsByProfileId: _modelOptionsByProfileId,
                       currentSelection: _activeDispatchSceneSelection,
                       onSelect: (selection) => unawaited(finish(selection)),
+                      onManage: () async {
+                        await finish(null);
+                        if (!mounted) {
+                          return;
+                        }
+                        GoRouterManager.push('/home/vlm_model_setting');
+                      },
                     ),
                   ),
                 ],
@@ -1133,6 +1140,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
     required this.providerModelsByProfileId,
     required this.currentSelection,
     this.onSelect,
+    this.onManage,
   });
 
   final double width;
@@ -1140,10 +1148,8 @@ class _ConversationModelSelectorContent extends StatefulWidget {
   final List<ModelProviderProfileSummary> profiles;
   final Map<String, List<ProviderModelOption>> providerModelsByProfileId;
   final _ChatModelOverrideSelection? currentSelection;
-
-  /// 非空时由调用方决定怎么消费选择(例如关闭外层 [OverlayEntry] + 触发后续逻辑)；
-  /// 为空时回退到 [Navigator.of(context).pop(selection)],兼容老的 route 调用方。
   final ValueChanged<_ChatModelOverrideSelection>? onSelect;
+  final FutureOr<void> Function()? onManage;
 
   @override
   State<_ConversationModelSelectorContent> createState() =>
@@ -1170,13 +1176,19 @@ class _ConversationModelSelectorContentState
   late final Set<String> _expandedProfileIds;
   late final Set<String> _expandedBackendKeys;
 
-  // 估算滚动定位用的行高常量（与下方各行的固定 padding/字号对应）。
   static const double _kProfileHeaderExtent = 43.0;
   static const double _kModelRowExtent = 43.0;
   static const double _kBackendHeaderExtent = 28.0;
   static const double _kProfileGapExtent = 6.0;
 
   bool get _hasSearchQuery => _searchController.text.trim().isNotEmpty;
+  bool get _hasAnyVisibleModels => widget.profiles.any((profile) {
+    if (!profile.configured) {
+      return false;
+    }
+    final models = widget.providerModelsByProfileId[profile.id] ?? const [];
+    return models.isNotEmpty;
+  });
 
   @override
   void initState() {
@@ -1222,10 +1234,6 @@ class _ConversationModelSelectorContentState
     super.dispose();
   }
 
-  /// 打开弹窗后自动滚动到当前选中的模型行。
-  ///
-  /// 列表为懒加载（ListView.builder），选中行可能尚未构建，因此先按固定行高
-  /// 估算偏移跳转到目标附近，待目标行构建后再用 ensureVisible 精确对齐。
   void _autoScrollToSelectedModel() {
     final selection = widget.currentSelection;
     if (selection == null || !_listScrollController.hasClients) {
@@ -1283,7 +1291,6 @@ class _ConversationModelSelectorContentState
     if (position.maxScrollExtent <= 0) {
       return;
     }
-    // 让目标行落在视口上方约 1/3 处。
     final target = (offset - position.viewportDimension * 0.35).clamp(
       0.0,
       position.maxScrollExtent,
@@ -1426,6 +1433,116 @@ class _ConversationModelSelectorContentState
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildSelectorHeader() {
+    final palette = context.omniPalette;
+    final isDark = context.isDarkTheme;
+    final onManage = widget.onManage;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildSearchRow(),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: onManage == null
+                  ? null
+                  : () {
+                      unawaited(Future<void>.value(onManage()));
+                    },
+              style: TextButton.styleFrom(
+                minimumSize: Size.zero,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                foregroundColor: isDark
+                    ? palette.accentPrimary
+                    : const Color(0xFF2C7FEB),
+              ),
+              icon: const Icon(Icons.tune_rounded, size: 15),
+              label: Text(
+                LegacyTextLocalizer.localize('管理模型'),
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSelectorEmptyState(
+    String title, {
+    String? subtitle,
+    bool showManageAction = false,
+    bool compact = false,
+  }) {
+    final palette = context.omniPalette;
+    final isDark = context.isDarkTheme;
+    final onManage = widget.onManage;
+    return Padding(
+      padding: compact
+          ? const EdgeInsets.fromLTRB(12, 6, 12, 10)
+          : const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            LegacyTextLocalizer.localize(title),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 12,
+              color: isDark ? palette.textTertiary : const Color(0xFF94A3B8),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              LegacyTextLocalizer.localize(subtitle),
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                color: isDark
+                    ? palette.textTertiary.withValues(alpha: 0.86)
+                    : const Color(0xFF9AA4B6),
+              ),
+            ),
+          ],
+          if (showManageAction && onManage != null) ...[
+            const SizedBox(height: 10),
+            TextButton(
+              onPressed: () {
+                unawaited(Future<void>.value(onManage()));
+              },
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                foregroundColor: isDark
+                    ? palette.accentPrimary
+                    : const Color(0xFF2C7FEB),
+              ),
+              child: Text(
+                LegacyTextLocalizer.localize('去管理模型'),
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }
@@ -1678,17 +1795,11 @@ class _ConversationModelSelectorContentState
   Widget _buildBackendGroupedModels(ModelProviderProfileSummary profile) {
     final groups = _groupByBackend(profile.id);
     if (groups.isEmpty) {
-      return Padding(
-        padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
-        child: Text(
-          LegacyTextLocalizer.localize('该 Provider 暂无可选模型'),
-          style: TextStyle(
-            fontSize: 12,
-            color: context.isDarkTheme
-                ? context.omniPalette.textTertiary
-                : const Color(0xFF94A3B8),
-          ),
-        ),
+      return _buildSelectorEmptyState(
+        '暂无已添加模型',
+        subtitle: '请到模型提供商页添加',
+        showManageAction: true,
+        compact: true,
       );
     }
     final sortedKeys = _sortedBackendKeys(groups.keys);
@@ -1708,16 +1819,75 @@ class _ConversationModelSelectorContentState
 
   @override
   Widget build(BuildContext context) {
-    final palette = context.omniPalette;
+    final configuredProfiles = widget.profiles
+        .where((profile) => profile.configured)
+        .toList();
     final mediaQuery = MediaQuery.of(context);
     final dynamicMaxHeight =
         (mediaQuery.size.height - mediaQuery.viewInsets.bottom - 96)
             .clamp(220.0, widget.maxHeight)
             .toDouble();
-    final configuredProfiles = widget.profiles
-        .where((profile) => profile.configured)
-        .toList();
     final visibleProfiles = _visibleProfiles;
+
+    late final Widget content;
+    if (configuredProfiles.isEmpty) {
+      content = _buildSelectorEmptyState(
+        '请先在模型提供商页配置 Provider',
+        showManageAction: true,
+      );
+    } else if (!_hasAnyVisibleModels && !_hasSearchQuery) {
+      content = _buildSelectorEmptyState(
+        '暂无可切换模型',
+        subtitle: '请先到模型提供商页添加',
+        showManageAction: true,
+      );
+    } else if (visibleProfiles.isEmpty) {
+      content = _buildSelectorEmptyState('没有匹配的模型');
+    } else {
+      content = Flexible(
+        child: Scrollbar(
+          controller: _listScrollController,
+          child: ListView.builder(
+            controller: _listScrollController,
+            padding: const EdgeInsets.only(bottom: 8),
+            itemCount: visibleProfiles.length,
+            itemBuilder: (context, index) {
+              final profile = visibleProfiles[index];
+              final expanded = _isExpanded(profile.id);
+              final models = _filteredModels(profile.id);
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildProfileHeader(profile),
+                  if (expanded)
+                    if (_needsBackendGrouping(profile.id))
+                      _buildBackendGroupedModels(profile)
+                    else if (models.isEmpty)
+                      _buildSelectorEmptyState(
+                        '暂无已添加模型',
+                        subtitle: '请到模型提供商页添加',
+                        showManageAction: true,
+                        compact: true,
+                      )
+                    else
+                      Column(
+                        children: models
+                            .map(
+                              (item) =>
+                                  _buildModelRow(profile: profile, model: item),
+                            )
+                            .toList(),
+                      ),
+                  if (index != visibleProfiles.length - 1)
+                    const SizedBox(height: 6),
+                ],
+              );
+            },
+          ),
+        ),
+      );
+    }
+
     return SizedBox(
       width: widget.width,
       child: OmniGlassPanel(
@@ -1729,92 +1899,7 @@ class _ConversationModelSelectorContentState
             constraints: BoxConstraints(maxHeight: dynamicMaxHeight),
             child: Column(
               mainAxisSize: MainAxisSize.min,
-              children: [
-                _buildSearchRow(),
-                if (configuredProfiles.isEmpty)
-                  Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Text(
-                      LegacyTextLocalizer.localize('请先在模型提供商页配置 Provider'),
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: context.isDarkTheme
-                            ? palette.textTertiary
-                            : const Color(0xFF94A3B8),
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  )
-                else if (visibleProfiles.isEmpty)
-                  Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Text(
-                      LegacyTextLocalizer.localize('没有匹配的模型'),
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: context.isDarkTheme
-                            ? palette.textTertiary
-                            : const Color(0xFF94A3B8),
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  )
-                else
-                  Flexible(
-                    child: Scrollbar(
-                      controller: _listScrollController,
-                      child: ListView.builder(
-                        controller: _listScrollController,
-                        padding: const EdgeInsets.only(bottom: 8),
-                        itemCount: visibleProfiles.length,
-                        itemBuilder: (context, index) {
-                          final profile = visibleProfiles[index];
-                          final expanded = _isExpanded(profile.id);
-                          final models = _filteredModels(profile.id);
-                          return Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              _buildProfileHeader(profile),
-                              if (expanded)
-                                if (_needsBackendGrouping(profile.id))
-                                  _buildBackendGroupedModels(profile)
-                                else if (models.isEmpty)
-                                  Padding(
-                                    padding: EdgeInsets.fromLTRB(12, 4, 12, 8),
-                                    child: Text(
-                                      LegacyTextLocalizer.localize(
-                                        '该 Provider 暂无可选模型',
-                                      ),
-                                      style: TextStyle(
-                                        fontSize: 12,
-                                        color: context.isDarkTheme
-                                            ? palette.textTertiary
-                                            : const Color(0xFF94A3B8),
-                                      ),
-                                    ),
-                                  )
-                                else
-                                  Column(
-                                    children: models
-                                        .map(
-                                          (item) => _buildModelRow(
-                                            profile: profile,
-                                            model: item,
-                                          ),
-                                        )
-                                        .toList(),
-                                  ),
-                              if (index != visibleProfiles.length - 1)
-                                const SizedBox(height: 6),
-                            ],
-                          );
-                        },
-                      ),
-                    ),
-                  ),
-              ],
+              children: [_buildSelectorHeader(), content],
             ),
           ),
         ),
@@ -1845,12 +1930,12 @@ class _DismissOverlayOnKeyboardHide extends StatefulWidget {
 
 class _DismissOverlayOnKeyboardHideState
     extends State<_DismissOverlayOnKeyboardHide> {
-  /// 要把 peak 视作"键盘是真的弹起过",最小高度;<50dp 通常是 nav bar / 手势
-  /// gutter 之类的固定 inset,不算键盘。
+  /// 瑕佹妸 peak 瑙嗕綔"閿洏鏄湡鐨勫脊璧疯繃",鏈€灏忛珮搴?<50dp 閫氬父鏄?nav bar / 鎵嬪娍
+  /// gutter 涔嬬被鐨勫浐瀹?inset,涓嶇畻閿洏銆?
   static const double _kKeyboardPeakMinimum = 50.0;
 
-  /// 已经看到的最大 viewInsets.bottom。键盘高度可能随键盘类型(文本/表情/语音)
-  /// 变化,我们只把"曾经达到过的最高值"当作 peak,避免切换布局时误触发收起。
+  /// 宸茬粡鐪嬪埌鐨勬渶澶?viewInsets.bottom銆傞敭鐩橀珮搴﹀彲鑳介殢閿洏绫诲瀷(鏂囨湰/琛ㄦ儏/璇煶)
+  /// 鍙樺寲,鎴戜滑鍙妸"鏇剧粡杈惧埌杩囩殑鏈€楂樺€?褰撲綔 peak,閬垮厤鍒囨崲甯冨眬鏃惰瑙﹀彂鏀惰捣銆?
   double _peakInset = 0;
   bool _firedOnce = false;
 
@@ -1861,21 +1946,21 @@ class _DismissOverlayOnKeyboardHideState
     if (bottomInset > _peakInset) {
       _peakInset = bottomInset;
     }
-    // 关键时序:Android 的 IME hide 是动画的(~250ms),如果等 viewInsets.bottom
-    // 全部跌到 0 再触发收起 popup,popup 的反向动画(220ms)就要排在 IME 动画
-    // 之后跑,用户看到的延迟 ≈ 250+220 ms,popup 卡顿明显。改为检测"开始下落"
-    // 的瞬间(从 peak 跌掉 ≥ 10%),触发 popup 反向动画并行跑——这样 IME 动画
-    // 跑完时 popup 也几乎同时消失。
+    // 鍏抽敭鏃跺簭:Android 鐨?IME hide 鏄姩鐢荤殑(~250ms),濡傛灉绛?viewInsets.bottom
+    // 鍏ㄩ儴璺屽埌 0 鍐嶈Е鍙戞敹璧?popup,popup 鐨勫弽鍚戝姩鐢?220ms)灏辫鎺掑湪 IME 鍔ㄧ敾
+    // 涔嬪悗璺?鐢ㄦ埛鐪嬪埌鐨勫欢杩?鈮?250+220 ms,popup 鍗￠】鏄庢樉銆傛敼涓烘娴?寮€濮嬩笅钀?
+    // 鐨勭灛闂?浠?peak 璺屾帀 鈮?10%),瑙﹀彂 popup 鍙嶅悜鍔ㄧ敾骞惰璺戔€斺€旇繖鏍?IME 鍔ㄧ敾
+    // 璺戝畬鏃?popup 涔熷嚑涔庡悓鏃舵秷澶便€?
     //
-    // 阈值 10% 而不是固定像素,是因为 PJD110/ColorOS 的 viewPadding 在静稳态
-    // 也会有亚像素抖动(见 composer-keyboard-debug-rig 笔记),百分比阈值
-    // 对噪声更稳健;peak 必须 ≥ 50dp 进一步保证是真键盘弹起过。
+    // 闃堝€?10% 鑰屼笉鏄浐瀹氬儚绱?鏄洜涓?PJD110/ColorOS 鐨?viewPadding 鍦ㄩ潤绋虫€?
+    // 涔熶細鏈変簹鍍忕礌鎶栧姩(瑙?composer-keyboard-debug-rig 绗旇),鐧惧垎姣旈槇鍊?
+    // 瀵瑰櫔澹版洿绋冲仴;peak 蹇呴』 鈮?50dp 杩涗竴姝ヤ繚璇佹槸鐪熼敭鐩樺脊璧疯繃銆?
     if (!_firedOnce &&
         _peakInset > _kKeyboardPeakMinimum &&
         bottomInset < _peakInset * 0.9) {
       _firedOnce = true;
-      // 不能在 didChangeDependencies 同步调 callback——callback 可能 setState,
-      // 而本帧正在 build。延到下一帧。
+      // 涓嶈兘鍦?didChangeDependencies 鍚屾璋?callback鈥斺€攃allback 鍙兘 setState,
+      // 鑰屾湰甯ф鍦?build銆傚欢鍒颁笅涓€甯с€?
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) widget.onKeyboardHide();
       });

--- a/ui/lib/features/home/pages/vlm_model_setting/vlm_model_setting_page.dart
+++ b/ui/lib/features/home/pages/vlm_model_setting/vlm_model_setting_page.dart
@@ -198,6 +198,8 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _baseUrlController = TextEditingController();
   final TextEditingController _apiKeyController = TextEditingController();
+  final TextEditingController _remoteModelSearchController =
+      TextEditingController();
   final FocusNode _nameFocusNode = FocusNode();
   final FocusNode _baseUrlFocusNode = FocusNode();
   final FocusNode _apiKeyFocusNode = FocusNode();
@@ -397,6 +399,51 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     return entries;
   }
 
+  List<ProviderModelOption> get _chatAddedModels => _manualModels;
+
+  List<ProviderModelOption> get _filteredRemoteModels {
+    final query = _remoteModelSearchController.text.trim().toLowerCase();
+    if (query.isEmpty) {
+      return _remoteModels;
+    }
+    return _remoteModels.where((model) {
+      final modelId = model.id.toLowerCase();
+      final displayName = model.displayName.toLowerCase();
+      return modelId.contains(query) || displayName.contains(query);
+    }).toList();
+  }
+
+  List<MapEntry<String, List<ProviderModelOption>>> _groupProviderModels(
+    List<ProviderModelOption> models,
+  ) {
+    final groups = <String, List<ProviderModelOption>>{};
+    final current = _currentProfile;
+    for (final model in models) {
+      final groupKey = ModelVendorCatalog.groupKeyFor(
+        model.id,
+        ownedBy: model.ownedBy,
+        providerId: model.modelsDevProviderId ?? current?.id,
+        providerName: current?.name,
+      );
+      groups.putIfAbsent(groupKey, () => <ProviderModelOption>[]).add(model);
+    }
+    final entries = groups.entries.toList()
+      ..sort((a, b) {
+        final orderCompare = ModelVendorCatalog.orderOf(
+          a.key,
+        ).compareTo(ModelVendorCatalog.orderOf(b.key));
+        if (orderCompare != 0) return orderCompare;
+        return a.key.compareTo(b.key);
+      });
+    return entries;
+  }
+
+  List<MapEntry<String, List<ProviderModelOption>>> get _addedModelGroups =>
+      _groupProviderModels(_chatAddedModels);
+
+  List<MapEntry<String, List<ProviderModelOption>>> get _remoteModelGroups =>
+      _groupProviderModels(_filteredRemoteModels);
+
   String _modelGroupExpansionKey(String groupName) {
     final profileKey = _editingProfileId.trim().isEmpty
         ? 'default'
@@ -462,6 +509,7 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     _nameController.addListener(_onProfileChanged);
     _baseUrlController.addListener(_onProfileChanged);
     _apiKeyController.addListener(_onProfileChanged);
+    _remoteModelSearchController.addListener(_handleRemoteModelSearchChanged);
     _nameFocusNode.addListener(_onProfileFieldFocusChanged);
     _baseUrlFocusNode.addListener(_onProfileFieldFocusChanged);
     _apiKeyFocusNode.addListener(_onProfileFieldFocusChanged);
@@ -481,9 +529,13 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     _nameController.removeListener(_onProfileChanged);
     _baseUrlController.removeListener(_onProfileChanged);
     _apiKeyController.removeListener(_onProfileChanged);
+    _remoteModelSearchController.removeListener(
+      _handleRemoteModelSearchChanged,
+    );
     _nameController.dispose();
     _baseUrlController.dispose();
     _apiKeyController.dispose();
+    _remoteModelSearchController.dispose();
     _nameFocusNode.dispose();
     _baseUrlFocusNode.dispose();
     _apiKeyFocusNode.dispose();
@@ -491,6 +543,13 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
       entry.dispose();
     }
     super.dispose();
+  }
+
+  void _handleRemoteModelSearchChanged() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
   }
 
   void _onProfileChanged() {
@@ -577,6 +636,31 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     } catch (_) {
       // no-op
     }
+  }
+
+  bool _hasAnyExpandedProviderGroups<T>(
+    List<MapEntry<String, List<T>>> groups,
+  ) {
+    return groups.any((group) => _isModelGroupExpanded(group.key));
+  }
+
+  bool _areAllProviderGroupsCollapsed<T>(
+    List<MapEntry<String, List<T>>> groups,
+  ) {
+    return groups.isNotEmpty &&
+        groups.every((group) => !_isModelGroupExpanded(group.key));
+  }
+
+  void _toggleAllProviderGroups<T>(List<MapEntry<String, List<T>>> groups) {
+    if (groups.isEmpty) {
+      return;
+    }
+    final shouldExpand = _areAllProviderGroupsCollapsed(groups);
+    setState(() {
+      for (final group in groups) {
+        _expandedModelGroups[_modelGroupExpansionKey(group.key)] = shouldExpand;
+      }
+    });
   }
 
   Future<void> _persistProfileDraft() async {
@@ -1192,8 +1276,7 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     }
 
     final existsInManual = _manualModelIds.any((item) => item == normalized);
-    final existsInRemote = _remoteModels.any((item) => item.id == normalized);
-    if (existsInManual || existsInRemote) {
+    if (existsInManual) {
       showToast(context.l10n.modelAlreadyExists, type: ToastType.warning);
       return;
     }
@@ -1217,53 +1300,97 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     showToast(context.l10n.modelAdded, type: ToastType.success);
   }
 
-  Future<void> _deleteModel(_ProviderModelItem item) async {
+  Future<void> _addModelToChatWhitelist(ProviderModelOption model) async {
     final current = _currentProfile;
-    if (current == null || _deletingModelIds.contains(item.id)) {
+    if (current == null || _manualModelIds.contains(model.id)) {
+      return;
+    }
+    final nextManual = [..._manualModelIds, model.id];
+    final nextManualModels = await _loadManualModelsForProfile(
+      current,
+      nextManual,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _manualModelIds = nextManual;
+      _manualModels = nextManualModels;
+    });
+    try {
+      await ModelProviderConfigService.saveManualModelIds(
+        profileId: current.id,
+        ids: nextManual,
+      );
+      if (!mounted) {
+        return;
+      }
+      showToast(context.l10n.modelAdded, type: ToastType.success);
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      final fallbackManualModels = await _loadManualModelsForProfile(
+        current,
+        _manualModelIds.where((id) => id != model.id).toList(),
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _manualModelIds = _manualModelIds
+            .where((id) => id != model.id)
+            .toList();
+        _manualModels = fallbackManualModels;
+      });
+      showToast(_headerText('添加失败', 'Failed to add'), type: ToastType.error);
+    }
+  }
+
+  Future<void> _removeModelFromChatWhitelist(ProviderModelOption model) async {
+    final current = _currentProfile;
+    if (current == null || _deletingModelIds.contains(model.id)) {
       return;
     }
 
     final prevManual = List<String>.from(_manualModelIds);
     final prevManualModels = List<ProviderModelOption>.from(_manualModels);
-    final prevRemote = List<ProviderModelOption>.from(_remoteModels);
 
     setState(() {
-      _deletingModelIds = {..._deletingModelIds, item.id};
-      _manualModelIds = _manualModelIds.where((id) => id != item.id).toList();
-      _manualModels = _manualModels.where((m) => m.id != item.id).toList();
-      _remoteModels = _remoteModels.where((m) => m.id != item.id).toList();
+      _deletingModelIds = {..._deletingModelIds, model.id};
+      _manualModelIds = _manualModelIds.where((id) => id != model.id).toList();
+      _manualModels = _manualModels.where((m) => m.id != model.id).toList();
     });
 
     try {
-      await Future.wait([
-        ModelProviderConfigService.saveManualModelIds(
-          profileId: current.id,
-          ids: _manualModelIds,
-        ),
-        ModelProviderConfigService.saveCachedFetchedModels(
-          profileId: current.id,
-          apiBase: _baseUrlController.text.trim(),
-          models: _remoteModels,
-        ),
-      ]);
+      await ModelProviderConfigService.saveManualModelIds(
+        profileId: current.id,
+        ids: _manualModelIds,
+      );
 
       if (!mounted) return;
-      showToast(context.l10n.modelDeleted, type: ToastType.success);
+      showToast(
+        _headerText('已从聊天页移除', 'Removed from chat'),
+        type: ToastType.success,
+      );
     } catch (_) {
       if (!mounted) return;
       setState(() {
         _manualModelIds = prevManual;
         _manualModels = prevManualModels;
-        _remoteModels = prevRemote;
       });
-      showToast(context.l10n.modelDeleteFailed, type: ToastType.error);
+      showToast(_headerText('移除失败', 'Failed to remove'), type: ToastType.error);
     } finally {
       if (mounted) {
         setState(() {
-          _deletingModelIds = {..._deletingModelIds}..remove(item.id);
+          _deletingModelIds = {..._deletingModelIds}..remove(model.id);
         });
       }
     }
+  }
+
+  Future<void> _deleteModel(_ProviderModelItem item) async {
+    await _removeModelFromChatWhitelist(item.model);
   }
 
   Future<void> _selectProviderType(String value) async {
@@ -2414,6 +2541,168 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     );
   }
 
+  Widget _buildProviderModelRow({
+    required ProviderModelOption model,
+    required bool added,
+    required VoidCallback? onAction,
+    required String actionLabel,
+    bool actionFilled = false,
+    bool actionDisabled = false,
+    bool removable = false,
+  }) {
+    final isBusy = _deletingModelIds.contains(model.id);
+    final metadataWidgets = _buildModelMetadataWidgets(model);
+    final accentColor = _isDarkTheme
+        ? context.omniPalette.accentPrimary
+        : const Color(0xFF2C7FEB);
+
+    Widget row = Material(
+      color: Colors.transparent,
+      child: SizedBox(
+        width: double.infinity,
+        height: 44,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Text(
+                  model.id,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: _primaryTextColor,
+                    fontFamily: 'PingFang SC',
+                    height: 1.2,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 10),
+              SizedBox(
+                width: 120,
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const BouncingScrollPhysics(),
+                  reverse: true,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (
+                        var index = 0;
+                        index < metadataWidgets.length;
+                        index++
+                      ) ...[
+                        if (index > 0) const SizedBox(width: 6),
+                        metadataWidgets[index],
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              TextButton(
+                onPressed: (actionDisabled || isBusy) ? null : onAction,
+                style: TextButton.styleFrom(
+                  minimumSize: const Size(68, 30),
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  foregroundColor: actionFilled ? Colors.white : accentColor,
+                  backgroundColor: actionFilled
+                      ? accentColor
+                      : Colors.transparent,
+                  disabledForegroundColor: _tertiaryTextColor,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(999),
+                    side: BorderSide(
+                      color: actionFilled
+                          ? accentColor
+                          : (_isDarkTheme
+                                ? context.omniPalette.borderSubtle
+                                : const Color(0x1F000000)),
+                    ),
+                  ),
+                  textStyle: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'PingFang SC',
+                  ),
+                ),
+                child: isBusy
+                    ? const SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(actionLabel),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    if (!removable) {
+      return row;
+    }
+
+    return IgnorePointer(
+      ignoring: isBusy,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 180),
+        opacity: isBusy ? 0.72 : 1,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final initialActionWidth =
+                constraints.maxWidth * _modelDeleteExtentRatio;
+            final deleteIconRightPadding =
+                ((initialActionWidth - _modelDeleteIconSize) / 2)
+                    .clamp(0.0, double.infinity)
+                    .toDouble();
+            return Slidable(
+              key: ValueKey<String>('provider-model-added-${model.id}'),
+              groupTag: 'provider-added-model-items',
+              closeOnScroll: true,
+              endActionPane: ActionPane(
+                motion: const BehindMotion(),
+                extentRatio: _modelDeleteExtentRatio,
+                dismissible: DismissiblePane(
+                  dismissThreshold: 0.4,
+                  closeOnCancel: true,
+                  motion: const InversedDrawerMotion(),
+                  onDismissed: () => _removeModelFromChatWhitelist(model),
+                ),
+                children: [
+                  CustomSlidableAction(
+                    onPressed: (_) => _removeModelFromChatWhitelist(model),
+                    backgroundColor: AppColors.alertRed,
+                    borderRadius: _modelDeleteActionRadius,
+                    padding: EdgeInsets.zero,
+                    alignment: Alignment.centerRight,
+                    child: Padding(
+                      padding: EdgeInsets.only(right: deleteIconRightPadding),
+                      child: SvgPicture.asset(
+                        'assets/memory/memory_delete.svg',
+                        width: _modelDeleteIconSize,
+                        height: _modelDeleteIconSize,
+                        colorFilter: const ColorFilter.mode(
+                          Colors.white,
+                          BlendMode.srcIn,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              child: row,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   Future<void> _openProviderSwitchMenu(BuildContext anchorContext) async {
     if (_profiles.isEmpty) {
       return;
@@ -2662,8 +2951,9 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final modelItems = _modelItems;
-    final modelGroups = _modelGroups;
+    final addedModelGroups = _addedModelGroups;
+    final remoteModelGroups = _remoteModelGroups;
+    final filteredRemoteModels = _filteredRemoteModels;
 
     return Scaffold(
       backgroundColor: _pageBackground,
@@ -2855,7 +3145,10 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                           children: [
                             Expanded(
                               child: Text(
-                                context.l10n.modelListCount(modelItems.length),
+                                _headerText(
+                                  '已添加到聊天页 ${_chatAddedModels.length} 个',
+                                  '${_chatAddedModels.length} added to chat',
+                                ),
                                 style: TextStyle(
                                   color: _secondaryTextColor,
                                   fontSize: 12,
@@ -2870,23 +3163,63 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                                   ? null
                                   : _promptAddModel,
                             ),
-                            const SizedBox(width: 8),
-                            _buildModelActionButton(
-                              svg: _kArrowBigDownSvg,
-                              onPressed: _isFetchingModels
-                                  ? null
-                                  : _fetchModelsLocalized,
-                              highlighted: true,
-                              loading: _isFetchingModels,
-                            ),
                             const SizedBox(width: 4),
-                            _buildModelGroupToggleButton(modelGroups),
+                            Tooltip(
+                              message:
+                                  _areAllProviderGroupsCollapsed(
+                                    addedModelGroups,
+                                  )
+                                  ? _headerText('展开全部分组', 'Expand all groups')
+                                  : _headerText(
+                                      '折叠全部分组',
+                                      'Collapse all groups',
+                                    ),
+                              child: GestureDetector(
+                                onTap: addedModelGroups.isEmpty
+                                    ? null
+                                    : () => _toggleAllProviderGroups(
+                                        addedModelGroups,
+                                      ),
+                                behavior: HitTestBehavior.opaque,
+                                child: AnimatedOpacity(
+                                  duration: const Duration(milliseconds: 180),
+                                  opacity: addedModelGroups.isEmpty ? 0.36 : 1,
+                                  child: SizedBox(
+                                    width: 48,
+                                    height: 44,
+                                    child: Center(
+                                      child: SvgPicture.asset(
+                                        _hasAnyExpandedProviderGroups(
+                                              addedModelGroups,
+                                            )
+                                            ? _kGroupToggleOpenIconAsset
+                                            : _kGroupToggleClosedIconAsset,
+                                        width: 20,
+                                        height: 20,
+                                        colorFilter: ColorFilter.mode(
+                                          _hasAnyExpandedProviderGroups(
+                                                addedModelGroups,
+                                              )
+                                              ? context
+                                                    .omniPalette
+                                                    .accentPrimary
+                                              : context
+                                                    .omniPalette
+                                                    .textSecondary,
+                                          BlendMode.srcIn,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
                           ],
                         ),
                         const SizedBox(height: 12),
                         SizedBox(
-                          height: 280,
-                          child: modelItems.isEmpty
+                          height: 220,
+                          child: _chatAddedModels.isEmpty
                               ? Padding(
                                   padding: const EdgeInsets.all(10),
                                   child: Center(
@@ -2904,7 +3237,10 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                                         ),
                                         const SizedBox(height: 10),
                                         Text(
-                                          context.l10n.modelAddPrompt,
+                                          _headerText(
+                                            '暂无已添加模型，请先从完整模型列表添加',
+                                            'No added models yet. Add from the full model list below.',
+                                          ),
                                           style: TextStyle(
                                             color: _secondaryTextColor,
                                             fontSize: 14,
@@ -2923,12 +3259,250 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                                     2,
                                     8,
                                   ),
-                                  itemCount: modelGroups.length,
+                                  itemCount: addedModelGroups.length,
                                   itemBuilder: (context, index) {
-                                    final group = modelGroups[index];
-                                    return _buildModelGroupSection(
-                                      group,
-                                      isLast: index == modelGroups.length - 1,
+                                    final group = addedModelGroups[index];
+                                    final expanded = _isModelGroupExpanded(
+                                      group.key,
+                                    );
+                                    return Padding(
+                                      padding: EdgeInsets.only(
+                                        bottom:
+                                            index == addedModelGroups.length - 1
+                                            ? 0
+                                            : 12,
+                                      ),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
+                                        children: [
+                                          _buildModelGroupHeader(
+                                            group.key,
+                                            group.value.length,
+                                            expanded: expanded,
+                                            onTap: () =>
+                                                _toggleModelGroup(group.key),
+                                          ),
+                                          if (expanded)
+                                            ...group.value.map(
+                                              (model) => _buildProviderModelRow(
+                                                model: model,
+                                                added: true,
+                                                actionLabel: _headerText(
+                                                  '移除',
+                                                  'Remove',
+                                                ),
+                                                onAction: () =>
+                                                    _removeModelFromChatWhitelist(
+                                                      model,
+                                                    ),
+                                                removable: true,
+                                              ),
+                                            ),
+                                        ],
+                                      ),
+                                    );
+                                  },
+                                ),
+                        ),
+                        const SizedBox(height: 18),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _headerText(
+                                  '完整模型列表 ${_remoteModels.length} 个',
+                                  '${_remoteModels.length} full models',
+                                ),
+                                style: TextStyle(
+                                  color: _secondaryTextColor,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                  fontFamily: 'PingFang SC',
+                                ),
+                              ),
+                            ),
+                            _buildModelActionButton(
+                              svg: _kArrowBigDownSvg,
+                              onPressed: _isFetchingModels
+                                  ? null
+                                  : _fetchModelsLocalized,
+                              highlighted: true,
+                              loading: _isFetchingModels,
+                            ),
+                            const SizedBox(width: 4),
+                            Tooltip(
+                              message:
+                                  _areAllProviderGroupsCollapsed(
+                                    remoteModelGroups,
+                                  )
+                                  ? _headerText('展开全部分组', 'Expand all groups')
+                                  : _headerText(
+                                      '折叠全部分组',
+                                      'Collapse all groups',
+                                    ),
+                              child: GestureDetector(
+                                onTap: remoteModelGroups.isEmpty
+                                    ? null
+                                    : () => _toggleAllProviderGroups(
+                                        remoteModelGroups,
+                                      ),
+                                behavior: HitTestBehavior.opaque,
+                                child: AnimatedOpacity(
+                                  duration: const Duration(milliseconds: 180),
+                                  opacity: remoteModelGroups.isEmpty ? 0.36 : 1,
+                                  child: SizedBox(
+                                    width: 48,
+                                    height: 44,
+                                    child: Center(
+                                      child: SvgPicture.asset(
+                                        _hasAnyExpandedProviderGroups(
+                                              remoteModelGroups,
+                                            )
+                                            ? _kGroupToggleOpenIconAsset
+                                            : _kGroupToggleClosedIconAsset,
+                                        width: 20,
+                                        height: 20,
+                                        colorFilter: ColorFilter.mode(
+                                          _hasAnyExpandedProviderGroups(
+                                                remoteModelGroups,
+                                              )
+                                              ? context
+                                                    .omniPalette
+                                                    .accentPrimary
+                                              : context
+                                                    .omniPalette
+                                                    .textSecondary,
+                                          BlendMode.srcIn,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          _headerText(
+                            '从当前 Provider 拉取，仅用于挑选加入聊天页',
+                            'Fetched from the current provider and used only for choosing models for chat.',
+                          ),
+                          style: TextStyle(
+                            color: _tertiaryTextColor,
+                            fontSize: 12,
+                            fontFamily: 'PingFang SC',
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        TextField(
+                          key: const Key('provider-remote-model-search'),
+                          controller: _remoteModelSearchController,
+                          style: context.omniInputTextStyle,
+                          decoration: _buildInputDecoration(
+                            label: _headerText('搜索模型 ID', 'Search model ID'),
+                            hint: 'gpt-4o',
+                            suffixIcon:
+                                _remoteModelSearchController.text.trim().isEmpty
+                                ? null
+                                : IconButton(
+                                    splashRadius: 18,
+                                    onPressed: () {
+                                      _remoteModelSearchController.clear();
+                                    },
+                                    icon: Icon(
+                                      Icons.close_rounded,
+                                      color: _tertiaryTextColor,
+                                      size: 18,
+                                    ),
+                                  ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        SizedBox(
+                          height: 320,
+                          child: filteredRemoteModels.isEmpty
+                              ? Padding(
+                                  padding: const EdgeInsets.all(10),
+                                  child: Center(
+                                    child: Text(
+                                      _remoteModels.isEmpty
+                                          ? _headerText(
+                                              '暂无完整模型，请先获取模型列表',
+                                              'No full models yet. Fetch the model list first.',
+                                            )
+                                          : _headerText(
+                                              '没有匹配的模型',
+                                              'No matching models',
+                                            ),
+                                      style: TextStyle(
+                                        color: _secondaryTextColor,
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.w600,
+                                        fontFamily: 'PingFang SC',
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                )
+                              : ListView.builder(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    2,
+                                    2,
+                                    2,
+                                    8,
+                                  ),
+                                  itemCount: remoteModelGroups.length,
+                                  itemBuilder: (context, index) {
+                                    final group = remoteModelGroups[index];
+                                    final expanded = _isModelGroupExpanded(
+                                      group.key,
+                                    );
+                                    return Padding(
+                                      padding: EdgeInsets.only(
+                                        bottom:
+                                            index ==
+                                                remoteModelGroups.length - 1
+                                            ? 0
+                                            : 12,
+                                      ),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
+                                        children: [
+                                          _buildModelGroupHeader(
+                                            group.key,
+                                            group.value.length,
+                                            expanded: expanded,
+                                            onTap: () =>
+                                                _toggleModelGroup(group.key),
+                                          ),
+                                          if (expanded)
+                                            ...group.value.map((model) {
+                                              final added = _manualModelIds
+                                                  .contains(model.id);
+                                              return _buildProviderModelRow(
+                                                model: model,
+                                                added: added,
+                                                actionLabel: added
+                                                    ? _headerText(
+                                                        '已添加',
+                                                        'Added',
+                                                      )
+                                                    : _headerText('添加', 'Add'),
+                                                actionDisabled: added,
+                                                actionFilled: !added,
+                                                onAction: added
+                                                    ? null
+                                                    : () =>
+                                                          _addModelToChatWhitelist(
+                                                            model,
+                                                          ),
+                                              );
+                                            }),
+                                        ],
+                                      ),
                                     );
                                   },
                                 ),

--- a/ui/lib/services/model_provider_config_service.dart
+++ b/ui/lib/services/model_provider_config_service.dart
@@ -772,11 +772,63 @@ class ModelProviderConfigService {
     );
   }
 
+  static Future<List<ProviderModelOption>> getChatModelOptionsForProfile(
+    String profileId, {
+    ModelProviderProfileSummary? profile,
+  }) async {
+    final normalizedProfileId = _canonicalProfileId(profileId);
+    final resolvedProfile = profile ?? await _findProfileById(profileId);
+    final manualModelIds = await getManualModelIds(
+      profileId: normalizedProfileId,
+    );
+    List<ProviderModelOption> remoteModels;
+    if (_isBuiltinLocalProfileId(normalizedProfileId)) {
+      try {
+        remoteModels = await fetchModels(
+          profileId: normalizedProfileId,
+          providerName: resolvedProfile?.name ?? '',
+        );
+      } catch (_) {
+        remoteModels = await getCachedFetchedModels(
+          profileId: normalizedProfileId,
+        );
+      }
+    } else {
+      remoteModels = await getCachedFetchedModels(
+        profileId: normalizedProfileId,
+        apiBase: resolvedProfile?.baseUrl ?? '',
+      );
+    }
+    final chatModels = buildChatModelOptions(
+      remoteModels: remoteModels,
+      manualModelIds: manualModelIds,
+    );
+    return enrichModelsForProfile(
+      profileId: normalizedProfileId,
+      providerName: resolvedProfile?.name ?? '',
+      apiBase: resolvedProfile?.baseUrl ?? '',
+      models: chatModels,
+    );
+  }
+
   static Future<List<ProviderModelGroup>> loadModelGroups() async {
     final payload = await listProfiles();
     final groups = <ProviderModelGroup>[];
     for (final profile in payload.profiles) {
       final models = await getStoredModelOptionsForProfile(
+        profile.id,
+        profile: profile,
+      );
+      groups.add(ProviderModelGroup(profile: profile, models: models));
+    }
+    return groups;
+  }
+
+  static Future<List<ProviderModelGroup>> loadChatModelGroups() async {
+    final payload = await listProfiles();
+    final groups = <ProviderModelGroup>[];
+    for (final profile in payload.profiles) {
+      final models = await getChatModelOptionsForProfile(
         profile.id,
         profile: profile,
       );
@@ -810,6 +862,34 @@ class ModelProviderConfigService {
       }
     }
     return merged;
+  }
+
+  static List<ProviderModelOption> buildChatModelOptions({
+    required List<ProviderModelOption> remoteModels,
+    required List<String> manualModelIds,
+  }) {
+    if (manualModelIds.isEmpty) {
+      return const <ProviderModelOption>[];
+    }
+    final remoteById = <String, ProviderModelOption>{
+      for (final item in remoteModels) item.id: item,
+    };
+    final selected = <ProviderModelOption>[];
+    final seen = <String>{};
+    for (final modelId in _normalizeModelIds(manualModelIds)) {
+      if (!seen.add(modelId)) {
+        continue;
+      }
+      selected.add(
+        remoteById[modelId] ??
+            ProviderModelOption(
+              id: modelId,
+              displayName: modelId,
+              ownedBy: 'manual',
+            ),
+      );
+    }
+    return selected;
   }
 
   static String defaultModelGroupName(

--- a/ui/test/features/home/pages/vlm_model_setting/vlm_model_setting_page_test.dart
+++ b/ui/test/features/home/pages/vlm_model_setting/vlm_model_setting_page_test.dart
@@ -538,7 +538,7 @@ void main() {
 
     expect(find.byKey(const Key('provider-logo')), findsNothing);
     expect(
-      find.byKey(const ValueKey('provider-model-group-toggle-button')),
+      find.byKey(const Key('provider-remote-model-search')),
       findsOneWidget,
     );
     expect(
@@ -582,8 +582,12 @@ void main() {
       findsOneWidget,
     );
 
-    final groupBody = find.byKey(const Key('provider-model-group-body-openai'));
-    expect(tester.getSize(groupBody).height, greaterThan(0));
+    final firstModel = find.byKey(const Key('provider-model-context-gpt-4o'));
+    final secondModel = find.byKey(
+      const Key('provider-model-context-gpt-4o-mini'),
+    );
+    expect(firstModel, findsOneWidget);
+    expect(secondModel, findsOneWidget);
     final shortLine = tester.getSize(
       find.byKey(const Key('provider-model-group-line-openai')),
     );
@@ -612,55 +616,23 @@ void main() {
     );
     expect(shortLineLeft.dx - shortCountRight.dx, closeTo(10, 0.5));
     expect(shortIconLeft.dx - shortLineRight.dx, closeTo(6, 0.5));
-    final firstModel = find.byKey(
-      const ValueKey<String>('provider-model-gpt-4o'),
-    );
-    final secondModel = find.byKey(
-      const ValueKey<String>('provider-model-gpt-4o-mini'),
-    );
-    expect(tester.getSize(firstModel).height, 44);
-    expect(tester.getSize(secondModel).height, 44);
-    expect(tester.getSize(firstModel).width, tester.getSize(secondModel).width);
-
-    await tester.tap(
-      find.byKey(const ValueKey('provider-model-group-toggle-button')),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, 0);
-    expect(
-      tester
-          .getSize(find.byKey(const Key('provider-model-group-body-anthropic')))
-          .height,
-      0,
-    );
-
-    await tester.tap(
-      find.byKey(const ValueKey('provider-model-group-toggle-button')),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, greaterThan(0));
-
-    await tester.scrollUntilVisible(
+    await tester.ensureVisible(
       find.byKey(const Key('provider-model-group-openai')),
-      120,
-      scrollable: find.byType(Scrollable).first,
     );
+    await tester.pump();
     await tester.tap(find.byKey(const Key('provider-model-group-openai')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, 0);
+    expect(firstModel, findsNothing);
 
-    await tester.scrollUntilVisible(
+    await tester.ensureVisible(
       find.byKey(const Key('provider-model-group-openai')),
-      120,
-      scrollable: find.byType(Scrollable).first,
     );
+    await tester.pump();
     await tester.tap(find.byKey(const Key('provider-model-group-openai')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, greaterThan(0));
+    expect(firstModel, findsOneWidget);
 
     expect(tester.takeException(), isNull);
   });

--- a/ui/test/services/model_provider_config_service_test.dart
+++ b/ui/test/services/model_provider_config_service_test.dart
@@ -279,4 +279,35 @@ void main() {
       expect(enriched.single.toolCall, isTrue);
     },
   );
+
+  test(
+    'buildChatModelOptions keeps only manual ids and reuses remote metadata',
+    () {
+      final models = ModelProviderConfigService.buildChatModelOptions(
+        remoteModels: const [
+          ProviderModelOption(
+            id: 'gpt-4o-mini',
+            displayName: 'GPT-4o Mini',
+            ownedBy: 'openai',
+            contextLimit: 128000,
+          ),
+          ProviderModelOption(
+            id: 'gpt-4.1',
+            displayName: 'GPT-4.1',
+            ownedBy: 'openai',
+          ),
+        ],
+        manualModelIds: const ['gpt-4o-mini', 'custom-model', 'gpt-4o-mini'],
+      );
+
+      expect(models.map((item) => item.id).toList(), [
+        'gpt-4o-mini',
+        'custom-model',
+      ]);
+      expect(models.first.displayName, 'GPT-4o Mini');
+      expect(models.first.contextLimit, 128000);
+      expect(models.last.displayName, 'custom-model');
+      expect(models.last.ownedBy, 'manual');
+    },
+  );
 }


### PR DESCRIPTION
## 变更摘要

本次改动把聊天页（Agent / Chat）的模型选择器，从直接展示 Provider 全量模型，调整为只展示“已添加到聊天页”的模型白名单。  完整模型的拉取、搜索、添加、移除统一收口到模型提供商页，同时继续兜底展示当前会话正在生效的模型，避免当前模型在 selector 中消失。

## 变更类型

- [x] 新功能

## 关联 Issue

## 主要改动

1. 聊天页模型 selector 改为读取聊天白名单，不再直接展示 Provider 全量模型。
2. 聊天页 selector 新增轻量“管理模型”入口跳转到现有模型提供商页。
3. 模型提供商页的模型区域拆成“已添加到聊天页”和“完整模型列表”两层；

## UI 变更（如有）

有。

<img width="864" height="1920" alt="70e062770f17df0657d0c6fa47147352" src="https://github.com/user-attachments/assets/aeca7fcc-84da-4d3f-a74d-c2e77ce5a7d1" />

<img width="864" height="1920" alt="70e062770f17df0657d0c6fa47147352" src="https://github.com/user-attachments/assets/b1699858-7d6d-4ff3-95f4-71a9cdcf43bf" />



