### PR TITLE
Feat/new diy selected models

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -1168,14 +1168,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   }
 
   bool get _hasSelectableNormalChatModels {
-    return _modelProviderProfiles.any((profile) {
-      if (!profile.configured) {
-        return false;
-      }
-      final models =
-          _modelOptionsByProfileId[profile.id] ?? const <ProviderModelOption>[];
-      return models.isNotEmpty;
-    });
+    return _modelProviderProfiles.any((profile) => profile.configured);
   }
 
   _ChatModelOverrideSelection? get _activeDispatchSceneSelection {

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -5,7 +5,7 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
   Future<void> _loadNormalChatModelContext() async {
     try {
       final results = await Future.wait<dynamic>([
-        ModelProviderConfigService.loadModelGroups(),
+        ModelProviderConfigService.loadChatModelGroups(),
         SceneModelConfigService.getSceneCatalog(),
       ]);
       if (!mounted) return;
@@ -1396,6 +1396,116 @@ class _ConversationModelSelectorContentState
     );
   }
 
+  Widget _buildSelectorHeader() {
+    final palette = context.omniPalette;
+    final isDark = context.isDarkTheme;
+    final onManage = widget.onManage;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _buildSearchRow(),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: onManage == null
+                  ? null
+                  : () {
+                      unawaited(Future<void>.value(onManage()));
+                    },
+              style: TextButton.styleFrom(
+                minimumSize: Size.zero,
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                foregroundColor: isDark
+                    ? palette.accentPrimary
+                    : const Color(0xFF2C7FEB),
+              ),
+              icon: const Icon(Icons.tune_rounded, size: 15),
+              label: Text(
+                LegacyTextLocalizer.localize('管理模型'),
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSelectorEmptyState(
+    String title, {
+    String? subtitle,
+    bool showManageAction = false,
+    bool compact = false,
+  }) {
+    final palette = context.omniPalette;
+    final isDark = context.isDarkTheme;
+    final onManage = widget.onManage;
+    return Padding(
+      padding: compact
+          ? const EdgeInsets.fromLTRB(12, 6, 12, 10)
+          : const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            LegacyTextLocalizer.localize(title),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 12,
+              color: isDark ? palette.textTertiary : const Color(0xFF94A3B8),
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              LegacyTextLocalizer.localize(subtitle),
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                color: isDark
+                    ? palette.textTertiary.withValues(alpha: 0.86)
+                    : const Color(0xFF9AA4B6),
+              ),
+            ),
+          ],
+          if (showManageAction && onManage != null) ...[
+            const SizedBox(height: 10),
+            TextButton(
+              onPressed: () {
+                unawaited(Future<void>.value(onManage()));
+              },
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                foregroundColor: isDark
+                    ? palette.accentPrimary
+                    : const Color(0xFF2C7FEB),
+              ),
+              child: Text(
+                LegacyTextLocalizer.localize('去管理模型'),
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   Widget _buildProfileHeader(ModelProviderProfileSummary profile) {
     final expanded = _isExpanded(profile.id);
     final models = _filteredModels(profile.id);
@@ -1644,18 +1754,7 @@ class _ConversationModelSelectorContentState
   Widget _buildBackendGroupedModels(ModelProviderProfileSummary profile) {
     final groups = _groupByBackend(profile.id);
     if (groups.isEmpty) {
-      return Padding(
-        padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
-        child: Text(
-          LegacyTextLocalizer.localize('该 Provider 暂无可选模型'),
-          style: TextStyle(
-            fontSize: 12,
-            color: context.isDarkTheme
-                ? context.omniPalette.textTertiary
-                : const Color(0xFF94A3B8),
-          ),
-        ),
-      );
+      return _buildSelectorEmptyState('该 Provider 暂无可选模型', compact: true);
     }
     final sortedKeys = _sortedBackendKeys(groups.keys);
     return Column(
@@ -1696,36 +1795,18 @@ class _ConversationModelSelectorContentState
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                _buildSearchRow(),
+                _buildSelectorHeader(),
                 if (configuredProfiles.isEmpty)
-                  Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Text(
-                      LegacyTextLocalizer.localize('请先在模型提供商页配置 Provider'),
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: context.isDarkTheme
-                            ? palette.textTertiary
-                            : const Color(0xFF94A3B8),
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
+                  _buildSelectorEmptyState(
+                    '请先在模型提供商页配置 Provider',
+                    subtitle: '并把需要的模型添加到聊天页',
+                    showManageAction: true,
                   )
                 else if (visibleProfiles.isEmpty)
-                  Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Text(
-                      LegacyTextLocalizer.localize('没有匹配的模型'),
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: context.isDarkTheme
-                            ? palette.textTertiary
-                            : const Color(0xFF94A3B8),
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
+                  _buildSelectorEmptyState(
+                    '没有匹配的模型',
+                    subtitle: '可前往模型提供商页管理聊天页模型',
+                    showManageAction: true,
                   )
                 else
                   Flexible(
@@ -1747,19 +1828,9 @@ class _ConversationModelSelectorContentState
                                 if (_needsBackendGrouping(profile.id))
                                   _buildBackendGroupedModels(profile)
                                 else if (models.isEmpty)
-                                  Padding(
-                                    padding: EdgeInsets.fromLTRB(12, 4, 12, 8),
-                                    child: Text(
-                                      LegacyTextLocalizer.localize(
-                                        '该 Provider 暂无可选模型',
-                                      ),
-                                      style: TextStyle(
-                                        fontSize: 12,
-                                        color: context.isDarkTheme
-                                            ? palette.textTertiary
-                                            : const Color(0xFF94A3B8),
-                                      ),
-                                    ),
+                                  _buildSelectorEmptyState(
+                                    '该 Provider 暂无可选模型',
+                                    compact: true,
                                   )
                                 else
                                   Column(

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -492,6 +492,13 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
           handle.keepOpenOnNextKeyboardHide();
           FocusManager.instance.primaryFocus?.unfocus();
         },
+        onManage: () async {
+          await handle.dismiss(null);
+          if (!mounted) {
+            return;
+          }
+          GoRouterManager.push('/home/vlm_model_setting');
+        },
         // dismiss 内部会立刻 complete future,让下面 await 的逻辑并行起跑;
         // 收起动画在后台跑完,UI 更响应。
         onSelect: (selection) => unawaited(handle.dismiss(selection)),
@@ -1087,6 +1094,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
     required this.currentSelection,
     this.onSearchSubmitted,
     this.onSelect,
+    this.onManage,
   });
 
   final double width;
@@ -1099,6 +1107,7 @@ class _ConversationModelSelectorContent extends StatefulWidget {
   /// 非空时由调用方决定怎么消费选择(例如关闭外层 [OverlayEntry] + 触发后续逻辑)；
   /// 为空时回退到 [Navigator.of(context).pop(selection)],兼容老的 route 调用方。
   final ValueChanged<_ChatModelOverrideSelection>? onSelect;
+  final Future<void> Function()? onManage;
 
   @override
   State<_ConversationModelSelectorContent> createState() =>

--- a/ui/lib/features/home/pages/vlm_model_setting/vlm_model_setting_page.dart
+++ b/ui/lib/features/home/pages/vlm_model_setting/vlm_model_setting_page.dart
@@ -198,6 +198,8 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _baseUrlController = TextEditingController();
   final TextEditingController _apiKeyController = TextEditingController();
+  final TextEditingController _remoteModelSearchController =
+      TextEditingController();
   final FocusNode _nameFocusNode = FocusNode();
   final FocusNode _baseUrlFocusNode = FocusNode();
   final FocusNode _apiKeyFocusNode = FocusNode();
@@ -397,6 +399,51 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     return entries;
   }
 
+  List<ProviderModelOption> get _chatAddedModels => _manualModels;
+
+  List<ProviderModelOption> get _filteredRemoteModels {
+    final query = _remoteModelSearchController.text.trim().toLowerCase();
+    if (query.isEmpty) {
+      return _remoteModels;
+    }
+    return _remoteModels.where((model) {
+      final modelId = model.id.toLowerCase();
+      final displayName = model.displayName.toLowerCase();
+      return modelId.contains(query) || displayName.contains(query);
+    }).toList();
+  }
+
+  List<MapEntry<String, List<ProviderModelOption>>> _groupProviderModels(
+    List<ProviderModelOption> models,
+  ) {
+    final groups = <String, List<ProviderModelOption>>{};
+    final current = _currentProfile;
+    for (final model in models) {
+      final groupKey = ModelVendorCatalog.groupKeyFor(
+        model.id,
+        ownedBy: model.ownedBy,
+        providerId: model.modelsDevProviderId ?? current?.id,
+        providerName: current?.name,
+      );
+      groups.putIfAbsent(groupKey, () => <ProviderModelOption>[]).add(model);
+    }
+    final entries = groups.entries.toList()
+      ..sort((a, b) {
+        final orderCompare = ModelVendorCatalog.orderOf(
+          a.key,
+        ).compareTo(ModelVendorCatalog.orderOf(b.key));
+        if (orderCompare != 0) return orderCompare;
+        return a.key.compareTo(b.key);
+      });
+    return entries;
+  }
+
+  List<MapEntry<String, List<ProviderModelOption>>> get _addedModelGroups =>
+      _groupProviderModels(_chatAddedModels);
+
+  List<MapEntry<String, List<ProviderModelOption>>> get _remoteModelGroups =>
+      _groupProviderModels(_filteredRemoteModels);
+
   String _modelGroupExpansionKey(String groupName) {
     final profileKey = _editingProfileId.trim().isEmpty
         ? 'default'
@@ -462,6 +509,7 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     _nameController.addListener(_onProfileChanged);
     _baseUrlController.addListener(_onProfileChanged);
     _apiKeyController.addListener(_onProfileChanged);
+    _remoteModelSearchController.addListener(_handleRemoteModelSearchChanged);
     _nameFocusNode.addListener(_onProfileFieldFocusChanged);
     _baseUrlFocusNode.addListener(_onProfileFieldFocusChanged);
     _apiKeyFocusNode.addListener(_onProfileFieldFocusChanged);
@@ -481,9 +529,13 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     _nameController.removeListener(_onProfileChanged);
     _baseUrlController.removeListener(_onProfileChanged);
     _apiKeyController.removeListener(_onProfileChanged);
+    _remoteModelSearchController.removeListener(
+      _handleRemoteModelSearchChanged,
+    );
     _nameController.dispose();
     _baseUrlController.dispose();
     _apiKeyController.dispose();
+    _remoteModelSearchController.dispose();
     _nameFocusNode.dispose();
     _baseUrlFocusNode.dispose();
     _apiKeyFocusNode.dispose();
@@ -491,6 +543,13 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
       entry.dispose();
     }
     super.dispose();
+  }
+
+  void _handleRemoteModelSearchChanged() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
   }
 
   void _onProfileChanged() {
@@ -577,6 +636,31 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     } catch (_) {
       // no-op
     }
+  }
+
+  bool _hasAnyExpandedProviderGroups<T>(
+    List<MapEntry<String, List<T>>> groups,
+  ) {
+    return groups.any((group) => _isModelGroupExpanded(group.key));
+  }
+
+  bool _areAllProviderGroupsCollapsed<T>(
+    List<MapEntry<String, List<T>>> groups,
+  ) {
+    return groups.isNotEmpty &&
+        groups.every((group) => !_isModelGroupExpanded(group.key));
+  }
+
+  void _toggleAllProviderGroups<T>(List<MapEntry<String, List<T>>> groups) {
+    if (groups.isEmpty) {
+      return;
+    }
+    final shouldExpand = _areAllProviderGroupsCollapsed(groups);
+    setState(() {
+      for (final group in groups) {
+        _expandedModelGroups[_modelGroupExpansionKey(group.key)] = shouldExpand;
+      }
+    });
   }
 
   Future<void> _persistProfileDraft() async {
@@ -1192,8 +1276,7 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     }
 
     final existsInManual = _manualModelIds.any((item) => item == normalized);
-    final existsInRemote = _remoteModels.any((item) => item.id == normalized);
-    if (existsInManual || existsInRemote) {
+    if (existsInManual) {
       showToast(context.l10n.modelAlreadyExists, type: ToastType.warning);
       return;
     }
@@ -1217,53 +1300,97 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     showToast(context.l10n.modelAdded, type: ToastType.success);
   }
 
-  Future<void> _deleteModel(_ProviderModelItem item) async {
+  Future<void> _addModelToChatWhitelist(ProviderModelOption model) async {
     final current = _currentProfile;
-    if (current == null || _deletingModelIds.contains(item.id)) {
+    if (current == null || _manualModelIds.contains(model.id)) {
+      return;
+    }
+    final nextManual = [..._manualModelIds, model.id];
+    final nextManualModels = await _loadManualModelsForProfile(
+      current,
+      nextManual,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _manualModelIds = nextManual;
+      _manualModels = nextManualModels;
+    });
+    try {
+      await ModelProviderConfigService.saveManualModelIds(
+        profileId: current.id,
+        ids: nextManual,
+      );
+      if (!mounted) {
+        return;
+      }
+      showToast(context.l10n.modelAdded, type: ToastType.success);
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      final fallbackManualModels = await _loadManualModelsForProfile(
+        current,
+        _manualModelIds.where((id) => id != model.id).toList(),
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _manualModelIds = _manualModelIds
+            .where((id) => id != model.id)
+            .toList();
+        _manualModels = fallbackManualModels;
+      });
+      showToast(_headerText('添加失败', 'Failed to add'), type: ToastType.error);
+    }
+  }
+
+  Future<void> _removeModelFromChatWhitelist(ProviderModelOption model) async {
+    final current = _currentProfile;
+    if (current == null || _deletingModelIds.contains(model.id)) {
       return;
     }
 
     final prevManual = List<String>.from(_manualModelIds);
     final prevManualModels = List<ProviderModelOption>.from(_manualModels);
-    final prevRemote = List<ProviderModelOption>.from(_remoteModels);
 
     setState(() {
-      _deletingModelIds = {..._deletingModelIds, item.id};
-      _manualModelIds = _manualModelIds.where((id) => id != item.id).toList();
-      _manualModels = _manualModels.where((m) => m.id != item.id).toList();
-      _remoteModels = _remoteModels.where((m) => m.id != item.id).toList();
+      _deletingModelIds = {..._deletingModelIds, model.id};
+      _manualModelIds = _manualModelIds.where((id) => id != model.id).toList();
+      _manualModels = _manualModels.where((m) => m.id != model.id).toList();
     });
 
     try {
-      await Future.wait([
-        ModelProviderConfigService.saveManualModelIds(
-          profileId: current.id,
-          ids: _manualModelIds,
-        ),
-        ModelProviderConfigService.saveCachedFetchedModels(
-          profileId: current.id,
-          apiBase: _baseUrlController.text.trim(),
-          models: _remoteModels,
-        ),
-      ]);
+      await ModelProviderConfigService.saveManualModelIds(
+        profileId: current.id,
+        ids: _manualModelIds,
+      );
 
       if (!mounted) return;
-      showToast(context.l10n.modelDeleted, type: ToastType.success);
+      showToast(
+        _headerText('已从聊天页移除', 'Removed from chat'),
+        type: ToastType.success,
+      );
     } catch (_) {
       if (!mounted) return;
       setState(() {
         _manualModelIds = prevManual;
         _manualModels = prevManualModels;
-        _remoteModels = prevRemote;
       });
-      showToast(context.l10n.modelDeleteFailed, type: ToastType.error);
+      showToast(_headerText('移除失败', 'Failed to remove'), type: ToastType.error);
     } finally {
       if (mounted) {
         setState(() {
-          _deletingModelIds = {..._deletingModelIds}..remove(item.id);
+          _deletingModelIds = {..._deletingModelIds}..remove(model.id);
         });
       }
     }
+  }
+
+  Future<void> _deleteModel(_ProviderModelItem item) async {
+    await _removeModelFromChatWhitelist(item.model);
   }
 
   Future<void> _selectProviderType(String value) async {
@@ -2414,6 +2541,168 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
     );
   }
 
+  Widget _buildProviderModelRow({
+    required ProviderModelOption model,
+    required bool added,
+    required VoidCallback? onAction,
+    required String actionLabel,
+    bool actionFilled = false,
+    bool actionDisabled = false,
+    bool removable = false,
+  }) {
+    final isBusy = _deletingModelIds.contains(model.id);
+    final metadataWidgets = _buildModelMetadataWidgets(model);
+    final accentColor = _isDarkTheme
+        ? context.omniPalette.accentPrimary
+        : const Color(0xFF2C7FEB);
+
+    Widget row = Material(
+      color: Colors.transparent,
+      child: SizedBox(
+        width: double.infinity,
+        height: 44,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Text(
+                  model.id,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: _primaryTextColor,
+                    fontFamily: 'PingFang SC',
+                    height: 1.2,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 10),
+              SizedBox(
+                width: 120,
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const BouncingScrollPhysics(),
+                  reverse: true,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (
+                        var index = 0;
+                        index < metadataWidgets.length;
+                        index++
+                      ) ...[
+                        if (index > 0) const SizedBox(width: 6),
+                        metadataWidgets[index],
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              TextButton(
+                onPressed: (actionDisabled || isBusy) ? null : onAction,
+                style: TextButton.styleFrom(
+                  minimumSize: const Size(68, 30),
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  foregroundColor: actionFilled ? Colors.white : accentColor,
+                  backgroundColor: actionFilled
+                      ? accentColor
+                      : Colors.transparent,
+                  disabledForegroundColor: _tertiaryTextColor,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(999),
+                    side: BorderSide(
+                      color: actionFilled
+                          ? accentColor
+                          : (_isDarkTheme
+                                ? context.omniPalette.borderSubtle
+                                : const Color(0x1F000000)),
+                    ),
+                  ),
+                  textStyle: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'PingFang SC',
+                  ),
+                ),
+                child: isBusy
+                    ? const SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(actionLabel),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    if (!removable) {
+      return row;
+    }
+
+    return IgnorePointer(
+      ignoring: isBusy,
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 180),
+        opacity: isBusy ? 0.72 : 1,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final initialActionWidth =
+                constraints.maxWidth * _modelDeleteExtentRatio;
+            final deleteIconRightPadding =
+                ((initialActionWidth - _modelDeleteIconSize) / 2)
+                    .clamp(0.0, double.infinity)
+                    .toDouble();
+            return Slidable(
+              key: ValueKey<String>('provider-model-added-${model.id}'),
+              groupTag: 'provider-added-model-items',
+              closeOnScroll: true,
+              endActionPane: ActionPane(
+                motion: const BehindMotion(),
+                extentRatio: _modelDeleteExtentRatio,
+                dismissible: DismissiblePane(
+                  dismissThreshold: 0.4,
+                  closeOnCancel: true,
+                  motion: const InversedDrawerMotion(),
+                  onDismissed: () => _removeModelFromChatWhitelist(model),
+                ),
+                children: [
+                  CustomSlidableAction(
+                    onPressed: (_) => _removeModelFromChatWhitelist(model),
+                    backgroundColor: AppColors.alertRed,
+                    borderRadius: _modelDeleteActionRadius,
+                    padding: EdgeInsets.zero,
+                    alignment: Alignment.centerRight,
+                    child: Padding(
+                      padding: EdgeInsets.only(right: deleteIconRightPadding),
+                      child: SvgPicture.asset(
+                        'assets/memory/memory_delete.svg',
+                        width: _modelDeleteIconSize,
+                        height: _modelDeleteIconSize,
+                        colorFilter: const ColorFilter.mode(
+                          Colors.white,
+                          BlendMode.srcIn,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              child: row,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   Future<void> _openProviderSwitchMenu(BuildContext anchorContext) async {
     if (_profiles.isEmpty) {
       return;
@@ -2662,8 +2951,9 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final modelItems = _modelItems;
-    final modelGroups = _modelGroups;
+    final addedModelGroups = _addedModelGroups;
+    final remoteModelGroups = _remoteModelGroups;
+    final filteredRemoteModels = _filteredRemoteModels;
 
     return Scaffold(
       backgroundColor: _pageBackground,
@@ -2855,7 +3145,10 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                           children: [
                             Expanded(
                               child: Text(
-                                context.l10n.modelListCount(modelItems.length),
+                                _headerText(
+                                  '已添加到聊天页 ${_chatAddedModels.length} 个',
+                                  '${_chatAddedModels.length} added to chat',
+                                ),
                                 style: TextStyle(
                                   color: _secondaryTextColor,
                                   fontSize: 12,
@@ -2870,23 +3163,63 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                                   ? null
                                   : _promptAddModel,
                             ),
-                            const SizedBox(width: 8),
-                            _buildModelActionButton(
-                              svg: _kArrowBigDownSvg,
-                              onPressed: _isFetchingModels
-                                  ? null
-                                  : _fetchModelsLocalized,
-                              highlighted: true,
-                              loading: _isFetchingModels,
-                            ),
                             const SizedBox(width: 4),
-                            _buildModelGroupToggleButton(modelGroups),
+                            Tooltip(
+                              message:
+                                  _areAllProviderGroupsCollapsed(
+                                    addedModelGroups,
+                                  )
+                                  ? _headerText('展开全部分组', 'Expand all groups')
+                                  : _headerText(
+                                      '折叠全部分组',
+                                      'Collapse all groups',
+                                    ),
+                              child: GestureDetector(
+                                onTap: addedModelGroups.isEmpty
+                                    ? null
+                                    : () => _toggleAllProviderGroups(
+                                        addedModelGroups,
+                                      ),
+                                behavior: HitTestBehavior.opaque,
+                                child: AnimatedOpacity(
+                                  duration: const Duration(milliseconds: 180),
+                                  opacity: addedModelGroups.isEmpty ? 0.36 : 1,
+                                  child: SizedBox(
+                                    width: 48,
+                                    height: 44,
+                                    child: Center(
+                                      child: SvgPicture.asset(
+                                        _hasAnyExpandedProviderGroups(
+                                              addedModelGroups,
+                                            )
+                                            ? _kGroupToggleOpenIconAsset
+                                            : _kGroupToggleClosedIconAsset,
+                                        width: 20,
+                                        height: 20,
+                                        colorFilter: ColorFilter.mode(
+                                          _hasAnyExpandedProviderGroups(
+                                                addedModelGroups,
+                                              )
+                                              ? context
+                                                    .omniPalette
+                                                    .accentPrimary
+                                              : context
+                                                    .omniPalette
+                                                    .textSecondary,
+                                          BlendMode.srcIn,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
                           ],
                         ),
                         const SizedBox(height: 12),
                         SizedBox(
-                          height: 280,
-                          child: modelItems.isEmpty
+                          height: 220,
+                          child: _chatAddedModels.isEmpty
                               ? Padding(
                                   padding: const EdgeInsets.all(10),
                                   child: Center(
@@ -2904,7 +3237,10 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                                         ),
                                         const SizedBox(height: 10),
                                         Text(
-                                          context.l10n.modelAddPrompt,
+                                          _headerText(
+                                            '暂无已添加模型，请先从完整模型列表添加',
+                                            'No added models yet. Add from the full model list below.',
+                                          ),
                                           style: TextStyle(
                                             color: _secondaryTextColor,
                                             fontSize: 14,
@@ -2923,12 +3259,250 @@ class _VlmModelSettingPageState extends State<VlmModelSettingPage> {
                                     2,
                                     8,
                                   ),
-                                  itemCount: modelGroups.length,
+                                  itemCount: addedModelGroups.length,
                                   itemBuilder: (context, index) {
-                                    final group = modelGroups[index];
-                                    return _buildModelGroupSection(
-                                      group,
-                                      isLast: index == modelGroups.length - 1,
+                                    final group = addedModelGroups[index];
+                                    final expanded = _isModelGroupExpanded(
+                                      group.key,
+                                    );
+                                    return Padding(
+                                      padding: EdgeInsets.only(
+                                        bottom:
+                                            index == addedModelGroups.length - 1
+                                            ? 0
+                                            : 12,
+                                      ),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
+                                        children: [
+                                          _buildModelGroupHeader(
+                                            group.key,
+                                            group.value.length,
+                                            expanded: expanded,
+                                            onTap: () =>
+                                                _toggleModelGroup(group.key),
+                                          ),
+                                          if (expanded)
+                                            ...group.value.map(
+                                              (model) => _buildProviderModelRow(
+                                                model: model,
+                                                added: true,
+                                                actionLabel: _headerText(
+                                                  '移除',
+                                                  'Remove',
+                                                ),
+                                                onAction: () =>
+                                                    _removeModelFromChatWhitelist(
+                                                      model,
+                                                    ),
+                                                removable: true,
+                                              ),
+                                            ),
+                                        ],
+                                      ),
+                                    );
+                                  },
+                                ),
+                        ),
+                        const SizedBox(height: 18),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                _headerText(
+                                  '完整模型列表 ${_remoteModels.length} 个',
+                                  '${_remoteModels.length} full models',
+                                ),
+                                style: TextStyle(
+                                  color: _secondaryTextColor,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                  fontFamily: 'PingFang SC',
+                                ),
+                              ),
+                            ),
+                            _buildModelActionButton(
+                              svg: _kArrowBigDownSvg,
+                              onPressed: _isFetchingModels
+                                  ? null
+                                  : _fetchModelsLocalized,
+                              highlighted: true,
+                              loading: _isFetchingModels,
+                            ),
+                            const SizedBox(width: 4),
+                            Tooltip(
+                              message:
+                                  _areAllProviderGroupsCollapsed(
+                                    remoteModelGroups,
+                                  )
+                                  ? _headerText('展开全部分组', 'Expand all groups')
+                                  : _headerText(
+                                      '折叠全部分组',
+                                      'Collapse all groups',
+                                    ),
+                              child: GestureDetector(
+                                onTap: remoteModelGroups.isEmpty
+                                    ? null
+                                    : () => _toggleAllProviderGroups(
+                                        remoteModelGroups,
+                                      ),
+                                behavior: HitTestBehavior.opaque,
+                                child: AnimatedOpacity(
+                                  duration: const Duration(milliseconds: 180),
+                                  opacity: remoteModelGroups.isEmpty ? 0.36 : 1,
+                                  child: SizedBox(
+                                    width: 48,
+                                    height: 44,
+                                    child: Center(
+                                      child: SvgPicture.asset(
+                                        _hasAnyExpandedProviderGroups(
+                                              remoteModelGroups,
+                                            )
+                                            ? _kGroupToggleOpenIconAsset
+                                            : _kGroupToggleClosedIconAsset,
+                                        width: 20,
+                                        height: 20,
+                                        colorFilter: ColorFilter.mode(
+                                          _hasAnyExpandedProviderGroups(
+                                                remoteModelGroups,
+                                              )
+                                              ? context
+                                                    .omniPalette
+                                                    .accentPrimary
+                                              : context
+                                                    .omniPalette
+                                                    .textSecondary,
+                                          BlendMode.srcIn,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          _headerText(
+                            '从当前 Provider 拉取，仅用于挑选加入聊天页',
+                            'Fetched from the current provider and used only for choosing models for chat.',
+                          ),
+                          style: TextStyle(
+                            color: _tertiaryTextColor,
+                            fontSize: 12,
+                            fontFamily: 'PingFang SC',
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        TextField(
+                          key: const Key('provider-remote-model-search'),
+                          controller: _remoteModelSearchController,
+                          style: context.omniInputTextStyle,
+                          decoration: _buildInputDecoration(
+                            label: _headerText('搜索模型 ID', 'Search model ID'),
+                            hint: 'gpt-4o',
+                            suffixIcon:
+                                _remoteModelSearchController.text.trim().isEmpty
+                                ? null
+                                : IconButton(
+                                    splashRadius: 18,
+                                    onPressed: () {
+                                      _remoteModelSearchController.clear();
+                                    },
+                                    icon: Icon(
+                                      Icons.close_rounded,
+                                      color: _tertiaryTextColor,
+                                      size: 18,
+                                    ),
+                                  ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        SizedBox(
+                          height: 320,
+                          child: filteredRemoteModels.isEmpty
+                              ? Padding(
+                                  padding: const EdgeInsets.all(10),
+                                  child: Center(
+                                    child: Text(
+                                      _remoteModels.isEmpty
+                                          ? _headerText(
+                                              '暂无完整模型，请先获取模型列表',
+                                              'No full models yet. Fetch the model list first.',
+                                            )
+                                          : _headerText(
+                                              '没有匹配的模型',
+                                              'No matching models',
+                                            ),
+                                      style: TextStyle(
+                                        color: _secondaryTextColor,
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.w600,
+                                        fontFamily: 'PingFang SC',
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                )
+                              : ListView.builder(
+                                  padding: const EdgeInsets.fromLTRB(
+                                    2,
+                                    2,
+                                    2,
+                                    8,
+                                  ),
+                                  itemCount: remoteModelGroups.length,
+                                  itemBuilder: (context, index) {
+                                    final group = remoteModelGroups[index];
+                                    final expanded = _isModelGroupExpanded(
+                                      group.key,
+                                    );
+                                    return Padding(
+                                      padding: EdgeInsets.only(
+                                        bottom:
+                                            index ==
+                                                remoteModelGroups.length - 1
+                                            ? 0
+                                            : 12,
+                                      ),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.stretch,
+                                        children: [
+                                          _buildModelGroupHeader(
+                                            group.key,
+                                            group.value.length,
+                                            expanded: expanded,
+                                            onTap: () =>
+                                                _toggleModelGroup(group.key),
+                                          ),
+                                          if (expanded)
+                                            ...group.value.map((model) {
+                                              final added = _manualModelIds
+                                                  .contains(model.id);
+                                              return _buildProviderModelRow(
+                                                model: model,
+                                                added: added,
+                                                actionLabel: added
+                                                    ? _headerText(
+                                                        '已添加',
+                                                        'Added',
+                                                      )
+                                                    : _headerText('添加', 'Add'),
+                                                actionDisabled: added,
+                                                actionFilled: !added,
+                                                onAction: added
+                                                    ? null
+                                                    : () =>
+                                                          _addModelToChatWhitelist(
+                                                            model,
+                                                          ),
+                                              );
+                                            }),
+                                        ],
+                                      ),
                                     );
                                   },
                                 ),

--- a/ui/lib/services/model_provider_config_service.dart
+++ b/ui/lib/services/model_provider_config_service.dart
@@ -772,11 +772,63 @@ class ModelProviderConfigService {
     );
   }
 
+  static Future<List<ProviderModelOption>> getChatModelOptionsForProfile(
+    String profileId, {
+    ModelProviderProfileSummary? profile,
+  }) async {
+    final normalizedProfileId = _canonicalProfileId(profileId);
+    final resolvedProfile = profile ?? await _findProfileById(profileId);
+    final manualModelIds = await getManualModelIds(
+      profileId: normalizedProfileId,
+    );
+    List<ProviderModelOption> remoteModels;
+    if (_isBuiltinLocalProfileId(normalizedProfileId)) {
+      try {
+        remoteModels = await fetchModels(
+          profileId: normalizedProfileId,
+          providerName: resolvedProfile?.name ?? '',
+        );
+      } catch (_) {
+        remoteModels = await getCachedFetchedModels(
+          profileId: normalizedProfileId,
+        );
+      }
+    } else {
+      remoteModels = await getCachedFetchedModels(
+        profileId: normalizedProfileId,
+        apiBase: resolvedProfile?.baseUrl ?? '',
+      );
+    }
+    final chatModels = buildChatModelOptions(
+      remoteModels: remoteModels,
+      manualModelIds: manualModelIds,
+    );
+    return enrichModelsForProfile(
+      profileId: normalizedProfileId,
+      providerName: resolvedProfile?.name ?? '',
+      apiBase: resolvedProfile?.baseUrl ?? '',
+      models: chatModels,
+    );
+  }
+
   static Future<List<ProviderModelGroup>> loadModelGroups() async {
     final payload = await listProfiles();
     final groups = <ProviderModelGroup>[];
     for (final profile in payload.profiles) {
       final models = await getStoredModelOptionsForProfile(
+        profile.id,
+        profile: profile,
+      );
+      groups.add(ProviderModelGroup(profile: profile, models: models));
+    }
+    return groups;
+  }
+
+  static Future<List<ProviderModelGroup>> loadChatModelGroups() async {
+    final payload = await listProfiles();
+    final groups = <ProviderModelGroup>[];
+    for (final profile in payload.profiles) {
+      final models = await getChatModelOptionsForProfile(
         profile.id,
         profile: profile,
       );
@@ -810,6 +862,34 @@ class ModelProviderConfigService {
       }
     }
     return merged;
+  }
+
+  static List<ProviderModelOption> buildChatModelOptions({
+    required List<ProviderModelOption> remoteModels,
+    required List<String> manualModelIds,
+  }) {
+    if (manualModelIds.isEmpty) {
+      return const <ProviderModelOption>[];
+    }
+    final remoteById = <String, ProviderModelOption>{
+      for (final item in remoteModels) item.id: item,
+    };
+    final selected = <ProviderModelOption>[];
+    final seen = <String>{};
+    for (final modelId in _normalizeModelIds(manualModelIds)) {
+      if (!seen.add(modelId)) {
+        continue;
+      }
+      selected.add(
+        remoteById[modelId] ??
+            ProviderModelOption(
+              id: modelId,
+              displayName: modelId,
+              ownedBy: 'manual',
+            ),
+      );
+    }
+    return selected;
   }
 
   static String defaultModelGroupName(

--- a/ui/test/features/home/pages/vlm_model_setting/vlm_model_setting_page_test.dart
+++ b/ui/test/features/home/pages/vlm_model_setting/vlm_model_setting_page_test.dart
@@ -538,7 +538,7 @@ void main() {
 
     expect(find.byKey(const Key('provider-logo')), findsNothing);
     expect(
-      find.byKey(const ValueKey('provider-model-group-toggle-button')),
+      find.byKey(const Key('provider-remote-model-search')),
       findsOneWidget,
     );
     expect(
@@ -582,8 +582,12 @@ void main() {
       findsOneWidget,
     );
 
-    final groupBody = find.byKey(const Key('provider-model-group-body-openai'));
-    expect(tester.getSize(groupBody).height, greaterThan(0));
+    final firstModel = find.byKey(const Key('provider-model-context-gpt-4o'));
+    final secondModel = find.byKey(
+      const Key('provider-model-context-gpt-4o-mini'),
+    );
+    expect(firstModel, findsOneWidget);
+    expect(secondModel, findsOneWidget);
     final shortLine = tester.getSize(
       find.byKey(const Key('provider-model-group-line-openai')),
     );
@@ -612,55 +616,23 @@ void main() {
     );
     expect(shortLineLeft.dx - shortCountRight.dx, closeTo(10, 0.5));
     expect(shortIconLeft.dx - shortLineRight.dx, closeTo(6, 0.5));
-    final firstModel = find.byKey(
-      const ValueKey<String>('provider-model-gpt-4o'),
-    );
-    final secondModel = find.byKey(
-      const ValueKey<String>('provider-model-gpt-4o-mini'),
-    );
-    expect(tester.getSize(firstModel).height, 44);
-    expect(tester.getSize(secondModel).height, 44);
-    expect(tester.getSize(firstModel).width, tester.getSize(secondModel).width);
-
-    await tester.tap(
-      find.byKey(const ValueKey('provider-model-group-toggle-button')),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, 0);
-    expect(
-      tester
-          .getSize(find.byKey(const Key('provider-model-group-body-anthropic')))
-          .height,
-      0,
-    );
-
-    await tester.tap(
-      find.byKey(const ValueKey('provider-model-group-toggle-button')),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, greaterThan(0));
-
-    await tester.scrollUntilVisible(
+    await tester.ensureVisible(
       find.byKey(const Key('provider-model-group-openai')),
-      120,
-      scrollable: find.byType(Scrollable).first,
     );
+    await tester.pump();
     await tester.tap(find.byKey(const Key('provider-model-group-openai')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, 0);
+    expect(firstModel, findsNothing);
 
-    await tester.scrollUntilVisible(
+    await tester.ensureVisible(
       find.byKey(const Key('provider-model-group-openai')),
-      120,
-      scrollable: find.byType(Scrollable).first,
     );
+    await tester.pump();
     await tester.tap(find.byKey(const Key('provider-model-group-openai')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 260));
-    expect(tester.getSize(groupBody).height, greaterThan(0));
+    expect(firstModel, findsOneWidget);
 
     expect(tester.takeException(), isNull);
   });

--- a/ui/test/services/model_provider_config_service_test.dart
+++ b/ui/test/services/model_provider_config_service_test.dart
@@ -279,4 +279,35 @@ void main() {
       expect(enriched.single.toolCall, isTrue);
     },
   );
+
+  test(
+    'buildChatModelOptions keeps only manual ids and reuses remote metadata',
+    () {
+      final models = ModelProviderConfigService.buildChatModelOptions(
+        remoteModels: const [
+          ProviderModelOption(
+            id: 'gpt-4o-mini',
+            displayName: 'GPT-4o Mini',
+            ownedBy: 'openai',
+            contextLimit: 128000,
+          ),
+          ProviderModelOption(
+            id: 'gpt-4.1',
+            displayName: 'GPT-4.1',
+            ownedBy: 'openai',
+          ),
+        ],
+        manualModelIds: const ['gpt-4o-mini', 'custom-model', 'gpt-4o-mini'],
+      );
+
+      expect(models.map((item) => item.id).toList(), [
+        'gpt-4o-mini',
+        'custom-model',
+      ]);
+      expect(models.first.displayName, 'GPT-4o Mini');
+      expect(models.first.contextLimit, 128000);
+      expect(models.last.displayName, 'custom-model');
+      expect(models.last.ownedBy, 'manual');
+    },
+  );
 }


### PR DESCRIPTION
## **变更摘要**

本次改动把聊天页（Agent / Chat）的模型选择器，从直接展示 Provider 全量模型，调整为只展示“已添加到聊天页”的模型白名单。 完整模型的拉取、搜索、添加、移除统一收口到模型提供商页，同时继续兜底展示当前会话正在生效的模型，避免当前模型在 selector 中消失。

## **变更类型**

- [x]  新功能

## **关联 Issue**

## **主要改动**

1. 聊天页模型 selector 改为读取聊天白名单，不再直接展示 Provider 全量模型。
2. 聊天页 selector 新增轻量“管理模型”入口跳转到现有模型提供商页。
3. 模型提供商页的模型区域拆成“已添加到聊天页”和“完整模型列表”两层；

## **UI 变更（如有）**

有。
<img width="864" height="1920" alt="c8ece12c30e6a0aff52d6b2ae058d111" src="https://github.com/user-attachments/assets/60e20f75-fdf4-4b8b-9eaa-280a66a89354" />
<img width="864" height="1920" alt="70e062770f17df0657d0c6fa47147352" src="https://github.com/user-attachments/assets/cf43fa86-f3cf-4abc-bf9c-7536a408aae3" />

