### PR TITLE
增加了关闭模型选择页面时的按钮旋转动画

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -146,8 +146,8 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   /// (条件是 **Navigator** 的 `requestFocus`,Route 的 `requestFocus` 不起作用)，
   /// 把焦点从输入框抢走 → 软键盘塌陷 → 输入栏下沉 → popup 锚点错位。
   /// 用 Overlay 直接挂面板可以彻底跳过这条路径。
-  OverlayGlassPopupHandle<_ChatModelOverrideSelection>?
-  _conversationModelSelectorHandle;
+  OverlayEntry? _conversationModelSelectorOverlayEntry;
+  Future<void> Function()? _conversationModelSelectorDismiss;
 
   // ===================== State =====================
   bool _isPopupVisible = false;
@@ -671,18 +671,9 @@ abstract class _ChatPageStateBase extends State<ChatPage>
       }
       return _newThreadTargetForConversationMode(conversationMode);
     }
-    final localCodexThreadId = _activeMode == ChatPageMode.codex
-        ? _activeCodexThreadId?.trim()
-        : null;
     return ConversationThreadTarget.existing(
       conversationId: conversationId,
       mode: conversationMode,
-      codexThreadId: localCodexThreadId == null || localCodexThreadId.isEmpty
-          ? null
-          : localCodexThreadId,
-      codexRuntime: localCodexThreadId == null || localCodexThreadId.isEmpty
-          ? null
-          : 'local',
     );
   }
 

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -146,7 +146,10 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (normalizedPreferredMode == null) {
       final lastVisible =
           await ConversationHistoryService.getLastVisibleThreadTarget();
-      final normalizedLastVisible = _normalizeVisibleThreadTarget(lastVisible);
+      final normalizedLastVisible = _normalizeVisibleThreadTarget(
+        lastVisible,
+        freshCodexOnImplicitRestore: true,
+      );
       if (normalizedLastVisible != null) {
         return normalizedLastVisible;
       }
@@ -174,13 +177,17 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
   }
 
   ConversationThreadTarget? _normalizeVisibleThreadTarget(
-    ConversationThreadTarget? target,
-  ) {
+    ConversationThreadTarget? target, {
+    bool freshCodexOnImplicitRestore = false,
+  }) {
     if (target == null) {
       return null;
     }
     if (target.mode == ConversationMode.openclaw) {
       return null;
+    }
+    if (freshCodexOnImplicitRestore && target.mode == ConversationMode.codex) {
+      return _newCodexThreadTarget();
     }
     return target;
   }
@@ -261,7 +268,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       _isSurfacePageScrolling = false;
     });
     _resetLocalConversationState(targetMode);
-    _restoreLocalCodexThreadIdFromTarget(effectiveTarget);
     _vlmAnswerController.clear();
     _applyDraftForConversationMode(targetMode);
     if (effectiveTarget.isRemoteCodexSessionTarget) {
@@ -282,18 +288,6 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     if (syncPage) {
       _jumpToCurrentModePage(animate: false);
     }
-  }
-
-  void _restoreLocalCodexThreadIdFromTarget(ConversationThreadTarget target) {
-    if (target.mode != ConversationMode.codex ||
-        target.isRemoteCodexSessionTarget) {
-      return;
-    }
-    final threadId = target.codexThreadId?.trim();
-    if (threadId == null || threadId.isEmpty) {
-      return;
-    }
-    _activeCodexThreadId = threadId;
   }
 
   @override
@@ -599,8 +593,9 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
   @override
   void dispose() {
     unawaited(_clearVisibleChatConversation());
-    unawaited(_conversationModelSelectorHandle?.dismiss());
-    _conversationModelSelectorHandle = null;
+    _conversationModelSelectorDismiss = null;
+    _conversationModelSelectorOverlayEntry?.remove();
+    _conversationModelSelectorOverlayEntry = null;
     WidgetsBinding.instance.removeObserver(this);
     unawaited(_runtimeCoordinator.flushAllPendingPersistence());
     _conversationListChangedSubscription?.cancel();

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -430,6 +430,16 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     );
   }
 
+  void _removeConversationModelSelectorOverlay() {
+    final entry = _conversationModelSelectorOverlayEntry;
+    if (entry == null) {
+      return;
+    }
+    _conversationModelSelectorOverlayEntry = null;
+    _conversationModelSelectorDismiss = null;
+    entry.remove();
+  }
+
   @override
   Future<void> _openConversationModelSelector(
     BuildContext anchorContext,
@@ -437,8 +447,13 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     if (_activeMode != ChatPageMode.normal) {
       return;
     }
-    if (_conversationModelSelectorHandle != null) {
-      // 已经开着,不重开。
+    if (_conversationModelSelectorOverlayEntry != null) {
+      final dismiss = _conversationModelSelectorDismiss;
+      if (dismiss != null) {
+        await dismiss();
+      } else {
+        _removeConversationModelSelectorOverlay();
+      }
       return;
     }
     if (_showSlashCommandPanel ||
@@ -462,9 +477,6 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     // 时的焦点迁移——`ModalRoute.didPush` 里检查的是 `navigator.widget.requestFocus`
     // (Navigator 的 requestFocus),不是 Route 的。详见 routes.dart:1668。要彻底
     // 跳过这条焦点迁移路径，唯一干净的办法是不走 Navigator 路由——直接挂到 Overlay。
-    // 这里走 [showOverlayGlassPopup],它把 OverlayEntry + Material + tap-outside +
-    // BackButtonListener + DismissOverlayOnKeyboardHide + playReverse 清理时序
-    // 都封装好了。
     final anchorBox = anchorContext.findRenderObject() as RenderBox?;
     final anchorRect = glassPopupAnchorFromContext(anchorContext);
     if (anchorBox == null || !anchorBox.hasSize || anchorRect == null) {
@@ -475,44 +487,102 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
         .clamp(260.0, 320.0)
         .toDouble();
     const popupMaxHeight = 360.0;
+    final overlayState = Overlay.of(context, rootOverlay: true);
+    final completer = Completer<_ChatModelOverrideSelection?>();
+    final wrapperKey = GlobalKey<GlassPopupOverlayContentState>();
+    OverlayEntry? entry;
+    bool dismissing = false;
+    bool keepOpenForNextKeyboardHide = false;
 
-    final handle = showOverlayGlassPopup<_ChatModelOverrideSelection>(
-      context: context,
-      anchor: anchorRect,
-      builder: (handle) => _ConversationModelSelectorContent(
-        width: popupWidth,
-        maxHeight: popupMaxHeight,
-        profiles: _modelProviderProfiles,
-        providerModelsByProfileId: _modelOptionsByProfileId,
-        currentSelection: _activeDispatchSceneSelection,
-        // 软键盘"确定"提交搜索时:先打开 popup 的"一次性键盘隐藏豁免",再 unfocus
-        // —— 这样 IME 塌陷不会被 DismissOverlayOnKeyboardHide 当作"用户想关 popup"
-        // 误关掉,搜索结果列表得以保留。
-        onSearchSubmitted: () {
-          handle.keepOpenOnNextKeyboardHide();
-          FocusManager.instance.primaryFocus?.unfocus();
-        },
-        // dismiss 内部会立刻 complete future,让下面 await 的逻辑并行起跑;
-        // 收起动画在后台跑完,UI 更响应。
-        onSelect: (selection) => unawaited(handle.dismiss(selection)),
-      ),
-    );
-    _conversationModelSelectorHandle = handle;
+    void handleSearchSubmitted() {
+      keepOpenForNextKeyboardHide = true;
+      FocusManager.instance.primaryFocus?.unfocus();
+    }
 
-    try {
-      final selected = await handle.future;
-      if (selected == null) {
-        return;
+    Future<void> finish(_ChatModelOverrideSelection? result) async {
+      if (dismissing) return;
+      dismissing = true;
+      _chatInputAreaKey.currentState?.playModelPickerCloseAnimation();
+      if (!completer.isCompleted) {
+        // 立刻 resolve caller,让 _applyDispatchSceneModelSelection 可以并行启动；
+        // 收起动画在背景里跑完即可,UI 更响应。
+        completer.complete(result);
       }
-      await _applyDispatchSceneModelSelection(
-        providerProfileId: selected.providerProfileId,
-        modelId: selected.modelId,
-      );
-    } finally {
-      if (_conversationModelSelectorHandle == handle) {
-        _conversationModelSelectorHandle = null;
+      final wrapper = wrapperKey.currentState;
+      if (wrapper != null) {
+        await wrapper.playReverse();
+      }
+      if (_conversationModelSelectorOverlayEntry == entry) {
+        _removeConversationModelSelectorOverlay();
       }
     }
+
+    _conversationModelSelectorDismiss = () => finish(null);
+
+    entry = OverlayEntry(
+      builder: (overlayContext) {
+        return BackButtonListener(
+          onBackButtonPressed: () async {
+            unawaited(finish(null));
+            return true;
+          },
+          // 系统返回手势在 Android 上的处理顺序:
+          //   1. 软键盘开着时,平台层先 hide IME,Flutter 收不到 back 事件;
+          //   2. IME 关掉后再按返回才会传到 Flutter 的 BackButtonListener / PopScope。
+          // 我们的 fix 让模型 popup 打开时键盘保持可见,所以第一击会被
+          // 平台吃掉变成"只关键盘",popup 留在原地。这里用一个 listener
+          // 观察 MediaQuery.viewInsets.bottom,从 >0 跳到 0 就主动关掉 popup,
+          // 这样从用户视角一次返回就把键盘和 popup 一起收掉。
+          child: _DismissOverlayOnKeyboardHide(
+            shouldDismissOnKeyboardHide: () {
+              if (keepOpenForNextKeyboardHide) {
+                keepOpenForNextKeyboardHide = false;
+                return false;
+              }
+              return true;
+            },
+            onKeyboardHide: () => unawaited(finish(null)),
+            child: Material(
+              color: Colors.transparent,
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () => unawaited(finish(null)),
+                    ),
+                  ),
+                  GlassPopupOverlayContent(
+                    key: wrapperKey,
+                    anchor: anchorRect,
+                    child: _ConversationModelSelectorContent(
+                      width: popupWidth,
+                      maxHeight: popupMaxHeight,
+                      profiles: _modelProviderProfiles,
+                      providerModelsByProfileId: _modelOptionsByProfileId,
+                      currentSelection: _activeDispatchSceneSelection,
+                      onSearchSubmitted: handleSearchSubmitted,
+                      onSelect: (selection) => unawaited(finish(selection)),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+    _conversationModelSelectorOverlayEntry = entry;
+    overlayState.insert(entry);
+
+    final selected = await completer.future;
+    if (selected == null) {
+      return;
+    }
+    await _applyDispatchSceneModelSelection(
+      providerProfileId: selected.providerProfileId,
+      modelId: selected.modelId,
+    );
   }
 
   @override
@@ -1780,8 +1850,75 @@ class _ConversationModelSelectorContentState
   }
 }
 
-// DismissOverlayOnKeyboardHide 已提取到 lib/widgets/glass_popup.dart,
-// 给 chat_input_area.dart 里的 context-usage tooltip 一起复用。
-// PR #410 引入的 shouldDismissOnKeyboardHide 一次性豁免 + bottomInset<=0 复位
-// 修复也都搬到了那里;调用方通过 [OverlayGlassPopupHandle.keepOpenOnNextKeyboardHide]
-// 触发豁免(本文件 _openConversationModelSelector 的 onSearchSubmitted 即用法)。
+/// 监听 [MediaQuery.viewInsetsOf] 的底部 inset。键盘从可见变成不可见时 (典型场景:
+/// Android 系统返回手势在键盘弹起状态下先被平台吃掉一击,只关键盘不传到 Flutter,
+/// popup 留在原地;还有 home/外部应用切走) 调一次 [onKeyboardHide]。
+///
+/// 用法:挂在 OverlayEntry 里包住 popup 内容。这样一次系统返回就能把键盘和
+/// popup 一起收掉,符合"输入框聚焦+popup 打开→返回→什么都没了"的直觉。
+class _DismissOverlayOnKeyboardHide extends StatefulWidget {
+  const _DismissOverlayOnKeyboardHide({
+    required this.shouldDismissOnKeyboardHide,
+    required this.onKeyboardHide,
+    required this.child,
+  });
+
+  final bool Function() shouldDismissOnKeyboardHide;
+  final VoidCallback onKeyboardHide;
+  final Widget child;
+
+  @override
+  State<_DismissOverlayOnKeyboardHide> createState() =>
+      _DismissOverlayOnKeyboardHideState();
+}
+
+class _DismissOverlayOnKeyboardHideState
+    extends State<_DismissOverlayOnKeyboardHide> {
+  /// 要把 peak 视作"键盘是真的弹起过",最小高度;<50dp 通常是 nav bar / 手势
+  /// gutter 之类的固定 inset,不算键盘。
+  static const double _kKeyboardPeakMinimum = 50.0;
+
+  /// 已经看到的最大 viewInsets.bottom。键盘高度可能随键盘类型(文本/表情/语音)
+  /// 变化,我们只把"曾经达到过的最高值"当作 peak,避免切换布局时误触发收起。
+  double _peakInset = 0;
+  bool _firedOnce = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    if (bottomInset <= 0) {
+      _peakInset = 0;
+      _firedOnce = false;
+      return;
+    }
+    if (bottomInset > _peakInset) {
+      _peakInset = bottomInset;
+    }
+    // 关键时序:Android 的 IME hide 是动画的(~250ms),如果等 viewInsets.bottom
+    // 全部跌到 0 再触发收起 popup,popup 的反向动画(220ms)就要排在 IME 动画
+    // 之后跑,用户看到的延迟 ≈ 250+220 ms,popup 卡顿明显。改为检测"开始下落"
+    // 的瞬间(从 peak 跌掉 ≥ 10%),触发 popup 反向动画并行跑——这样 IME 动画
+    // 跑完时 popup 也几乎同时消失。
+    //
+    // 阈值 10% 而不是固定像素,是因为 PJD110/ColorOS 的 viewPadding 在静稳态
+    // 也会有亚像素抖动(见 composer-keyboard-debug-rig 笔记),百分比阈值
+    // 对噪声更稳健;peak 必须 ≥ 50dp 进一步保证是真键盘弹起过。
+    if (!_firedOnce &&
+        _peakInset > _kKeyboardPeakMinimum &&
+        bottomInset < _peakInset * 0.9) {
+      _firedOnce = true;
+      if (!widget.shouldDismissOnKeyboardHide()) {
+        return;
+      }
+      // 不能在 didChangeDependencies 同步调 callback——callback 可能 setState,
+      // 而本帧正在 build。延到下一帧。
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onKeyboardHide();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1322,6 +1322,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                               modelId: _activeNormalChatModelId ?? '',
                               hasSelectableModels:
                                   _hasSelectableNormalChatModels,
+                              isOpen: () =>
+                                  _conversationModelSelectorOverlayEntry !=
+                                  null,
                               onPointerDown: () {
                                 _suppressNextOutsideTapKeyboardHide = true;
                               },
@@ -1804,9 +1807,14 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                 if (didPop) return;
                 // 模型选择器是 OverlayEntry，不在 Navigator 栈里，普通 pop
                 // 不会关掉它；这里手动关，让系统返回手势先吃掉它再走原本的退出逻辑。
-                if (_conversationModelSelectorHandle != null) {
-                  unawaited(_conversationModelSelectorHandle?.dismiss());
-                  _conversationModelSelectorHandle = null;
+                if (_conversationModelSelectorOverlayEntry != null) {
+                  final dismiss = _conversationModelSelectorDismiss;
+                  if (dismiss != null) {
+                    unawaited(dismiss());
+                  } else {
+                    _conversationModelSelectorOverlayEntry?.remove();
+                    _conversationModelSelectorOverlayEntry = null;
+                  }
                   return;
                 }
                 if (isHdPadLandscape &&

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
@@ -65,12 +65,14 @@ class ChatModelPickerSettings {
     required this.modelId,
     required this.hasSelectableModels,
     required this.onOpen,
+    this.isOpen,
     this.onPointerDown,
   });
 
   final String modelId;
   final bool hasSelectableModels;
   final FutureOr<void> Function(BuildContext anchorContext) onOpen;
+  final bool Function()? isOpen;
   final VoidCallback? onPointerDown;
 }
 
@@ -412,7 +414,11 @@ class _ContextUsageRingPainter extends CustomPainter {
 }
 
 class ChatInputAreaState extends _ChatInputAreaStateBase
-    with _ChatInputAreaComposerMixin, _ChatInputAreaPopupMixin {}
+    with _ChatInputAreaComposerMixin, _ChatInputAreaPopupMixin {
+  void playModelPickerCloseAnimation() {
+    _playModelPickerCloseAnimation();
+  }
+}
 
 enum _ComposerKeyboardPhase { hidden, opening, visible, closing }
 
@@ -518,6 +524,14 @@ abstract class _ChatInputAreaStateBase extends State<ChatInputArea>
       duration: const Duration(milliseconds: 520),
     );
     _reportInputHeightAfterBuild();
+  }
+
+  void _playModelPickerOpenAnimation() {
+    _modelPickerSpinController.forward(from: 0);
+  }
+
+  void _playModelPickerCloseAnimation() {
+    _modelPickerSpinController.reverse(from: 1);
   }
 
   @override

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
@@ -767,7 +767,10 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
       if (anchorContext == null || !enabled) {
         return;
       }
-      _modelPickerSpinController.forward(from: 0);
+      final shouldClose = settings.isOpen?.call() ?? false;
+      if (!shouldClose) {
+        _playModelPickerOpenAnimation();
+      }
       await Future<void>.sync(() => settings.onOpen(anchorContext));
     }
 


### PR DESCRIPTION
# Conflicts:
#	ui/lib/features/home/pages/chat/chat_page.dart
#	ui/lib/features/home/pages/chat/chat_page_lifecycle.dart #	ui/lib/features/home/pages/chat/chat_page_model_context.dart #	ui/lib/features/home/pages/chat/chat_page_ui.dart

## 变更摘要

增加了关闭Overlay的时候按钮逆时针旋转动画

## 变更类型
- [x] 新功能
## 关联 Issue

无
## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 动画执行逻辑放到关闭Overlay时的回调里面了

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [x] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [x] 已执行相关测试
- [x] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->
无
## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->
无
## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [x] 已确认不会影响无关模块
