### PR TITLE
feat(chat): 优化消息列表性能和渲染效率

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page_models.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_models.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
+import 'package:ui/features/home/pages/chat/utils/agent_run_timeline.dart';
 import 'package:ui/models/chat_message_model.dart';
 
 enum ChatIslandDisplayLayer {
@@ -127,12 +128,64 @@ class ObservableChatMessageList extends ChangeNotifier
     final previous = _messages[index];
     _messages[index] = value;
     _messageNotifiers[index].update(value);
-    _recordContentMutation(
-      affectsPageChrome:
-          _messageAffectsPageChrome(previous) ||
-          _messageAffectsPageChrome(value),
-    );
+    final affectsPageChrome =
+        _messageAffectsPageChrome(previous) || _messageAffectsPageChrome(value);
+    if (_timelineStructureChanged(previous, value)) {
+      _recordStructureMutation(affectsPageChrome: affectsPageChrome);
+    } else {
+      _recordContentMutation(affectsPageChrome: affectsPageChrome);
+    }
     notifyListeners();
+  }
+
+  /// 判断一次原位替换是否会影响 agent_run_timeline 的分组结果。流式追加
+  /// 文本时这些字段都不变，可以走 content 通道；任何会改变分组归属/可见
+  /// 消息判定的字段变化都必须按 structure 通知，让列表重建时间线。
+  static bool _timelineStructureChanged(
+    ChatMessageModel previous,
+    ChatMessageModel next,
+  ) {
+    if (previous.id != next.id ||
+        previous.user != next.user ||
+        previous.type != next.type ||
+        previous.isError != next.isError ||
+        previous.createAt != next.createAt) {
+      return true;
+    }
+    final previousTaskId = agentRunParentTaskId(previous);
+    if (previousTaskId != agentRunParentTaskId(next)) {
+      return true;
+    }
+    final previousMeta = previous.streamMeta;
+    final nextMeta = next.streamMeta;
+    if ((previousMeta?.containsKey('isFinal') ?? false) !=
+            (nextMeta?.containsKey('isFinal') ?? false) ||
+        previousMeta?['isFinal'] != nextMeta?['isFinal']) {
+      return true;
+    }
+    // 注意：不比较 seq/roundIndex——agent 流式每个 chunk 都会携带递增的
+    // seq，但同一条消息原位更新时 seq 变化不影响它的分组归属；分组内的
+    // 展示刷新由行级 listener 负责。
+    if (agentRunKind(previous) != agentRunKind(next)) {
+      return true;
+    }
+    if (_timelineCardType(previous) != _timelineCardType(next)) {
+      return true;
+    }
+    if (previousTaskId != null &&
+        _isCancelledTaskText(previous) != _isCancelledTaskText(next)) {
+      return true;
+    }
+    return false;
+  }
+
+  static String _timelineCardType(ChatMessageModel message) {
+    return (message.cardData?['type'] ?? '').toString().trim();
+  }
+
+  static bool _isCancelledTaskText(ChatMessageModel message) {
+    final text = (message.text ?? '').trim().toLowerCase();
+    return text == '任务已取消' || text == 'task canceled' || text == 'task cancelled';
   }
 
   @override

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -727,7 +727,9 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
             opacity: Curves.easeOutCubic.transform(visibility),
             child: Transform.translate(
               offset: Offset(horizontalOffset, 0),
-              child: child,
+              // 翻页拖拽期间 opacity/offset 每帧变化；RepaintBoundary 让子树
+              // 图层只录制一次，逐帧仅更新透明度与位移，不重绘内容。
+              child: RepaintBoundary(child: child),
             ),
           ),
         );

--- a/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
+++ b/ui/lib/features/home/pages/chat/mixins/agent_stream_handler.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:ui/features/home/pages/authorize/authorize_page_args.dart';
+import 'package:ui/features/home/pages/chat/chat_page_models.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
 import 'package:ui/models/agent_stream_event.dart';
 import 'package:ui/models/chat_message_model.dart';
@@ -251,49 +252,71 @@ mixin AgentStreamHandler<T extends StatefulWidget> on State<T> {
       isFinal: event.isFinal,
     );
 
-    setState(() {
-      _finalizeThinkingCardInMessages(event.taskId, completedThinkingCardId);
-      final index = messages.indexWhere((msg) => msg.id == messageId);
-      if (index == -1) {
-        final content = <String, dynamic>{
-          'text': text,
-          'id': messageId,
-          if (event.isFinal && event.prefillTokensPerSecond != null)
-            'prefillTokensPerSecond': event.prefillTokensPerSecond,
-          if (event.isFinal && event.decodeTokensPerSecond != null)
-            'decodeTokensPerSecond': event.decodeTokensPerSecond,
-        };
-        _clearAgentRetryPresentation(content);
-        messages.insert(
-          0,
-          ChatMessageModel(
-            id: messageId,
-            type: 1,
-            user: 2,
+    // 纯文本增长（消息已存在、非最终帧、无思考卡需要收敛、页面状态不变）
+    // 直接原位更新：ObservableChatMessageList 会通知对应行精确刷新，
+    // 不再让每个 chunk 触发整页 setState/rebuild。
+    final existingIndex = messages.indexWhere((msg) => msg.id == messageId);
+    final isPureTextGrowth =
+        !event.isFinal &&
+        existingIndex != -1 &&
+        (completedThinkingCardId ?? '').trim().isEmpty &&
+        isAiResponding &&
+        messages is ObservableChatMessageList;
+    if (isPureTextGrowth) {
+      final existing = messages[existingIndex];
+      final content = Map<String, dynamic>.from(existing.content ?? {});
+      content['text'] = text;
+      _clearAgentRetryPresentation(content);
+      messages[existingIndex] = existing.copyWith(
+        content: content,
+        streamMeta: streamMeta,
+        reasoningContent: reasoningContent ?? existing.reasoningContent,
+      );
+    } else {
+      setState(() {
+        _finalizeThinkingCardInMessages(event.taskId, completedThinkingCardId);
+        final index = messages.indexWhere((msg) => msg.id == messageId);
+        if (index == -1) {
+          final content = <String, dynamic>{
+            'text': text,
+            'id': messageId,
+            if (event.isFinal && event.prefillTokensPerSecond != null)
+              'prefillTokensPerSecond': event.prefillTokensPerSecond,
+            if (event.isFinal && event.decodeTokensPerSecond != null)
+              'decodeTokensPerSecond': event.decodeTokensPerSecond,
+          };
+          _clearAgentRetryPresentation(content);
+          messages.insert(
+            0,
+            ChatMessageModel(
+              id: messageId,
+              type: 1,
+              user: 2,
+              content: content,
+              streamMeta: streamMeta,
+              reasoningContent: reasoningContent,
+            ),
+          );
+        } else {
+          final existing = messages[index];
+          final content = Map<String, dynamic>.from(existing.content ?? {});
+          content['text'] = text;
+          if (event.isFinal && event.prefillTokensPerSecond != null) {
+            content['prefillTokensPerSecond'] = event.prefillTokensPerSecond;
+          }
+          if (event.isFinal && event.decodeTokensPerSecond != null) {
+            content['decodeTokensPerSecond'] = event.decodeTokensPerSecond;
+          }
+          _clearAgentRetryPresentation(content);
+          messages[index] = existing.copyWith(
             content: content,
             streamMeta: streamMeta,
-            reasoningContent: reasoningContent,
-          ),
-        );
-      } else {
-        final existing = messages[index];
-        final content = Map<String, dynamic>.from(existing.content ?? {});
-        content['text'] = text;
-        if (event.isFinal && event.prefillTokensPerSecond != null) {
-          content['prefillTokensPerSecond'] = event.prefillTokensPerSecond;
+            reasoningContent: reasoningContent ?? existing.reasoningContent,
+          );
         }
-        if (event.isFinal && event.decodeTokensPerSecond != null) {
-          content['decodeTokensPerSecond'] = event.decodeTokensPerSecond;
-        }
-        _clearAgentRetryPresentation(content);
-        messages[index] = existing.copyWith(
-          content: content,
-          streamMeta: streamMeta,
-          reasoningContent: reasoningContent ?? existing.reasoningContent,
-        );
-      }
-      isAiResponding = true;
-    });
+        isAiResponding = true;
+      });
+    }
     onAgentTextMessageUpdated(messageId, isFinal: event.isFinal);
     unawaited(
       VoicePlaybackCoordinator.instance.onAssistantMessageUpdated(

--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -1498,6 +1498,10 @@ class _ChatMessageListState extends State<ChatMessageList> {
   DateTime? _autoStickSuppressedUntil;
   GlobalKey? _editingUserMessageRevealKey;
   String? _editingUserMessageRevealKeyId;
+  List<AgentRunTimelineEntry>? _timelineEntriesCache;
+  ObservableChatMessageList? _timelineCacheSource;
+  int _timelineCacheStructureRevision = -1;
+  Set<String>? _timelineCacheActiveTaskIds;
 
   Set<String> get _expandedAgentRunTaskIds =>
       widget.expandedAgentRunTaskIds ?? _localExpandedAgentRunTaskIds;
@@ -1667,6 +1671,13 @@ class _ChatMessageListState extends State<ChatMessageList> {
     _collapseCancelledAgentRuns();
     if (_autoStickToLatest && !_isAutoStickTemporarilySuppressed) {
       _scheduleStickToLatest();
+    }
+    // 流式追加文本这类 content 级变更由每行的 ValueListenableBuilder 精确
+    // 刷新，这里不再整表 setState（否则每个 chunk 都会重跑时间线分组和
+    // 全部可见行的 itemBuilder）。结构变化仍走完整重建。
+    if (_observableMessages?.lastMutationKind ==
+        ChatMessageListMutationKind.content) {
+      return;
     }
     setState(() {});
   }
@@ -1945,6 +1956,39 @@ class _ChatMessageListState extends State<ChatMessageList> {
     return listenables;
   }
 
+  /// 时间线分组按 structureRevision 缓存：content 级流式更新与父层
+  /// （键盘高度、翻页过渡等）触发的重建直接复用上次分组结果，避免每帧
+  /// 对全部消息重跑 O(n·g) 的分组扫描。
+  List<AgentRunTimelineEntry> _resolveTimelineEntries(
+    List<ChatMessageModel> messageSource,
+  ) {
+    final observable = messageSource is ObservableChatMessageList
+        ? messageSource
+        : null;
+    if (observable == null) {
+      return buildAgentRunTimelineEntries(
+        List<ChatMessageModel>.from(messageSource),
+        activeTaskIds: widget.activeAgentTaskIds,
+      );
+    }
+    final cached = _timelineEntriesCache;
+    if (cached != null &&
+        identical(_timelineCacheSource, observable) &&
+        _timelineCacheStructureRevision == observable.structureRevision &&
+        setEquals(_timelineCacheActiveTaskIds, widget.activeAgentTaskIds)) {
+      return cached;
+    }
+    final entries = buildAgentRunTimelineEntries(
+      List<ChatMessageModel>.from(observable),
+      activeTaskIds: widget.activeAgentTaskIds,
+    );
+    _timelineEntriesCache = entries;
+    _timelineCacheSource = observable;
+    _timelineCacheStructureRevision = observable.structureRevision;
+    _timelineCacheActiveTaskIds = Set<String>.from(widget.activeAgentTaskIds);
+    return entries;
+  }
+
   AgentRunTimelineGroup _refreshTimelineGroup(
     ObservableChatMessageList messages,
     AgentRunTimelineGroup group,
@@ -2097,10 +2141,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
 
     String? latestUserMessageId;
     final messageSource = _observableMessages ?? widget.messages;
-    final timelineEntries = buildAgentRunTimelineEntries(
-      List<ChatMessageModel>.from(messageSource),
-      activeTaskIds: widget.activeAgentTaskIds,
-    );
+    final timelineEntries = _resolveTimelineEntries(messageSource);
     for (final item in messageSource) {
       if (item.user == 1) {
         latestUserMessageId = item.id;

--- a/ui/lib/features/home/widgets/home_drawer.dart
+++ b/ui/lib/features/home/widgets/home_drawer.dart
@@ -150,6 +150,14 @@ class HomeDrawerState extends ConsumerState<HomeDrawer> {
   Timer? _searchDebounceTimer;
   String? _editingThreadKey;
   List<ScheduledTask> _scheduledTasks = <ScheduledTask>[];
+  // 分组结果缓存：_allConversations/_scheduledTasks 只会被整体替换（不会原地
+  // 修改），因此按列表 identity 判断是否需要重算，避免每次 build 重复
+  // filter+sort（该 getter 一次 build 会被调用多次）。
+  List<_ScheduledConversationGroup>? _scheduledGroupsCache;
+  List<ConversationModel>? _scheduledGroupsCacheConversations;
+  List<ScheduledTask>? _scheduledGroupsCacheTasks;
+  Set<String>? _promotedThreadKeysCache;
+  List<_ScheduledConversationGroup>? _promotedThreadKeysCacheSource;
   StreamSubscription<Map<String, dynamic>>?
   _conversationListChangedSubscription;
   StreamSubscription<List<ScheduledTask>>? _scheduledTasksChangedSubscription;

--- a/ui/lib/features/home/widgets/home_drawer_image_previews.dart
+++ b/ui/lib/features/home/widgets/home_drawer_image_previews.dart
@@ -825,23 +825,29 @@ class _ConversationImageThumbnailState
     final fallbackColor = context.isDarkTheme
         ? palette.surfaceSecondary
         : palette.previewFallback;
+    // 34dp 缩略图按显示像素解码，避免原图全分辨率解码占用图像缓存。
+    final cacheWidth =
+        (widget.size * MediaQuery.devicePixelRatioOf(context)).ceil();
     final image = switch (widget.preview) {
       _ConversationImagePreview(bytes: final bytes?) => Image.memory(
         bytes,
         fit: BoxFit.cover,
         gaplessPlayback: true,
+        cacheWidth: cacheWidth,
         errorBuilder: (_, __, ___) => _markFailed(),
       ),
       _ConversationImagePreview(url: final url?) => Image.network(
         url,
         fit: BoxFit.cover,
         gaplessPlayback: true,
+        cacheWidth: cacheWidth,
         errorBuilder: (_, __, ___) => _markFailed(),
       ),
       _ConversationImagePreview(path: final path?) => Image.file(
         File(path),
         fit: BoxFit.cover,
         gaplessPlayback: true,
+        cacheWidth: cacheWidth,
         errorBuilder: (_, __, ___) => _markFailed(),
       ),
       _ => _markFailed(),

--- a/ui/lib/features/home/widgets/home_drawer_search.dart
+++ b/ui/lib/features/home/widgets/home_drawer_search.dart
@@ -27,13 +27,20 @@ extension _HomeDrawerSearch on HomeDrawerState {
   }
 
   Set<String> get _promotedConversationThreadKeys {
+    final groups = _scheduledConversationGroups;
+    final cached = _promotedThreadKeysCache;
+    if (cached != null && identical(_promotedThreadKeysCacheSource, groups)) {
+      return cached;
+    }
     final keys = <String>{};
-    for (final group in _scheduledConversationGroups) {
+    for (final group in groups) {
       keys.add(group.parent.threadKey);
       for (final child in group.children) {
         keys.add(child.conversation.threadKey);
       }
     }
+    _promotedThreadKeysCacheSource = groups;
+    _promotedThreadKeysCache = keys;
     return keys;
   }
 
@@ -54,6 +61,20 @@ extension _HomeDrawerSearch on HomeDrawerState {
   }
 
   List<_ScheduledConversationGroup> get _scheduledConversationGroups {
+    final cached = _scheduledGroupsCache;
+    if (cached != null &&
+        identical(_scheduledGroupsCacheConversations, _allConversations) &&
+        identical(_scheduledGroupsCacheTasks, _scheduledTasks)) {
+      return cached;
+    }
+    final groups = _computeScheduledConversationGroups();
+    _scheduledGroupsCacheConversations = _allConversations;
+    _scheduledGroupsCacheTasks = _scheduledTasks;
+    _scheduledGroupsCache = groups;
+    return groups;
+  }
+
+  List<_ScheduledConversationGroup> _computeScheduledConversationGroups() {
     final visibleConversations = _allConversations
         .where((conversation) => !conversation.isArchived)
         .toList(growable: false);


### PR DESCRIPTION
- 实现了 agent_run_timeline 分组结果缓存机制，避免每次流式更新时 重复执行 O(n·g) 的分组计算
- 区分 content 和 structure 级别的消息变更：纯文本增长走精确刷新， 结构变化才触发完整重建
- 为聊天消息列表添加了 timelineEntries 缓存，按 structureRevision 进行有效性判断
- 在翻页拖拽场景中引入 RepaintBoundary，将透明度和位移动画与内容 重绘分离，提升动画流畅度
- 添加了缩略图预览的 cacheWidth 优化，按显示像素解码避免内存浪费
- 实现了首页抽屉搜索功能的分组结果缓存，减少重复的 filter+sort 计算开销

## 变更摘要

<!-- 用 1-3 句话描述本次改动解决了什么问题 -->

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

<!-- 例如：Closes #123 -->

## 主要改动

<!-- 请列出关键改动点，便于 Review -->

1. 
2. 
3. 

## 测试说明

<!-- 说明你如何验证改动有效 -->

- [ ] 已本地编译通过（例如 `./gradlew :app:assembleDevelopDebug`）
- [ ] 已执行相关测试
- [ ] 已手动验证关键路径

测试细节：

```text
请粘贴测试命令、关键日志或验证步骤
```

## UI 变更（如有）

<!-- 有界面改动请附截图或录屏，无则填“无” -->

## 风险与回滚

<!-- 简述潜在风险和回滚方案，无则填“无” -->

## 自检清单

- [ ] 代码遵循项目现有风格
- [ ] 无新增明显警告或错误日志
- [ ] 已更新必要文档（如 README/注释/配置说明）
- [ ] 已确认不会影响无关模块
