### PR TITLE
feat(codex): add local ChatGPT auth and model picker

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerManager.kt
@@ -6,16 +6,18 @@ import android.os.Looper
 import android.util.Log
 import com.ai.assistance.operit.terminal.TerminalManager
 import com.ai.assistance.operit.terminal.setup.EnvironmentSetupLogic
+import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.database.DatabaseHelper
+import cn.com.omnimind.baselib.llm.OpenAiWireApi
 import cn.com.omnimind.bot.BuildConfig
 import cn.com.omnimind.bot.agent.AgentWorkspaceManager
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
+import com.google.gson.JsonParser
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
 
 class CodexAppServerManager private constructor(
@@ -24,9 +26,11 @@ class CodexAppServerManager private constructor(
     private val appContext = context.applicationContext
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val sessionMutex = Mutex()
+    private val localConfigMigrationMutex = Mutex()
     private val threadStartMutex = Mutex()
     private val mainHandler = Handler(Looper.getMainLooper())
     private val bindingRepository = CodexThreadBindingRepository(appContext)
+    private val localConfigStore = CodexLocalConfigStore(appContext)
     private val remoteConfigStore = CodexRemoteBridgeConfigStore(appContext)
     private val activeTurnsByThreadId = ConcurrentHashMap<String, String>()
 
@@ -46,6 +50,11 @@ class CodexAppServerManager private constructor(
 
     suspend fun status(): Map<String, Any?> {
         val runtime = resolveRuntime()
+        val localConfig = if (runtime.kind == CodexRuntimeKind.LOCAL) {
+            resolveStoredLocalConfig(allowReadFailure = true)
+        } else {
+            localConfigStore.read()
+        }
         val connected = session?.isRunning == true && activeRuntime == runtime.kind
         val probe = when (runtime.kind) {
             CodexRuntimeKind.REMOTE -> probeRemoteCodex(runtime.remoteConfig)
@@ -59,6 +68,7 @@ class CodexAppServerManager private constructor(
             "codexHome" to CodexAppServerDefaults.CODEX_HOME,
             "cwd" to resolveDefaultCwd(),
             "runtime" to runtime.kind.payloadValue,
+            "localAuthMode" to localConfig.authMode.payloadValue,
             "remoteEnabled" to runtime.remoteConfig.enabled,
             "remoteBridgeUrl" to runtime.remoteConfig.bridgeUrl,
             "remoteCwd" to runtime.remoteConfig.cwd,
@@ -81,10 +91,23 @@ class CodexAppServerManager private constructor(
             session = null
             activeRuntime = null
             activeTurnsByThreadId.clear()
+            val localConfig = if (runtime.kind == CodexRuntimeKind.LOCAL) {
+                resolveStoredLocalConfig(allowReadFailure = false)
+            } else {
+                localConfigStore.read()
+            }
             val nextSession = CodexAppServerSession(
                 context = appContext,
                 scope = scope,
                 onServerMessage = ::handleServerMessage,
+                localEnvironment = if (runtime.kind == CodexRuntimeKind.LOCAL) {
+                    buildCodexLocalEnvironment(
+                        authMode = localConfig.authMode,
+                        apiKey = localConfig.apiKey
+                    )
+                } else {
+                    emptyMap()
+                },
                 connectionFactory = when (runtime.kind) {
                     CodexRuntimeKind.REMOTE -> {
                         {
@@ -149,6 +172,7 @@ class CodexAppServerManager private constructor(
             )
             "config/local/read" -> readLocalConfig()
             "config/local/write" -> writeLocalConfig(args)
+            "config/local/models" -> listLocalApiModels(args)
             "config/remote/test" -> testRemoteConfig(args)
             "config/remote/fs/list" -> listRemoteDirectories(args)
             "config/remote/fs/read" -> readRemoteFile(args)
@@ -413,6 +437,41 @@ class CodexAppServerManager private constructor(
 
     private suspend fun readLocalConfig(): Map<String, Any?> {
         val remoteConfig = remoteConfigStore.read()
+        val localConfig = resolveStoredLocalConfig(
+            allowReadFailure = remoteConfig.enabled
+        )
+        return buildCodexLocalConfigPayload(
+            localConfig = localConfig,
+            remoteConfig = remoteConfig,
+            runtime = resolveRuntime().kind.payloadValue
+        )
+    }
+
+    private suspend fun resolveStoredLocalConfig(
+        allowReadFailure: Boolean
+    ): CodexLocalConfig {
+        if (
+            localConfigStore.hasStoredConfig &&
+            !localConfigStore.needsLegacyAuthKeyCleanup
+        ) {
+            return localConfigStore.read()
+        }
+        return localConfigMigrationMutex.withLock {
+            if (
+                localConfigStore.hasStoredConfig &&
+                !localConfigStore.needsLegacyAuthKeyCleanup
+            ) {
+                return@withLock localConfigStore.read()
+            }
+            val files = readLocalConfigFiles(allowReadFailure)
+                ?: return@withLock localConfigStore.read()
+            resolveLocalConfig(files.configToml, files.authJson)
+        }
+    }
+
+    private suspend fun readLocalConfigFiles(
+        allowReadFailure: Boolean
+    ): CodexLocalConfigFiles? {
         val command = """
             mkdir -p ${shellQuote(CodexAppServerDefaults.CODEX_HOME)}
             printf '__OMNI_CODEX_CONFIG_START__\n'
@@ -439,10 +498,11 @@ class CodexAppServerManager private constructor(
             }
             result.output
         }
-        if (localRead.isFailure && !remoteConfig.enabled) {
+        if (localRead.isFailure && !allowReadFailure) {
             throw localRead.exceptionOrNull()
                 ?: IllegalStateException("Failed to read Codex config.")
         }
+        if (localRead.isFailure) return null
         val localOutput = localRead.getOrDefault("")
         val configToml = extractMarkedBlock(
             localOutput,
@@ -454,58 +514,46 @@ class CodexAppServerManager private constructor(
             "__OMNI_CODEX_AUTH_START__",
             "__OMNI_CODEX_AUTH_END__"
         )
-        return buildCodexLocalConfigPayload(
-            model = extractTomlString(configToml, "model").orEmpty(),
-            baseUrl = extractTomlString(configToml, "base_url").orEmpty(),
-            apiKey = extractOpenAiApiKey(authJson).orEmpty(),
-            remoteConfig = remoteConfig,
-            runtime = resolveRuntime().kind.payloadValue
-        )
+        return CodexLocalConfigFiles(configToml = configToml, authJson = authJson)
     }
 
     private suspend fun writeLocalConfig(args: Map<String, Any?>): Map<String, Any?> {
-        val baseUrl = args.stringValue("baseUrl").orEmpty()
-        val model = args.stringValue("model").orEmpty()
-        val apiKey = args.stringValue("apiKey").orEmpty()
+        val storedLocalConfig = localConfigStore.read()
+        val authMode = CodexLocalAuthMode.fromPayload(args.stringValue("localAuthMode"))
+            ?: storedLocalConfig.authMode
+        val localConfig = CodexLocalConfig(
+            authMode = authMode,
+            baseUrl = args.stringValueOrStored("baseUrl", storedLocalConfig.baseUrl),
+            apiModel = args.stringValueOrStored("model", storedLocalConfig.apiModel),
+            apiKey = args.stringValueOrStored("apiKey", storedLocalConfig.apiKey),
+            officialModel = args.stringValueOrStored(
+                "officialModel",
+                storedLocalConfig.officialModel
+            )
+        ).normalized()
         val remoteConfig = CodexRemoteBridgeConfig(
             enabled = args["remoteEnabled"] == true,
             bridgeUrl = args.stringValue("remoteBridgeUrl").orEmpty(),
             authToken = args.stringValue("remoteBridgeToken").orEmpty(),
             cwd = args.stringValue("remoteCwd").orEmpty()
         )
-        val localComplete = baseUrl.isNotBlank() && model.isNotBlank() && apiKey.isNotBlank()
+        val localComplete = when (localConfig.authMode) {
+            CodexLocalAuthMode.CHATGPT -> true
+            CodexLocalAuthMode.API -> {
+                localConfig.baseUrl.isNotBlank() &&
+                    localConfig.apiModel.isNotBlank() &&
+                    localConfig.apiKey.isNotBlank()
+            }
+        }
         if (remoteConfig.enabled && !remoteConfig.isConfigured) {
             throw IllegalArgumentException("Remote Codex bridge URL and cwd are required.")
         }
 
-        val savedRemoteConfig = remoteConfigStore.write(remoteConfig)
         if (localComplete) {
-            val configToml = buildCodexConfigToml(baseUrl = baseUrl, model = model)
-            val authJson = JSONObject()
-                .put("OPENAI_API_KEY", apiKey)
-                .toString(4) + "\n"
-            val configPath = "${CodexAppServerDefaults.CODEX_HOME}/config.toml"
-            val authPath = "${CodexAppServerDefaults.CODEX_HOME}/auth.json"
-            val command = """
-                set -eu
-                mkdir -p ${shellQuote(CodexAppServerDefaults.CODEX_HOME)}
-                umask 077
-                printf %s ${shellQuote(configToml)} > ${shellQuote(configPath)}
-                printf %s ${shellQuote(authJson)} > ${shellQuote(authPath)}
-                chmod 600 ${shellQuote(configPath)} ${shellQuote(authPath)}
-                printf '__OMNI_CODEX_WRITE_OK__\n'
-            """.trimIndent()
-            val result = TerminalManager.getInstance(appContext).executeHiddenCommand(
-                command = command,
-                executorKey = "codex-config-write",
-                timeoutMs = 30_000L
-            )
-            if (!result.isOk || result.exitCode != 0) {
-                throw IllegalStateException(
-                    result.error.ifBlank { result.rawOutputPreview.ifBlank { "Failed to write Codex config." } }
-                )
-            }
+            writeLocalConfigToml(localConfig)
         }
+        val savedLocalConfig = localConfigStore.write(localConfig)
+        val savedRemoteConfig = remoteConfigStore.write(remoteConfig)
         sessionMutex.withLock {
             session?.disconnect()
             session = null
@@ -513,11 +561,125 @@ class CodexAppServerManager private constructor(
             activeTurnsByThreadId.clear()
         }
         return buildCodexLocalConfigPayload(
-            model = model,
-            baseUrl = baseUrl,
-            apiKey = apiKey,
+            localConfig = savedLocalConfig,
             remoteConfig = savedRemoteConfig,
             runtime = resolveRuntime().kind.payloadValue
+        )
+    }
+
+    private suspend fun resolveLocalConfig(
+        configToml: String,
+        authJson: String
+    ): CodexLocalConfig {
+        if (localConfigStore.hasStoredConfig) {
+            cleanupLegacyAuthKey(authJson)
+            return localConfigStore.read()
+        }
+        val migrated = migrateLegacyCodexLocalConfig(configToml, authJson)
+        val shouldPersist =
+            configToml.isNotBlank() ||
+                migrated.apiKey.isNotBlank() ||
+                hasChatGptAuthTokens(authJson)
+        if (!shouldPersist) {
+            return migrated
+        }
+        if (shouldRewriteMigratedCustomApiConfig(configToml, migrated)) {
+            writeLocalConfigToml(migrated)
+        }
+        val needsLegacyAuthKeyCleanup =
+            migrated.authMode == CodexLocalAuthMode.API &&
+                extractOpenAiApiKey(authJson) != null
+        val saved = localConfigStore.write(
+            migrated,
+            needsLegacyAuthKeyCleanup = needsLegacyAuthKeyCleanup
+        )
+        cleanupLegacyAuthKey(authJson)
+        return saved
+    }
+
+    private suspend fun cleanupLegacyAuthKey(authJson: String) {
+        if (!localConfigStore.needsLegacyAuthKeyCleanup) return
+        removeLegacyOpenAiApiKey(authJson)?.let { sanitized ->
+            writeLocalAuthJson(sanitized)
+        }
+        localConfigStore.markLegacyAuthKeyCleanupComplete()
+    }
+
+    private suspend fun writeLocalConfigToml(localConfig: CodexLocalConfig) {
+        val normalized = localConfig.normalized()
+        val selectedModel = when (normalized.authMode) {
+            CodexLocalAuthMode.CHATGPT -> normalized.officialModel
+            CodexLocalAuthMode.API -> normalized.apiModel
+        }
+        val configToml = buildCodexConfigToml(
+            authMode = normalized.authMode,
+            baseUrl = normalized.baseUrl,
+            model = selectedModel
+        )
+        val configPath = "${CodexAppServerDefaults.CODEX_HOME}/config.toml"
+        val command = """
+            set -eu
+            mkdir -p ${shellQuote(CodexAppServerDefaults.CODEX_HOME)}
+            umask 077
+            printf %s ${shellQuote(configToml)} > ${shellQuote(configPath)}
+            chmod 600 ${shellQuote(configPath)}
+            printf '__OMNI_CODEX_WRITE_OK__\n'
+        """.trimIndent()
+        val result = TerminalManager.getInstance(appContext).executeHiddenCommand(
+            command = command,
+            executorKey = "codex-config-write",
+            timeoutMs = 30_000L
+        )
+        if (!result.isOk || result.exitCode != 0) {
+            throw IllegalStateException(
+                result.error.ifBlank {
+                    result.rawOutputPreview.ifBlank { "Failed to write Codex config." }
+                }
+            )
+        }
+    }
+
+    private suspend fun writeLocalAuthJson(authJson: String) {
+        val authPath = "${CodexAppServerDefaults.CODEX_HOME}/auth.json"
+        val command = """
+            set -eu
+            mkdir -p ${shellQuote(CodexAppServerDefaults.CODEX_HOME)}
+            umask 077
+            printf %s ${shellQuote(authJson)} > ${shellQuote(authPath)}
+            chmod 600 ${shellQuote(authPath)}
+        """.trimIndent()
+        val result = TerminalManager.getInstance(appContext).executeHiddenCommand(
+            command = command,
+            executorKey = "codex-auth-migrate",
+            timeoutMs = 30_000L
+        )
+        if (!result.isOk || result.exitCode != 0) {
+            throw IllegalStateException(
+                result.error.ifBlank {
+                    result.rawOutputPreview.ifBlank { "Failed to migrate Codex auth." }
+                }
+            )
+        }
+    }
+
+    private suspend fun listLocalApiModels(args: Map<String, Any?>): Map<String, Any?> {
+        val baseUrl = args.stringValue("baseUrl").orEmpty()
+        val apiKey = args.stringValue("apiKey").orEmpty()
+        require(baseUrl.isNotBlank()) { "Custom API base URL is required." }
+        require(apiKey.isNotBlank()) { "Custom API key is required." }
+        val models = HttpController.fetchProviderModels(
+            apiBase = baseUrl,
+            apiKey = apiKey,
+            protocolType = "openai_compatible",
+            wireApi = OpenAiWireApi.RESPONSES
+        )
+        return mapOf(
+            "models" to models.map { model ->
+                mapOf(
+                    "id" to model.id,
+                    "displayName" to model.displayName
+                )
+            }
         )
     }
 
@@ -998,6 +1160,11 @@ private enum class CodexRuntimeKind(val payloadValue: String) {
     REMOTE("remote")
 }
 
+private data class CodexLocalConfigFiles(
+    val configToml: String,
+    val authJson: String
+)
+
 private data class CodexThreadListEntry(
     val threadId: String,
     val cwd: String?,
@@ -1128,17 +1295,17 @@ private fun String.normalizeCodexCollaborationModeKind(): String? {
 }
 
 private fun buildCodexLocalConfigPayload(
-    model: String,
-    baseUrl: String,
-    apiKey: String,
+    localConfig: CodexLocalConfig,
     remoteConfig: CodexRemoteBridgeConfig,
     runtime: String
 ): Map<String, Any?> {
     return linkedMapOf(
         "codexHome" to CodexAppServerDefaults.CODEX_HOME,
-        "model" to model,
-        "baseUrl" to baseUrl,
-        "apiKey" to apiKey,
+        "model" to localConfig.apiModel,
+        "officialModel" to localConfig.officialModel,
+        "baseUrl" to localConfig.baseUrl,
+        "apiKey" to localConfig.apiKey,
+        "localAuthMode" to localConfig.authMode.payloadValue,
         "remoteEnabled" to remoteConfig.enabled,
         "remoteBridgeUrl" to remoteConfig.bridgeUrl,
         "remoteBridgeToken" to remoteConfig.authToken,
@@ -1148,19 +1315,39 @@ private fun buildCodexLocalConfigPayload(
     )
 }
 
-private fun buildCodexConfigToml(baseUrl: String, model: String): String {
-    return """
-        model_provider = "omnimind"
-        model = ${tomlString(model)}
-        model_reasoning_effort = "xhigh"
-        disable_response_storage = true
+internal fun buildCodexConfigToml(
+    authMode: CodexLocalAuthMode,
+    baseUrl: String,
+    model: String
+): String {
+    val lines = mutableListOf("model_provider = ${tomlString(authMode.providerId)}")
+    model.trim().takeIf { it.isNotEmpty() }?.let {
+        lines += "model = ${tomlString(it)}"
+    }
+    lines += "model_reasoning_effort = \"xhigh\""
+    lines += "disable_response_storage = true"
+    if (authMode == CodexLocalAuthMode.CHATGPT) {
+        lines += "cli_auth_credentials_store = \"file\""
+    } else {
+        lines += ""
+        lines += "[model_providers.omnimind]"
+        lines += "name = \"omnimind\""
+        lines += "base_url = ${tomlString(baseUrl.trim())}"
+        lines += "wire_api = \"responses\""
+        lines += "env_key = ${tomlString(CODEX_CUSTOM_API_KEY_ENV)}"
+        lines += "requires_openai_auth = false"
+    }
+    return lines.joinToString(separator = "\n", postfix = "\n")
+}
 
-        [model_providers.omnimind]
-        name = "omnimind"
-        base_url = ${tomlString(baseUrl)}
-        wire_api = "responses"
-        requires_openai_auth = true
-    """.trimIndent() + "\n"
+private val CodexLocalAuthMode.providerId: String
+    get() = if (this == CodexLocalAuthMode.CHATGPT) "openai" else "omnimind"
+
+private fun Map<String, Any?>.stringValueOrStored(key: String, stored: String): String {
+    if (!containsKey(key)) {
+        return stored
+    }
+    return stringValue(key).orEmpty()
 }
 
 private fun extractMarkedBlock(source: String, startMarker: String, endMarker: String): String {
@@ -1185,8 +1372,152 @@ private fun extractOpenAiApiKey(source: String): String? {
     val trimmed = source.trim()
     if (trimmed.isEmpty()) return null
     return runCatching {
-        JSONObject(trimmed).optString("OPENAI_API_KEY").trim().takeIf { it.isNotEmpty() }
+        val value = JsonParser.parseString(trimmed)
+            .takeIf { it.isJsonObject }
+            ?.asJsonObject
+            ?.get("OPENAI_API_KEY")
+        if (value == null || value.isJsonNull || !value.isJsonPrimitive) {
+            null
+        } else {
+            value.asString.trim().takeIf { it.isNotEmpty() }
+        }
     }.getOrNull()
+}
+
+internal fun removeLegacyOpenAiApiKey(source: String): String? {
+    val trimmed = source.trim()
+    if (trimmed.isEmpty()) return null
+    return runCatching {
+        val root = JsonParser.parseString(trimmed)
+            .takeIf { it.isJsonObject }
+            ?.asJsonObject
+            ?: return@runCatching null
+        if (!root.has("OPENAI_API_KEY")) return@runCatching null
+        root.remove("OPENAI_API_KEY")
+        root.toString()
+    }.getOrNull()
+}
+
+internal fun migrateLegacyCodexLocalConfig(
+    configToml: String,
+    authJson: String
+): CodexLocalConfig {
+    val model = extractTomlString(configToml, "model").orEmpty()
+    val provider = extractTomlString(configToml, "model_provider").orEmpty()
+    val baseUrl = if (provider.isBlank()) {
+        extractTomlString(configToml, "base_url")
+    } else {
+        extractTomlTableString(
+            configToml,
+            table = "model_providers.$provider",
+            key = "base_url"
+        )
+    }.orEmpty()
+    val apiKey = extractOpenAiApiKey(authJson).orEmpty()
+    val hasCustomProviderConfig = baseUrl.isNotBlank() ||
+        provider.equals("omnimind", ignoreCase = true)
+    val hasOfficialProviderConfig = configToml.isNotBlank() &&
+        !hasCustomProviderConfig
+    val authMode = if (
+        !hasCustomProviderConfig &&
+        (hasChatGptAuthTokens(authJson) || hasOfficialProviderConfig)
+    ) {
+        CodexLocalAuthMode.CHATGPT
+    } else {
+        CodexLocalAuthMode.API
+    }
+    return CodexLocalConfig(
+        authMode = authMode,
+        baseUrl = baseUrl,
+        apiModel = if (authMode == CodexLocalAuthMode.API) model else "",
+        apiKey = apiKey,
+        officialModel = if (authMode == CodexLocalAuthMode.CHATGPT) model else ""
+    ).normalized()
+}
+
+internal fun shouldRewriteMigratedCustomApiConfig(
+    configToml: String,
+    config: CodexLocalConfig
+): Boolean {
+    if (
+        config.authMode != CodexLocalAuthMode.API ||
+        config.baseUrl.isBlank() ||
+        config.apiModel.isBlank() ||
+        config.apiKey.isBlank()
+    ) {
+        return false
+    }
+    val provider = extractTomlString(configToml, "model_provider").orEmpty()
+    if (provider.isBlank()) return true
+    val table = "model_providers.$provider"
+    val envKey = extractTomlTableString(configToml, table, "env_key")
+    val requiresOpenAiAuth = extractTomlTableBoolean(
+        configToml,
+        table,
+        "requires_openai_auth"
+    )
+    return envKey != CODEX_CUSTOM_API_KEY_ENV || requiresOpenAiAuth != false
+}
+
+private fun hasChatGptAuthTokens(source: String): Boolean {
+    val trimmed = source.trim()
+    if (trimmed.isEmpty()) return false
+    return runCatching {
+        val tokens = JsonParser.parseString(trimmed)
+            .takeIf { it.isJsonObject }
+            ?.asJsonObject
+            ?.get("tokens")
+            ?.takeIf { it.isJsonObject }
+            ?.asJsonObject
+            ?: return@runCatching false
+        listOf("access_token", "id_token", "refresh_token").any { key ->
+            val value = tokens.get(key)
+            value != null &&
+                !value.isJsonNull &&
+                value.isJsonPrimitive &&
+                value.asString.isNotBlank()
+        }
+    }.getOrDefault(false)
+}
+
+private fun extractTomlTableString(
+    source: String,
+    table: String,
+    key: String
+): String? {
+    return extractTomlTableBody(source, table)?.let { body ->
+        extractTomlString(body, key)
+    }
+}
+
+private fun extractTomlTableBoolean(
+    source: String,
+    table: String,
+    key: String
+): Boolean? {
+    val body = extractTomlTableBody(source, table) ?: return null
+    val escapedKey = Regex.escape(key)
+    val pattern = Regex(
+        pattern = """(?m)^\s*$escapedKey\s*=\s*(true|false)\s*(?:#.*)?$""",
+        option = RegexOption.IGNORE_CASE
+    )
+    return pattern.find(body)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.lowercase()
+        ?.toBooleanStrictOrNull()
+}
+
+private fun extractTomlTableBody(source: String, table: String): String? {
+    if (source.isBlank()) return null
+    val escapedTable = Regex.escape(table)
+    val header = Regex(
+        pattern = """(?m)^\s*\[$escapedTable]\s*(?:#.*)?$"""
+    ).find(source) ?: return null
+    val bodyStart = header.range.last + 1
+    val nextHeader = Regex(pattern = """(?m)^\s*\[""").find(source, bodyStart)
+    val bodyEnd = nextHeader?.range?.first ?: source.length
+    return source.substring(bodyStart, bodyEnd)
 }
 
 private fun tomlString(value: String): String {

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerSession.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexAppServerSession.kt
@@ -21,6 +21,7 @@ internal class CodexAppServerSession(
     private val scope: CoroutineScope,
     private val onServerMessage: suspend (Map<String, Any?>) -> Unit,
     private val connectionFactory: (() -> CodexAppServerConnection)? = null,
+    private val localEnvironment: Map<String, String> = emptyMap(),
     private val processStarter: suspend (String, Map<String, String>) -> Process = { command, extraEnvironment ->
         defaultLocalProcessStarter(context, command, extraEnvironment)
     }
@@ -211,7 +212,7 @@ internal class CodexAppServerSession(
             "OMNIBOT_HEADLESS" to "1",
             "CODEX_HOME" to CodexAppServerDefaults.CODEX_HOME,
             "OMNIBOT_SESSION_CWD" to CodexAppServerDefaults.FALLBACK_CWD
-        )
+        ) + localEnvironment
     }
 
     private fun buildStartCommand(): String {

--- a/app/src/main/java/cn/com/omnimind/bot/codex/CodexLocalConfigStore.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/codex/CodexLocalConfigStore.kt
@@ -1,0 +1,105 @@
+package cn.com.omnimind.bot.codex
+
+import android.content.Context
+
+internal enum class CodexLocalAuthMode(val payloadValue: String) {
+    CHATGPT("chatgpt"),
+    API("api");
+
+    companion object {
+        fun fromPayload(value: String?): CodexLocalAuthMode? {
+            return when (value?.trim()?.lowercase()) {
+                CHATGPT.payloadValue -> CHATGPT
+                API.payloadValue -> API
+                else -> null
+            }
+        }
+    }
+}
+
+internal data class CodexLocalConfig(
+    val authMode: CodexLocalAuthMode = CodexLocalAuthMode.API,
+    val baseUrl: String = "",
+    val apiModel: String = "",
+    val apiKey: String = "",
+    val officialModel: String = ""
+)
+
+internal fun CodexLocalConfig.normalized(): CodexLocalConfig {
+    return copy(
+        baseUrl = baseUrl.trim(),
+        apiModel = apiModel.trim(),
+        apiKey = apiKey.trim(),
+        officialModel = officialModel.trim()
+    )
+}
+
+internal class CodexLocalConfigStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences(
+        PREFS_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    val hasStoredConfig: Boolean
+        get() = prefs.contains(KEY_AUTH_MODE)
+
+    val needsLegacyAuthKeyCleanup: Boolean
+        get() = prefs.getBoolean(KEY_LEGACY_AUTH_KEY_CLEANUP, false)
+
+    fun read(): CodexLocalConfig {
+        return CodexLocalConfig(
+            authMode = CodexLocalAuthMode.fromPayload(
+                prefs.getString(KEY_AUTH_MODE, null)
+            ) ?: CodexLocalAuthMode.API,
+            baseUrl = prefs.getString(KEY_BASE_URL, "").orEmpty(),
+            apiModel = prefs.getString(KEY_API_MODEL, "").orEmpty(),
+            apiKey = prefs.getString(KEY_API_KEY, "").orEmpty(),
+            officialModel = prefs.getString(KEY_OFFICIAL_MODEL, "").orEmpty()
+        )
+    }
+
+    fun write(
+        config: CodexLocalConfig,
+        needsLegacyAuthKeyCleanup: Boolean? = null
+    ): CodexLocalConfig {
+        val normalized = config.normalized()
+        val editor = prefs.edit()
+            .putString(KEY_AUTH_MODE, normalized.authMode.payloadValue)
+            .putString(KEY_BASE_URL, normalized.baseUrl)
+            .putString(KEY_API_MODEL, normalized.apiModel)
+            .putString(KEY_API_KEY, normalized.apiKey)
+            .putString(KEY_OFFICIAL_MODEL, normalized.officialModel)
+        needsLegacyAuthKeyCleanup?.let {
+            editor.putBoolean(KEY_LEGACY_AUTH_KEY_CLEANUP, it)
+        }
+        editor.apply()
+        return read()
+    }
+
+    fun markLegacyAuthKeyCleanupComplete() {
+        prefs.edit().putBoolean(KEY_LEGACY_AUTH_KEY_CLEANUP, false).apply()
+    }
+
+    private companion object {
+        private const val PREFS_NAME = "codex_local_config"
+        private const val KEY_AUTH_MODE = "auth_mode"
+        private const val KEY_BASE_URL = "base_url"
+        private const val KEY_API_MODEL = "api_model"
+        private const val KEY_API_KEY = "api_key"
+        private const val KEY_OFFICIAL_MODEL = "official_model"
+        private const val KEY_LEGACY_AUTH_KEY_CLEANUP = "legacy_auth_key_cleanup"
+    }
+}
+
+internal fun buildCodexLocalEnvironment(
+    authMode: CodexLocalAuthMode,
+    apiKey: String
+): Map<String, String> {
+    val normalizedApiKey = apiKey.trim()
+    if (authMode != CodexLocalAuthMode.API || normalizedApiKey.isEmpty()) {
+        return emptyMap()
+    }
+    return mapOf(CODEX_CUSTOM_API_KEY_ENV to normalizedApiKey)
+}
+
+internal const val CODEX_CUSTOM_API_KEY_ENV = "OMNIBOT_CODEX_API_KEY"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,6 +6,7 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
+    <exclude domain="sharedpref" path="codex_local_config.xml"/>
     <!--
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,13 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
+        <exclude domain="sharedpref" path="codex_local_config.xml"/>
         <!-- TODO: Use <include> and <exclude> to control what is backed up.
         <include .../>
         <exclude .../>
         -->
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="codex_local_config.xml"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerProtocolPayloadTest.kt
@@ -1,6 +1,7 @@
 package cn.com.omnimind.bot.codex
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -210,5 +211,158 @@ class CodexAppServerProtocolPayloadTest {
         assertEquals(false, enriched.containsKey("active"))
         assertEquals(false, enriched.containsKey("activeTurnId"))
         assertEquals(false, enriched.containsKey("turnId"))
+    }
+
+    @Test
+    fun buildChatGptCodexConfigUsesBuiltInOpenAiProvider() {
+        val config = buildCodexConfigToml(
+            authMode = CodexLocalAuthMode.CHATGPT,
+            baseUrl = "",
+            model = "gpt-5.5"
+        )
+
+        assertTrue(config.contains("model_provider = \"openai\""))
+        assertTrue(config.contains("model = \"gpt-5.5\""))
+        assertTrue(config.contains("cli_auth_credentials_store = \"file\""))
+        assertFalse(config.contains("[model_providers.omnimind]"))
+        assertFalse(config.contains("OMNIBOT_CODEX_API_KEY"))
+    }
+
+    @Test
+    fun buildCustomApiCodexConfigUsesDedicatedEnvironmentKey() {
+        val config = buildCodexConfigToml(
+            authMode = CodexLocalAuthMode.API,
+            baseUrl = "https://example.com/v1",
+            model = "custom-codex"
+        )
+
+        assertTrue(config.contains("model_provider = \"omnimind\""))
+        assertTrue(config.contains("model = \"custom-codex\""))
+        assertTrue(config.contains("base_url = \"https://example.com/v1\""))
+        assertTrue(config.contains("env_key = \"OMNIBOT_CODEX_API_KEY\""))
+        assertTrue(config.contains("requires_openai_auth = false"))
+    }
+
+    @Test
+    fun buildLocalCodexEnvironmentOnlyExposesCustomApiKeyInApiMode() {
+        assertEquals(
+            mapOf("OMNIBOT_CODEX_API_KEY" to "secret"),
+            buildCodexLocalEnvironment(
+                authMode = CodexLocalAuthMode.API,
+                apiKey = " secret "
+            )
+        )
+        assertTrue(
+            buildCodexLocalEnvironment(
+                authMode = CodexLocalAuthMode.CHATGPT,
+                apiKey = "secret"
+            ).isEmpty()
+        )
+    }
+
+    @Test
+    fun migrateLegacyCodexConfigRecognizesChatGptTokensWithoutConfigToml() {
+        val config = migrateLegacyCodexLocalConfig(
+            configToml = "",
+            authJson = """
+                {
+                  "OPENAI_API_KEY": null,
+                  "tokens": {
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token"
+                  }
+                }
+            """.trimIndent()
+        )
+
+        assertEquals(CodexLocalAuthMode.CHATGPT, config.authMode)
+        assertEquals("", config.apiKey)
+    }
+
+    @Test
+    fun migrateLegacyCodexConfigKeepsCustomApiProviderAndKey() {
+        val legacyConfigToml = """
+                model_provider = "omnimind"
+                model = " custom-model "
+
+                [model_providers.omnimind]
+                base_url = " https://example.com/v1 "
+            """.trimIndent()
+        val config = migrateLegacyCodexLocalConfig(
+            configToml = legacyConfigToml,
+            authJson = """
+                {
+                  "OPENAI_API_KEY": " custom-key ",
+                  "tokens": {"access_token": "stale-chatgpt-token"}
+                }
+            """.trimIndent()
+        )
+
+        assertEquals(CodexLocalAuthMode.API, config.authMode)
+        assertEquals("https://example.com/v1", config.baseUrl)
+        assertEquals("custom-model", config.apiModel)
+        assertEquals("custom-key", config.apiKey)
+        assertTrue(shouldRewriteMigratedCustomApiConfig(legacyConfigToml, config))
+        assertFalse(
+            shouldRewriteMigratedCustomApiConfig(
+                buildCodexConfigToml(
+                    authMode = config.authMode,
+                    baseUrl = config.baseUrl,
+                    model = config.apiModel
+                ),
+                config
+            )
+        )
+    }
+
+    @Test
+    fun migrateLegacyCodexConfigIgnoresUnusedProviderBaseUrl() {
+        val config = migrateLegacyCodexLocalConfig(
+            configToml = """
+                model_provider = "openai"
+                model = "gpt-5.5-codex"
+
+                [model_providers.omnimind]
+                base_url = "https://unused.example.com/v1"
+            """.trimIndent(),
+            authJson = """
+                {"tokens":{"access_token":"chatgpt-token"}}
+            """.trimIndent()
+        )
+
+        assertEquals(CodexLocalAuthMode.CHATGPT, config.authMode)
+        assertEquals("", config.baseUrl)
+        assertEquals("gpt-5.5-codex", config.officialModel)
+    }
+
+    @Test
+    fun removeLegacyOpenAiApiKeyPreservesChatGptTokens() {
+        val sanitized = removeLegacyOpenAiApiKey(
+            """
+                {
+                  "OPENAI_API_KEY": "legacy-key",
+                  "tokens": {
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token"
+                  },
+                  "last_refresh": "2026-07-10T00:00:00Z"
+                }
+            """.trimIndent()
+        )
+
+        assertTrue(sanitized != null)
+        assertFalse(sanitized!!.contains("OPENAI_API_KEY"))
+        assertTrue(sanitized.contains("access-token"))
+        assertTrue(sanitized.contains("refresh-token"))
+        assertTrue(sanitized.contains("last_refresh"))
+    }
+
+    @Test
+    fun removeLegacyOpenAiApiKeySkipsAuthWithoutApiKey() {
+        assertNull(
+            removeLegacyOpenAiApiKey(
+                """{"tokens":{"access_token":"access-token"}}"""
+            )
+        )
     }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerSessionTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/codex/CodexAppServerSessionTest.kt
@@ -125,7 +125,30 @@ class CodexAppServerSessionTest {
         }
     }
 
-    private class CodexSessionHarness(scriptBody: String) {
+    @Test
+    fun localEnvironmentIsForwardedToTheAppServerProcess() = runBlocking {
+        val harness = CodexSessionHarness(
+            scriptBody = """
+            read init
+            printf '{"id":1,"result":{}}\n'
+            read initialized
+            sleep 5
+            """.trimIndent(),
+            localEnvironment = mapOf("OMNIBOT_CODEX_API_KEY" to "secret")
+        )
+        try {
+            harness.session.start(clientVersion = "1.2.3")
+
+            assertEquals("secret", harness.startEnvironment["OMNIBOT_CODEX_API_KEY"])
+        } finally {
+            harness.close()
+        }
+    }
+
+    private class CodexSessionHarness(
+        scriptBody: String,
+        localEnvironment: Map<String, String> = emptyMap()
+    ) {
         private val tempDir: File = Files.createTempDirectory("codex-session-test").toFile()
         val logFile: File = File(tempDir, "stdin.log")
         private val scriptFile: File = File(tempDir, "fake-app-server.sh")
@@ -141,6 +164,7 @@ class CodexAppServerSessionTest {
         val session = CodexAppServerSession(
             scope = scope,
             onServerMessage = { message -> events.add(message) },
+            localEnvironment = localEnvironment,
             processStarter = { command, environment ->
                 startCommand = command
                 startEnvironment = environment

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -423,6 +423,9 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   bool _isCodexCollaborationModeListLoading = false;
   String? _codexModelListError;
   String? _codexCollaborationModeListError;
+  String? _loadedCodexModelSourceKey;
+  String? _loadingCodexModelSourceKey;
+  int _codexModelListRequestId = 0;
   List<String> _codexModelOptions = const <String>[];
   List<String> _codexReasoningEffortOptions = const <String>[
     'low',
@@ -1754,6 +1757,8 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   Future<void> _refreshCodexStatus();
 
   Future<void> _refreshCodexCommandPreferences();
+
+  Future<void> _loadCodexModelOptionsWhenReady();
 
   Future<void> _loadCodexModelOptions({bool force = false});
 

--- a/ui/lib/features/home/pages/chat/chat_page_codex.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_codex.dart
@@ -286,18 +286,11 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
     }
   }
 
+  @override
   Future<void> _loadCodexModelOptionsWhenReady() async {
-    if ((_codexModelOptions.isNotEmpty &&
-            (_activeCodexModelId ?? '').trim().isNotEmpty &&
-            (_activeCodexReasoningEffort ?? '').trim().isNotEmpty) ||
-        _isCodexModelListLoading) {
-      return;
-    }
-    var status = _codexStatus;
+    late CodexStatus status;
     try {
-      if (!status.ready) {
-        status = await CodexAppServerService.status();
-      }
+      status = await CodexAppServerService.status();
       if (!status.ready) {
         return;
       }
@@ -305,6 +298,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         status = await CodexAppServerService.connect();
         unawaited(CodexAppServerService.listThreads());
       }
+      _applyRefreshedCodexStatus(status);
     } catch (error) {
       debugPrint('Prepare Codex model options failed: $error');
       return;
@@ -312,34 +306,54 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
     if (!mounted || !status.connected) {
       return;
     }
-    setState(() {
-      _codexStatus = status;
-    });
+    final sourceKey = codexModelSourceKey(status);
+    if ((_loadedCodexModelSourceKey == sourceKey &&
+            _codexModelOptions.isNotEmpty &&
+            (_activeCodexModelId ?? '').trim().isNotEmpty &&
+            (_activeCodexReasoningEffort ?? '').trim().isNotEmpty) ||
+        (_isCodexModelListLoading &&
+            _loadingCodexModelSourceKey == sourceKey)) {
+      return;
+    }
     await _loadCodexModelOptions(force: true);
   }
 
   @override
   Future<void> _loadCodexModelOptions({bool force = false}) async {
-    if (_isCodexModelListLoading) {
+    final statusForRequest = _codexStatus;
+    final sourceKey = codexModelSourceKey(statusForRequest);
+    if (_isCodexModelListLoading &&
+        _loadingCodexModelSourceKey == sourceKey) {
       return;
     }
     if (!force &&
+        _loadedCodexModelSourceKey == sourceKey &&
         _codexModelOptions.isNotEmpty &&
         (_activeCodexModelId ?? '').trim().isNotEmpty) {
       return;
     }
     if (!mounted) return;
+    final requestId = ++_codexModelListRequestId;
     setState(() {
       _isCodexModelListLoading = true;
+      _loadingCodexModelSourceKey = sourceKey;
       _codexModelListError = null;
     });
     try {
       final configSettings = await _readCodexRunSettingsFromServerConfig();
-      final response = await CodexAppServerService.listModels();
-      final models = _extractCodexOptionIds(
-        response,
-        _kCodexModelListResponseKeys,
-      );
+      final useConfiguredApiModelOnly =
+          statusForRequest.runtime != 'remote' &&
+          !statusForRequest.remoteEnabled &&
+          statusForRequest.localAuthMode == CodexLocalAuthMode.api;
+      final response = useConfiguredApiModelOnly
+          ? const <String, dynamic>{}
+          : await CodexAppServerService.listModels();
+      final models = useConfiguredApiModelOnly
+          ? <String>[
+              if ((configSettings.modelId ?? '').trim().isNotEmpty)
+                configSettings.modelId!.trim(),
+            ]
+          : _extractCodexOptionIds(response, _kCodexModelListResponseKeys);
       if (models.isEmpty) {
         debugPrint(
           '[Codex] model/list returned no parseable models: ${jsonEncode(response)}',
@@ -350,15 +364,27 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
           _extractCodexPreferredOptionId(response) ??
           _extractCodexDefaultModelId(response) ??
           (models.isNotEmpty ? models.first : null);
-      final activeModel = (_activeCodexModelId ?? '').trim();
-      final modelOptions = _mergeCodexOptionIds(
-        current: activeModel.isEmpty ? preferredModel : activeModel,
-        preferred: preferredModel,
-        options: models,
+      final conversationId = _currentConversationIdByMode[ChatPageMode.codex];
+      final scopedModel = _readCodexPreference(
+        _kCodexModelPreferenceKey,
+        conversationId: conversationId,
       );
-      final effectiveModel = activeModel.isNotEmpty
-          ? activeModel
-          : preferredModel;
+      final activeModel =
+          (_loadedCodexModelSourceKey == sourceKey
+                  ? _activeCodexModelId
+                  : scopedModel)
+              ?.trim() ??
+          '';
+      final effectiveModel = useConfiguredApiModelOnly
+          ? preferredModel
+          : (activeModel.isNotEmpty ? activeModel : preferredModel);
+      final modelOptions = useConfiguredApiModelOnly
+          ? models
+          : _mergeCodexOptionIds(
+              current: effectiveModel,
+              preferred: preferredModel,
+              options: models,
+            );
       final modelDefaultEffort = _extractCodexModelDefaultReasoningEffort(
         response,
         effectiveModel,
@@ -367,13 +393,19 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         current: configSettings.reasoningEffort ?? modelDefaultEffort,
         options: _extractCodexReasoningEffortOptions(response),
       );
-      if (!mounted) return;
+      if (!mounted ||
+          !isCurrentCodexModelLoad(
+            requestId: requestId,
+            activeRequestId: _codexModelListRequestId,
+            requestSource: sourceKey,
+            currentSource: codexModelSourceKey(_codexStatus),
+          )) {
+        return;
+      }
       setState(() {
+        _loadedCodexModelSourceKey = sourceKey;
         _codexModelOptions = modelOptions;
-        if ((_activeCodexModelId ?? '').trim().isEmpty &&
-            preferredModel != null) {
-          _activeCodexModelId = preferredModel;
-        }
+        _activeCodexModelId = effectiveModel;
         if ((_activeCodexReasoningEffort ?? '').trim().isEmpty) {
           _activeCodexReasoningEffort =
               configSettings.reasoningEffort ??
@@ -383,15 +415,28 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
                   : _kDefaultCodexReasoningEffort);
         }
         _codexReasoningEffortOptions = effortOptions;
-        _isCodexModelListLoading = false;
         _codexModelListError = null;
       });
     } catch (error) {
-      if (!mounted) return;
+      if (!mounted ||
+          !isCurrentCodexModelLoad(
+            requestId: requestId,
+            activeRequestId: _codexModelListRequestId,
+            requestSource: sourceKey,
+            currentSource: codexModelSourceKey(_codexStatus),
+          )) {
+        return;
+      }
       setState(() {
-        _isCodexModelListLoading = false;
         _codexModelListError = error.toString();
       });
+    } finally {
+      if (mounted && requestId == _codexModelListRequestId) {
+        setState(() {
+          _isCodexModelListLoading = false;
+          _loadingCodexModelSourceKey = null;
+        });
+      }
     }
   }
 
@@ -575,7 +620,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
       );
       _requestComposerFocus();
       _handleSlashCommandInput();
-      await _loadCodexModelOptions();
+      await _loadCodexModelOptionsWhenReady();
       return;
     }
     if (command == '/review') {
@@ -605,7 +650,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         return false;
       case CodexSlashSubmitKind.openModelPicker:
         _triggerSlashCommandPanel();
-        await _loadCodexModelOptions();
+        await _loadCodexModelOptionsWhenReady();
         return true;
       case CodexSlashSubmitKind.selectModel:
         await _selectCodexModel(intent.value ?? '');
@@ -662,8 +707,17 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
     _inputFocusNode.unfocus();
     _messageController.clear();
     _hideSlashCommandPanel();
+    late CodexStatus status;
+    try {
+      status = await _refreshConnectedCodexStatus();
+    } catch (error) {
+      if (mounted) {
+        handleAgentError('Codex review 启动失败: $error');
+      }
+      return;
+    }
     final messageIds = addUserMessage('/review');
-    final remoteCodex = _isRemoteCodexConfigured();
+    final remoteCodex = codexModelSourceKey(status) == 'remote';
     int? conversationId;
     if (remoteCodex) {
       conversationId = _ensureRemoteCodexRuntimeForCurrentMessages();
@@ -704,22 +758,14 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
     }
 
     try {
-      CodexStatus status = _codexStatus;
-      if (!status.connected) {
-        status = await CodexAppServerService.connect();
-        if (mounted) {
-          setState(() {
-            _codexStatus = status;
-          });
-        }
-      }
+      final reviewModel = await _resolveCodexRequestModel(status);
       final response = await CodexAppServerService.startReview(
         conversationId: remoteCodex ? null : resolvedConversationId,
         threadId: _activeCodexThreadId,
         approvalPolicy: _codexPermissionMode.approvalPolicy,
         approvalsReviewer: _codexPermissionMode.approvalsReviewer,
         sandboxPolicy: _codexPermissionMode.sandboxPolicy,
-        model: _activeCodexModelId,
+        model: reviewModel,
         effort: _activeCodexReasoningEffort,
         collaborationMode: _activeCodexCollaborationMode,
       );
@@ -828,10 +874,13 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
   }
 
   String _codexPreferenceKey(String kind, {int? conversationId}) {
+    final source = kind == _kCodexModelPreferenceKey
+        ? '.${codexModelSourceKey(_codexStatus)}'
+        : '';
     if (conversationId == null) {
-      return '$_kCodexPreferenceStoragePrefix.$kind.global';
+      return '$_kCodexPreferenceStoragePrefix.$kind$source.global';
     }
-    return '$_kCodexPreferenceStoragePrefix.$kind.conversation.$conversationId';
+    return '$_kCodexPreferenceStoragePrefix.$kind$source.conversation.$conversationId';
   }
 
   @override
@@ -947,7 +996,17 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
     String? modelOverride,
     String? collaborationModeOverride,
   }) async {
-    final remoteCodex = _isRemoteCodexConfigured();
+    late CodexStatus status;
+    try {
+      status = await _refreshConnectedCodexStatus();
+    } catch (error) {
+      if (mounted) {
+        _currentDispatchTaskId = aiMessageId;
+        handleAgentError('Codex 连接失败: $error');
+      }
+      return;
+    }
+    final remoteCodex = codexModelSourceKey(status) == 'remote';
     int? conversationId;
     if (remoteCodex) {
       conversationId = _ensureRemoteCodexRuntimeForCurrentMessages();
@@ -991,15 +1050,10 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         collaborationModeOverride ?? _activeCodexCollaborationMode;
     final turnUsesPlanMode = _isCodexPlanMode(collaborationModeForTurn);
     try {
-      CodexStatus status = _codexStatus;
-      if (!status.connected) {
-        status = await CodexAppServerService.connect();
-        if (mounted) {
-          setState(() {
-            _codexStatus = status;
-          });
-        }
-      }
+      final turnModel = await _resolveCodexRequestModel(
+        status,
+        overrideModel: modelOverride,
+      );
       final response = await CodexAppServerService.startTurn(
         conversationId: remoteCodex ? null : resolvedConversationId,
         threadId: _activeCodexThreadId,
@@ -1007,7 +1061,7 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
         approvalPolicy: _codexPermissionMode.approvalPolicy,
         approvalsReviewer: _codexPermissionMode.approvalsReviewer,
         sandboxPolicy: _codexPermissionMode.sandboxPolicy,
-        model: modelOverride ?? _activeCodexModelId,
+        model: turnModel,
         effort: _activeCodexReasoningEffort,
         collaborationMode: collaborationModeForTurn,
       );
@@ -1594,11 +1648,11 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
       final account = await CodexAppServerService.readAccount();
       final accountMap = account['account'];
       final requiresOpenaiAuth = account['requiresOpenaiAuth'] == true;
-      final isLoggedIn =
-          accountMap is Map &&
-          ((accountMap['email']?.toString().trim().isNotEmpty ?? false) ||
-              (accountMap['type']?.toString().trim().isNotEmpty ?? false));
-      if (isLoggedIn && !requiresOpenaiAuth) {
+      final accountType = accountMap is Map
+          ? accountMap['type']?.toString().trim()
+          : null;
+      final isLoggedInWithChatGpt = accountType == 'chatgpt';
+      if (isLoggedInWithChatGpt || !requiresOpenaiAuth) {
         return;
       }
       if (!mounted) return;
@@ -1614,7 +1668,12 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
                 ? 'Login'
                 : '登录',
             onPressed: () {
-              unawaited(_startCodexLogin());
+              if (_codexStatus.runtime == 'remote' ||
+                  _codexStatus.remoteEnabled) {
+                unawaited(_startRemoteCodexLogin());
+              } else {
+                GoRouterManager.push('/home/codex_setting');
+              }
             },
           ),
         ),
@@ -1624,15 +1683,66 @@ mixin _ChatPageCodexMixin on _ChatPageStateBase {
     }
   }
 
-  Future<void> _startCodexLogin() async {
+  Future<void> _startRemoteCodexLogin() async {
     try {
       final response = await CodexAppServerService.startLogin();
       final authUrl = _asCodexString(response['authUrl']);
       if (authUrl == null) return;
       await launchUrlString(authUrl, mode: LaunchMode.externalApplication);
     } catch (error) {
-      debugPrint('Start Codex login failed: $error');
+      debugPrint('Start remote Codex login failed: $error');
     }
+  }
+
+  Future<CodexStatus> _refreshConnectedCodexStatus() async {
+    var status = await CodexAppServerService.status();
+    if (!status.connected) {
+      status = await CodexAppServerService.connect();
+      unawaited(CodexAppServerService.listThreads());
+    }
+    _applyRefreshedCodexStatus(status);
+    return status;
+  }
+
+  void _applyRefreshedCodexStatus(CodexStatus status) {
+    final sourceChanged =
+        codexModelSourceKey(_codexStatus) != codexModelSourceKey(status);
+    if (!mounted) return;
+    setState(() {
+      _codexStatus = status;
+      if (sourceChanged) {
+        _activeCodexThreadId = null;
+        _activeCodexTurnId = null;
+        _codexModelOptions = const <String>[];
+        _codexModelListError = null;
+      }
+    });
+  }
+
+  Future<String?> _resolveCodexRequestModel(
+    CodexStatus status, {
+    String? overrideModel,
+  }) async {
+    final sourceKey = codexModelSourceKey(status);
+    final scopedModel = _readCodexPreference(
+      _kCodexModelPreferenceKey,
+      conversationId: _currentConversationIdByMode[ChatPageMode.codex],
+    );
+    final localApiMode =
+        status.runtime != 'remote' &&
+        !status.remoteEnabled &&
+        status.localAuthMode == CodexLocalAuthMode.api;
+    final configuredApiModel = localApiMode
+        ? (await _readCodexRunSettingsFromServerConfig()).modelId
+        : null;
+    return selectCodexRequestModel(
+      status: status,
+      overrideModel: overrideModel,
+      activeModel: _activeCodexModelId,
+      scopedModel: scopedModel,
+      configuredApiModel: configuredApiModel,
+      activeModelSourceMatches: _loadedCodexModelSourceKey == sourceKey,
+    );
   }
 }
 

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -377,7 +377,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     if (_codexModelOptions.isEmpty &&
         !_isCodexModelListLoading &&
         _codexModelListError == null) {
-      unawaited(_loadCodexModelOptions());
+      unawaited(_loadCodexModelOptionsWhenReady());
     }
     final query = _slashCommandRouteQuery(
       _SlashCommandPanelRoute.codexModel,
@@ -1375,7 +1375,7 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                           : null,
                       onCodexRunSettingsOpened:
                           _activeMode == ChatPageMode.codex
-                          ? () => _loadCodexModelOptions(force: true)
+                          ? _loadCodexModelOptionsWhenReady
                           : null,
                       onCodexRunSettingsChanged:
                           _activeMode == ChatPageMode.codex

--- a/ui/lib/features/home/pages/codex/codex_setting_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_setting_page.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_switch/flutter_switch.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 import 'package:ui/features/home/pages/codex/codex_bridge_qr_scanner_page.dart';
 import 'package:ui/features/home/pages/codex/codex_remote_directory_picker.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
@@ -26,6 +28,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
 
   late final TextEditingController _baseUrlController;
   late final TextEditingController _modelController;
+  late final TextEditingController _officialModelController;
   late final TextEditingController _apiKeyController;
   late final TextEditingController _bridgeUrlController;
   late final TextEditingController _bridgeTokenController;
@@ -35,15 +38,29 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
   bool _isLoading = true;
   bool _isSaving = false;
   bool _isTestingBridge = false;
+  bool _isFetchingApiModels = false;
+  bool _isLoadingOfficialModels = false;
+  bool _isStartingLogin = false;
   bool _isSyncing = false;
   bool _obscureApiKey = true;
   bool _obscureBridgeToken = true;
   bool _remoteEnabled = false;
+  CodexLocalAuthMode _localAuthMode = CodexLocalAuthMode.api;
   String _codexHome = _defaultCodexHome;
   String _runtime = 'local';
   String? _error;
   String? _status;
   String? _lastSavedSignature;
+  String? _apiModelOptionsSource;
+  List<String> _apiModelOptions = const <String>[];
+  List<String> _officialModelOptions = const <String>[];
+
+  bool get _isChatGptMode => _localAuthMode == CodexLocalAuthMode.chatgpt;
+
+  String get _apiModelRequestSource => [
+    _baseUrlController.text.trim(),
+    _apiKeyController.text.trim(),
+  ].join('\n');
 
   bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
   bool get _isDarkTheme => context.isDarkTheme;
@@ -74,6 +91,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     super.initState();
     _baseUrlController = TextEditingController();
     _modelController = TextEditingController(text: _defaultCodexModel);
+    _officialModelController = TextEditingController(text: _defaultCodexModel);
     _apiKeyController = TextEditingController();
     _bridgeUrlController = TextEditingController();
     _bridgeTokenController = TextEditingController();
@@ -81,6 +99,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     for (final controller in [
       _baseUrlController,
       _modelController,
+      _officialModelController,
       _apiKeyController,
       _bridgeUrlController,
       _bridgeTokenController,
@@ -97,6 +116,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     for (final controller in [
       _baseUrlController,
       _modelController,
+      _officialModelController,
       _apiKeyController,
       _bridgeUrlController,
       _bridgeTokenController,
@@ -124,11 +144,18 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _modelController,
         config.model.trim().isEmpty ? _defaultCodexModel : config.model,
       );
+      _setControllerText(
+        _officialModelController,
+        config.officialModel.trim().isEmpty
+            ? _defaultCodexModel
+            : config.officialModel,
+      );
       _setControllerText(_apiKeyController, config.apiKey);
       _setControllerText(_bridgeUrlController, config.remoteBridgeUrl);
       _setControllerText(_bridgeTokenController, config.remoteBridgeToken);
       _setControllerText(_bridgeCwdController, config.remoteCwd);
       _remoteEnabled = config.remoteEnabled;
+      _localAuthMode = config.localAuthMode;
     } finally {
       _isSyncing = false;
     }
@@ -137,7 +164,9 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
   String _signature({
     required String baseUrl,
     required String model,
+    required String officialModel,
     required String apiKey,
+    required CodexLocalAuthMode localAuthMode,
     required String remoteBridgeUrl,
     required String remoteBridgeToken,
     required String remoteCwd,
@@ -146,7 +175,9 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     return [
       baseUrl.trim(),
       model.trim(),
+      officialModel.trim(),
       apiKey.trim(),
+      localAuthMode.payloadValue,
       remoteEnabled ? 'remote' : 'local',
       remoteBridgeUrl.trim(),
       remoteBridgeToken.trim(),
@@ -158,7 +189,9 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     return _signature(
       baseUrl: _baseUrlController.text,
       model: _modelController.text,
+      officialModel: _officialModelController.text,
       apiKey: _apiKeyController.text,
+      localAuthMode: _localAuthMode,
       remoteBridgeUrl: _bridgeUrlController.text,
       remoteBridgeToken: _bridgeTokenController.text,
       remoteCwd: _bridgeCwdController.text,
@@ -169,7 +202,8 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
   bool get _hasAnyLocalInput =>
       _baseUrlController.text.trim().isNotEmpty ||
       _modelController.text.trim().isNotEmpty ||
-      _apiKeyController.text.trim().isNotEmpty;
+      _apiKeyController.text.trim().isNotEmpty ||
+      _officialModelController.text.trim().isNotEmpty;
 
   bool get _hasAnyRemoteInput =>
       _bridgeUrlController.text.trim().isNotEmpty ||
@@ -177,9 +211,10 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       _bridgeCwdController.text.trim().isNotEmpty;
 
   bool get _hasCompleteLocalInput =>
-      _baseUrlController.text.trim().isNotEmpty &&
-      _modelController.text.trim().isNotEmpty &&
-      _apiKeyController.text.trim().isNotEmpty;
+      _isChatGptMode ||
+      (_baseUrlController.text.trim().isNotEmpty &&
+          _modelController.text.trim().isNotEmpty &&
+          _apiKeyController.text.trim().isNotEmpty);
 
   bool get _hasCompleteRemoteInput =>
       _bridgeUrlController.text.trim().isNotEmpty &&
@@ -201,8 +236,14 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     _saveDebounce?.cancel();
     final signature = _currentSignature();
     final anyInput = _hasAnyLocalInput || _hasAnyRemoteInput || _remoteEnabled;
+    final apiModelRequestSource = _apiModelRequestSource;
     setState(() {
       _error = null;
+      if (_apiModelOptionsSource != null &&
+          _apiModelOptionsSource != apiModelRequestSource) {
+        _apiModelOptionsSource = null;
+        _apiModelOptions = const <String>[];
+      }
       if (_isRemoteIncomplete) {
         _status = _localeText(
           zh: '远程 Bridge URL 与远程工作目录填写完整后将自动保存。',
@@ -212,10 +253,10 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         _status = null;
       } else if (!_hasCompleteInput) {
         _status = _localeText(
-          zh: _remoteEnabled ? '填写完整后将自动保存。' : '本地配置填写完整后将自动保存。',
+          zh: _remoteEnabled ? '填写完整后将自动保存。' : '自定义 API 配置填写完整后将自动保存。',
           en: _remoteEnabled
               ? 'Complete all fields to autosave.'
-              : 'Complete the local config to autosave.',
+              : 'Complete the custom API config to autosave.',
         );
       } else if (signature == _lastSavedSignature) {
         _status = _localeText(zh: '已自动保存。', en: 'Autosaved.');
@@ -226,6 +267,24 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     if (_hasCompleteInput && signature != _lastSavedSignature) {
       _scheduleAutoSave();
     }
+  }
+
+  void _setLocalAuthMode(CodexLocalAuthMode value) {
+    if (_localAuthMode == value || _isSaving) return;
+    setState(() {
+      _localAuthMode = value;
+      _error = null;
+      _status = value == CodexLocalAuthMode.chatgpt
+          ? _localeText(
+              zh: '将切换到 ChatGPT 账号模式。',
+              en: 'Switching to ChatGPT account mode.',
+            )
+          : _localeText(
+              zh: '将切换到自定义 API 模式。',
+              en: 'Switching to custom API mode.',
+            );
+    });
+    _handleEdited();
   }
 
   void _setRemoteEnabled(bool value) {
@@ -267,6 +326,8 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       setState(() {
         _codexHome = config.codexHome ?? _defaultCodexHome;
         _runtime = config.runtime ?? 'local';
+        _apiModelOptionsSource = null;
+        _apiModelOptions = const <String>[];
         _isLoading = false;
         _error = null;
         _status = null;
@@ -284,10 +345,10 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     }
   }
 
-  Future<void> _saveConfig() async {
-    if (_isSaving) return;
+  Future<bool> _saveConfig() async {
+    if (_isSaving) return false;
     if (_isRemoteIncomplete || !_hasCompleteInput) {
-      if (!mounted) return;
+      if (!mounted) return false;
       setState(() {
         _status = _isRemoteIncomplete
             ? _localeText(
@@ -301,7 +362,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                     : 'Complete the local config to autosave.',
               );
       });
-      return;
+      return false;
     }
 
     final savingSignature = _currentSignature();
@@ -309,7 +370,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
       if (mounted) {
         setState(() => _status = _localeText(zh: '已自动保存。', en: 'Autosaved.'));
       }
-      return;
+      return true;
     }
 
     setState(() {
@@ -322,16 +383,20 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         baseUrl: _baseUrlController.text.trim(),
         model: _modelController.text.trim(),
         apiKey: _apiKeyController.text.trim(),
+        officialModel: _officialModelController.text.trim(),
+        localAuthMode: _localAuthMode,
         remoteEnabled: _remoteEnabled,
         remoteBridgeUrl: _bridgeUrlController.text.trim(),
         remoteBridgeToken: _bridgeTokenController.text.trim(),
         remoteCwd: _bridgeCwdController.text.trim(),
       );
-      if (!mounted) return;
+      if (!mounted) return false;
       final savedSignature = _signature(
         baseUrl: saved.baseUrl,
         model: saved.model,
+        officialModel: saved.officialModel,
         apiKey: saved.apiKey,
+        localAuthMode: saved.localAuthMode,
         remoteBridgeUrl: saved.remoteBridgeUrl,
         remoteBridgeToken: saved.remoteBridgeToken,
         remoteCwd: saved.remoteCwd,
@@ -349,15 +414,20 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
             ? _localeText(
                 zh: saved.remoteEnabled
                     ? '已自动保存，Codex 模式将使用远程 PC Bridge。'
-                    : '已自动保存，将使用本地 Alpine Codex。',
+                    : saved.localAuthMode == CodexLocalAuthMode.chatgpt
+                    ? '已自动保存，将使用本地 ChatGPT 账号。'
+                    : '已自动保存，将使用本地自定义 API。',
                 en: saved.remoteEnabled
                     ? 'Autosaved. Codex mode will use the remote PC Bridge.'
-                    : 'Autosaved. Codex mode will use local Alpine Codex.',
+                    : saved.localAuthMode == CodexLocalAuthMode.chatgpt
+                    ? 'Autosaved. Local Codex will use the ChatGPT account.'
+                    : 'Autosaved. Local Codex will use the custom API.',
               )
             : _localeText(zh: '即将自动保存...', en: 'Autosave pending...');
       });
+      return true;
     } catch (error) {
-      if (!mounted) return;
+      if (!mounted) return false;
       setState(() {
         _error = _localeText(
           zh: 'Codex 配置保存失败：$error',
@@ -365,6 +435,7 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         );
         _status = null;
       });
+      return false;
     } finally {
       if (mounted) {
         setState(() => _isSaving = false);
@@ -436,6 +507,203 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     }
   }
 
+  Future<void> _fetchApiModels() async {
+    if (_isFetchingApiModels) return;
+    final baseUrl = _baseUrlController.text.trim();
+    final apiKey = _apiKeyController.text.trim();
+    if (baseUrl.isEmpty || apiKey.isEmpty) {
+      showToast(
+        _localeText(
+          zh: '请先填写 Base URL 和 API Key。',
+          en: 'Enter the Base URL and API Key first.',
+        ),
+        type: ToastType.warning,
+      );
+      return;
+    }
+    final requestSource = _apiModelRequestSource;
+    setState(() => _isFetchingApiModels = true);
+    try {
+      final response = await CodexAppServerService.listLocalApiModels(
+        baseUrl: baseUrl,
+        apiKey: apiKey,
+      );
+      final ids = _extractCodexModelIds(response);
+      if (!mounted) return;
+      if (_apiModelRequestSource != requestSource) return;
+      setState(() {
+        _apiModelOptionsSource = requestSource;
+        _apiModelOptions = ids;
+      });
+      showToast(
+        ids.isEmpty
+            ? _localeText(
+                zh: '接口未返回模型，可继续手动输入模型 ID。',
+                en: 'No models returned. You can still enter a model ID.',
+              )
+            : _localeText(
+                zh: '已拉取 ${ids.length} 个模型。',
+                en: 'Fetched ${ids.length} models.',
+              ),
+        type: ids.isEmpty ? ToastType.warning : ToastType.success,
+      );
+    } catch (error) {
+      if (!mounted) return;
+      showToast(
+        _localeText(
+          zh: '模型列表拉取失败：$error，可继续手动输入模型 ID。',
+          en: 'Failed to fetch models: $error. You can enter a model ID manually.',
+        ),
+        type: ToastType.error,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isFetchingApiModels = false);
+      }
+    }
+  }
+
+  Future<void> _loadOfficialModels() async {
+    if (_isLoadingOfficialModels || _isSaving || _remoteEnabled) return;
+    setState(() => _isLoadingOfficialModels = true);
+    try {
+      if (!await _saveConfig()) return;
+      await CodexAppServerService.connect();
+      final response = await CodexAppServerService.listModels();
+      final models = _extractCodexModelIds(response);
+      if (!mounted) return;
+      setState(() => _officialModelOptions = models);
+      showToast(
+        models.isEmpty
+            ? _localeText(
+                zh: 'Codex 未返回可选官方模型。',
+                en: 'Codex returned no selectable official models.',
+              )
+            : _localeText(
+                zh: '已加载 ${models.length} 个官方模型。',
+                en: 'Loaded ${models.length} official models.',
+              ),
+        type: models.isEmpty ? ToastType.warning : ToastType.success,
+      );
+    } catch (error) {
+      if (!mounted) return;
+      showToast(
+        _localeText(
+          zh: '官方模型加载失败：$error',
+          en: 'Failed to load official models: $error',
+        ),
+        type: ToastType.error,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isLoadingOfficialModels = false);
+      }
+    }
+  }
+
+  List<String> _extractCodexModelIds(Map<String, dynamic> response) {
+    final raw = response['data'] ?? response['models'] ?? response['items'];
+    if (raw is! List) return const <String>[];
+    final ids = <String>{};
+    for (final item in raw) {
+      if (item is! Map) continue;
+      final id = (item['id'] ?? item['model'])?.toString().trim() ?? '';
+      if (id.isNotEmpty) ids.add(id);
+    }
+    return ids.toList(growable: false);
+  }
+
+  Future<void> _startChatGptLogin() async {
+    if (_isStartingLogin || _isSaving || _remoteEnabled) return;
+    setState(() => _isStartingLogin = true);
+    try {
+      if (!await _saveConfig()) return;
+      await CodexAppServerService.connect();
+      final response = await CodexAppServerService.startLogin(
+        type: CodexLoginType.chatgptDeviceCode,
+      );
+      final loginId = response['loginId']?.toString().trim() ?? '';
+      final verificationUrl =
+          response['verificationUrl']?.toString().trim() ?? '';
+      final userCode = response['userCode']?.toString().trim() ?? '';
+      if (verificationUrl.isEmpty || userCode.isEmpty) {
+        throw StateError(
+          'Codex did not return a device verification URL and code.',
+        );
+      }
+      if (!mounted) return;
+      unawaited(
+        launchUrlString(verificationUrl, mode: LaunchMode.externalApplication),
+      );
+      final shouldRefresh = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) => AlertDialog(
+          title: Text(_localeText(zh: '登录 ChatGPT', en: 'Sign in to ChatGPT')),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                _localeText(
+                  zh: '浏览器打开后输入以下设备码：',
+                  en: 'Enter this device code in the browser:',
+                ),
+              ),
+              const SizedBox(height: 12),
+              SelectableText(
+                userCode,
+                key: const Key('codex-chatgpt-device-code'),
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 2,
+                ),
+              ),
+              const SizedBox(height: 8),
+              SelectableText(verificationUrl),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(_localeText(zh: '取消', en: 'Cancel')),
+            ),
+            TextButton.icon(
+              onPressed: () async {
+                await Clipboard.setData(ClipboardData(text: userCode));
+              },
+              icon: const Icon(Icons.copy_rounded, size: 17),
+              label: Text(_localeText(zh: '复制设备码', en: 'Copy code')),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(_localeText(zh: '已完成登录', en: 'Signed in')),
+            ),
+          ],
+        ),
+      );
+      if (shouldRefresh == true && mounted) {
+        unawaited(_loadOfficialModels());
+      } else if (loginId.isNotEmpty) {
+        await CodexAppServerService.cancelLogin(loginId: loginId);
+      }
+    } catch (error) {
+      if (!mounted) return;
+      showToast(
+        _localeText(
+          zh: 'ChatGPT 登录启动失败：$error',
+          en: 'Failed to start ChatGPT login: $error',
+        ),
+        type: ToastType.error,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isStartingLogin = false);
+      }
+    }
+  }
+
   Future<void> _openRemoteDirectoryPicker() async {
     final bridgeUrl = _bridgeUrlController.text.trim();
     if (bridgeUrl.isEmpty) {
@@ -498,12 +766,14 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
     required String hint,
     TextInputType keyboardType = TextInputType.text,
     bool obscureText = false,
+    bool readOnly = false,
     Widget? suffixIcon,
   }) {
     return TextField(
       key: key,
       controller: controller,
       obscureText: obscureText,
+      readOnly: readOnly,
       keyboardType: keyboardType,
       textInputAction: TextInputAction.next,
       style: TextStyle(
@@ -524,6 +794,142 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
         focusedErrorBorder: _borderlessInputBorder,
         isDense: true,
         suffixIcon: suffixIcon,
+      ),
+    );
+  }
+
+  Widget _buildModelField({
+    required Key fieldKey,
+    required Key refreshKey,
+    required Key menuKey,
+    required TextEditingController controller,
+    required String label,
+    required String hint,
+    required List<String> options,
+    required bool loading,
+    required VoidCallback onRefresh,
+    bool readOnly = false,
+  }) {
+    return _buildTextField(
+      key: fieldKey,
+      controller: controller,
+      label: label,
+      hint: hint,
+      readOnly: readOnly,
+      suffixIcon: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            key: refreshKey,
+            tooltip: _localeText(zh: '拉取模型列表', en: 'Fetch models'),
+            onPressed: loading ? null : onRefresh,
+            icon: loading
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.refresh_rounded, size: 18),
+          ),
+          PopupMenuButton<String>(
+            key: menuKey,
+            tooltip: _localeText(zh: '选择模型', en: 'Choose model'),
+            enabled: options.isNotEmpty,
+            icon: const Icon(Icons.arrow_drop_down_rounded, size: 22),
+            onSelected: (model) {
+              _setControllerText(controller, model);
+              _handleEdited();
+            },
+            itemBuilder: (context) => options
+                .map(
+                  (model) => PopupMenuItem<String>(
+                    value: model,
+                    child: Text(
+                      model,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                )
+                .toList(growable: false),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLocalAuthModeSelector() {
+    return Row(
+      children: [
+        Expanded(
+          child: ChoiceChip(
+            key: const Key('codex-local-auth-chatgpt'),
+            label: Text(_localeText(zh: 'ChatGPT 账号', en: 'ChatGPT account')),
+            selected: _localAuthMode == CodexLocalAuthMode.chatgpt,
+            onSelected: _isSaving
+                ? null
+                : (_) => _setLocalAuthMode(CodexLocalAuthMode.chatgpt),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: ChoiceChip(
+            key: const Key('codex-local-auth-api'),
+            label: Text(_localeText(zh: '自定义 API', en: 'Custom API')),
+            selected: _localAuthMode == CodexLocalAuthMode.api,
+            onSelected: _isSaving
+                ? null
+                : (_) => _setLocalAuthMode(CodexLocalAuthMode.api),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChatGptAccountCard() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: _mutedSurfaceColor,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _localeText(
+              zh: '通过 Codex CLI 的设备码流程登录或切换 ChatGPT 账号，使用套餐包含的 Codex 用量。',
+              en: 'Use the Codex CLI device-code flow to sign in or switch ChatGPT accounts and use Codex access included with the plan.',
+            ),
+            style: TextStyle(
+              color: _secondaryTextColor,
+              fontSize: 12,
+              height: 1.4,
+              fontFamily: 'PingFang SC',
+            ),
+          ),
+          const SizedBox(height: 10),
+          FilledButton.icon(
+            key: const Key('codex-chatgpt-login-button'),
+            onPressed: _isStartingLogin || _isSaving || _remoteEnabled
+                ? null
+                : () => unawaited(_startChatGptLogin()),
+            icon: _isStartingLogin
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.login_rounded, size: 17),
+            label: Text(
+              _localeText(
+                zh: '登录或切换 ChatGPT 账号',
+                en: 'Sign in or switch account',
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -804,44 +1210,82 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                           ),
                         ),
                         const SizedBox(height: 8),
-                        _buildTextField(
-                          key: const Key('codex-config-base-url-field'),
-                          controller: _baseUrlController,
-                          label: 'Base URL',
-                          hint: 'https://bring_your_own_key.endpoint/v1',
-                          keyboardType: TextInputType.url,
-                        ),
+                        _buildLocalAuthModeSelector(),
                         const SizedBox(height: 12),
-                        _buildTextField(
-                          key: const Key('codex-config-model-field'),
-                          controller: _modelController,
-                          label: 'Model',
-                          hint: _defaultCodexModel,
-                        ),
-                        const SizedBox(height: 12),
-                        _buildTextField(
-                          key: const Key('codex-config-api-key-field'),
-                          controller: _apiKeyController,
-                          label: 'OPENAI_API_KEY',
-                          hint: 'your_own_key',
-                          obscureText: _obscureApiKey,
-                          suffixIcon: IconButton(
-                            tooltip: _obscureApiKey
-                                ? _localeText(zh: '显示密钥', en: 'Show key')
-                                : _localeText(zh: '隐藏密钥', en: 'Hide key'),
-                            onPressed: () {
-                              setState(() {
-                                _obscureApiKey = !_obscureApiKey;
-                              });
-                            },
-                            icon: Icon(
-                              _obscureApiKey
-                                  ? Icons.visibility_outlined
-                                  : Icons.visibility_off_outlined,
-                              size: 18,
+                        if (_isChatGptMode) ...[
+                          _buildChatGptAccountCard(),
+                          const SizedBox(height: 12),
+                          _buildModelField(
+                            fieldKey: const Key(
+                              'codex-config-official-model-field',
+                            ),
+                            refreshKey: const Key(
+                              'codex-config-official-model-refresh',
+                            ),
+                            menuKey: const Key(
+                              'codex-config-official-model-menu',
+                            ),
+                            controller: _officialModelController,
+                            label: _localeText(
+                              zh: '官方 Codex 模型',
+                              en: 'Official Codex model',
+                            ),
+                            hint: _defaultCodexModel,
+                            options: _officialModelOptions,
+                            loading: _isLoadingOfficialModels,
+                            onRefresh: () => unawaited(_loadOfficialModels()),
+                            readOnly: true,
+                          ),
+                        ] else ...[
+                          _buildTextField(
+                            key: const Key('codex-config-base-url-field'),
+                            controller: _baseUrlController,
+                            label: 'Base URL',
+                            hint: 'https://bring_your_own_key.endpoint/v1',
+                            keyboardType: TextInputType.url,
+                          ),
+                          const SizedBox(height: 12),
+                          _buildTextField(
+                            key: const Key('codex-config-api-key-field'),
+                            controller: _apiKeyController,
+                            label: 'API Key',
+                            hint: 'your_own_key',
+                            obscureText: _obscureApiKey,
+                            suffixIcon: IconButton(
+                              tooltip: _obscureApiKey
+                                  ? _localeText(zh: '显示密钥', en: 'Show key')
+                                  : _localeText(zh: '隐藏密钥', en: 'Hide key'),
+                              onPressed: () {
+                                setState(() {
+                                  _obscureApiKey = !_obscureApiKey;
+                                });
+                              },
+                              icon: Icon(
+                                _obscureApiKey
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                                size: 18,
+                              ),
                             ),
                           ),
-                        ),
+                          const SizedBox(height: 12),
+                          _buildModelField(
+                            fieldKey: const Key('codex-config-model-field'),
+                            refreshKey: const Key(
+                              'codex-config-api-model-refresh',
+                            ),
+                            menuKey: const Key('codex-config-api-model-menu'),
+                            controller: _modelController,
+                            label: _localeText(
+                              zh: '模型 ID（可手动输入）',
+                              en: 'Model ID (editable)',
+                            ),
+                            hint: _defaultCodexModel,
+                            options: _apiModelOptions,
+                            loading: _isFetchingApiModels,
+                            onRefresh: () => unawaited(_fetchApiModels()),
+                          ),
+                        ],
                         const SizedBox(height: 12),
                         Container(
                           width: double.infinity,
@@ -862,8 +1306,8 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                               Expanded(
                                 child: Text(
                                   _localeText(
-                                    zh: '远程开关关闭时使用本地 Codex；配置修改会自动保存并断开当前 Codex 会话。',
-                                    en: 'When the remote switch is off, local Codex is used. Changes autosave and disconnect the current Codex session.',
+                                    zh: '远程开关关闭时使用本地 Codex；官网账号与自定义 API 凭证相互隔离。配置修改会自动保存并断开当前 Codex 会话。',
+                                    en: 'When the remote switch is off, local Codex is used. ChatGPT and custom API credentials stay separate. Changes autosave and disconnect the current Codex session.',
                                   ),
                                   style: TextStyle(
                                     color: _secondaryTextColor,

--- a/ui/lib/services/codex_app_server_service.dart
+++ b/ui/lib/services/codex_app_server_service.dart
@@ -3,6 +3,31 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
+enum CodexLocalAuthMode {
+  chatgpt('chatgpt'),
+  api('api');
+
+  const CodexLocalAuthMode(this.payloadValue);
+
+  final String payloadValue;
+
+  static CodexLocalAuthMode fromValue(Object? value) {
+    return value?.toString().trim().toLowerCase() == chatgpt.payloadValue
+        ? chatgpt
+        : api;
+  }
+}
+
+enum CodexLoginType {
+  chatgpt('chatgpt'),
+  chatgptDeviceCode('chatgptDeviceCode'),
+  apiKey('apiKey');
+
+  const CodexLoginType(this.payloadValue);
+
+  final String payloadValue;
+}
+
 class CodexStatus {
   const CodexStatus({
     required this.connected,
@@ -12,6 +37,7 @@ class CodexStatus {
     this.codexHome,
     this.cwd,
     this.runtime,
+    this.localAuthMode = CodexLocalAuthMode.api,
     this.remoteEnabled = false,
     this.remoteBridgeUrl,
     this.remoteCwd,
@@ -29,6 +55,7 @@ class CodexStatus {
   final String? codexHome;
   final String? cwd;
   final String? runtime;
+  final CodexLocalAuthMode localAuthMode;
   final bool remoteEnabled;
   final String? remoteBridgeUrl;
   final String? remoteCwd;
@@ -50,6 +77,7 @@ class CodexStatus {
       codexHome: _stringOrNull(source['codexHome']),
       cwd: _stringOrNull(source['cwd']),
       runtime: _stringOrNull(source['runtime']),
+      localAuthMode: CodexLocalAuthMode.fromValue(source['localAuthMode']),
       remoteEnabled: source['remoteEnabled'] == true,
       remoteBridgeUrl: _stringOrNull(source['remoteBridgeUrl']),
       remoteCwd: _stringOrNull(source['remoteCwd']),
@@ -64,11 +92,49 @@ class CodexStatus {
   static const disconnected = CodexStatus(connected: false, ready: false);
 }
 
+String codexModelSourceKey(CodexStatus status) {
+  if (status.runtime == 'remote' || status.remoteEnabled) {
+    return 'remote';
+  }
+  return 'local-${status.localAuthMode.payloadValue}';
+}
+
+String? selectCodexRequestModel({
+  required CodexStatus status,
+  required String? overrideModel,
+  required String? activeModel,
+  required String? scopedModel,
+  required String? configuredApiModel,
+  required bool activeModelSourceMatches,
+}) {
+  final isLocalApi =
+      status.runtime != 'remote' &&
+      !status.remoteEnabled &&
+      status.localAuthMode == CodexLocalAuthMode.api;
+  if (isLocalApi) {
+    return _stringOrNull(configuredApiModel);
+  }
+  return _stringOrNull(
+    overrideModel ?? (activeModelSourceMatches ? activeModel : scopedModel),
+  );
+}
+
+bool isCurrentCodexModelLoad({
+  required int requestId,
+  required int activeRequestId,
+  required String requestSource,
+  required String currentSource,
+}) {
+  return requestId == activeRequestId && requestSource == currentSource;
+}
+
 class CodexLocalConfig {
   const CodexLocalConfig({
     required this.baseUrl,
     required this.model,
     required this.apiKey,
+    this.officialModel = '',
+    this.localAuthMode = CodexLocalAuthMode.api,
     this.codexHome,
     this.remoteEnabled = false,
     this.remoteBridgeUrl = '',
@@ -81,6 +147,8 @@ class CodexLocalConfig {
   final String baseUrl;
   final String model;
   final String apiKey;
+  final String officialModel;
+  final CodexLocalAuthMode localAuthMode;
   final String? codexHome;
   final bool remoteEnabled;
   final String remoteBridgeUrl;
@@ -95,6 +163,8 @@ class CodexLocalConfig {
       baseUrl: _stringOrNull(source['baseUrl']) ?? '',
       model: _stringOrNull(source['model']) ?? '',
       apiKey: _stringOrNull(source['apiKey']) ?? '',
+      officialModel: _stringOrNull(source['officialModel']) ?? '',
+      localAuthMode: CodexLocalAuthMode.fromValue(source['localAuthMode']),
       codexHome: _stringOrNull(source['codexHome']),
       remoteEnabled: source['remoteEnabled'] == true,
       remoteBridgeUrl: _stringOrNull(source['remoteBridgeUrl']) ?? '',
@@ -434,6 +504,8 @@ class CodexAppServerService {
     required String baseUrl,
     required String model,
     required String apiKey,
+    String? officialModel,
+    CodexLocalAuthMode? localAuthMode,
     bool remoteEnabled = false,
     String remoteBridgeUrl = '',
     String remoteBridgeToken = '',
@@ -443,12 +515,24 @@ class CodexAppServerService {
       'baseUrl': baseUrl.trim(),
       'model': model.trim(),
       'apiKey': apiKey.trim(),
+      if (officialModel != null) 'officialModel': officialModel.trim(),
+      if (localAuthMode != null) 'localAuthMode': localAuthMode.payloadValue,
       'remoteEnabled': remoteEnabled,
       'remoteBridgeUrl': remoteBridgeUrl.trim(),
       'remoteBridgeToken': remoteBridgeToken.trim(),
       'remoteCwd': remoteCwd.trim(),
     });
     return CodexLocalConfig.fromMap(result);
+  }
+
+  static Future<Map<String, dynamic>> listLocalApiModels({
+    required String baseUrl,
+    required String apiKey,
+  }) {
+    return _invokeMap('config/local/models', {
+      'baseUrl': baseUrl.trim(),
+      'apiKey': apiKey.trim(),
+    });
   }
 
   static Future<Map<String, dynamic>> testRemoteConfig({
@@ -581,12 +665,17 @@ class CodexAppServerService {
     return _invokeMap('account/read');
   }
 
-  static Future<Map<String, dynamic>> startLogin({String type = 'chatgpt'}) {
-    return _invokeMap('account/login/start', {'type': type});
+  static Future<Map<String, dynamic>> startLogin({
+    CodexLoginType type = CodexLoginType.chatgpt,
+  }) {
+    return _invokeMap('account/login/start', {'type': type.payloadValue});
   }
 
-  static Future<Map<String, dynamic>> cancelLogin() {
-    return _invokeMap('account/login/cancel');
+  static Future<Map<String, dynamic>> cancelLogin({String? loginId}) {
+    return _invokeMap('account/login/cancel', {
+      if (loginId != null && loginId.trim().isNotEmpty)
+        'loginId': loginId.trim(),
+    });
   }
 
   static Future<Map<String, dynamic>> respondToApproval({

--- a/ui/test/features/home/pages/scene_model_setting/scene_model_setting_page_test.dart
+++ b/ui/test/features/home/pages/scene_model_setting/scene_model_setting_page_test.dart
@@ -51,9 +51,15 @@ void main() {
 
   late Map<String, dynamic> savedVoiceConfig;
   late Map<String, dynamic> savedOperationConfig;
+  late Map<String, dynamic> codexReadConfig;
   late Map<String, dynamic>? savedCodexConfig;
+  late List<Map<String, dynamic>> fetchedProviderModels;
+  late Map<String, dynamic>? fetchProviderModelsArguments;
+  late bool failCodexWrite;
   late int getSceneModelCatalogCount;
   late int codexWriteCount;
+  late int codexConnectCount;
+  late int codexModelListCount;
 
   setUp(() async {
     AssistsMessageService.initialize();
@@ -61,7 +67,20 @@ void main() {
     await StorageService.init();
     getSceneModelCatalogCount = 0;
     codexWriteCount = 0;
+    codexConnectCount = 0;
+    codexModelListCount = 0;
+    failCodexWrite = false;
     savedCodexConfig = null;
+    fetchedProviderModels = <Map<String, dynamic>>[];
+    fetchProviderModelsArguments = null;
+    codexReadConfig = <String, dynamic>{
+      'baseUrl': 'https://example.com/v1',
+      'model': 'gpt-5.5',
+      'officialModel': 'gpt-5.5',
+      'apiKey': 'test-key',
+      'localAuthMode': 'api',
+      'codexHome': '/root/.codex',
+    };
     savedVoiceConfig = <String, dynamic>{
       'autoPlay': false,
       'voiceId': 'default_zh',
@@ -185,13 +204,11 @@ void main() {
         .setMockMethodCallHandler(codexChannel, (call) async {
           switch (call.method) {
             case 'config/local/read':
-              return <String, dynamic>{
-                'baseUrl': 'https://example.com/v1',
-                'model': 'gpt-5.5',
-                'apiKey': 'test-key',
-                'codexHome': '/root/.codex',
-              };
+              return codexReadConfig;
             case 'config/local/write':
+              if (failCodexWrite) {
+                throw PlatformException(code: 'write_failed');
+              }
               savedCodexConfig = Map<String, dynamic>.from(
                 (call.arguments as Map).cast<String, dynamic>(),
               );
@@ -200,6 +217,26 @@ void main() {
                 ...savedCodexConfig!,
                 'codexHome': '/root/.codex',
               };
+            case 'connect':
+              codexConnectCount += 1;
+              return <String, dynamic>{
+                'connected': true,
+                'runtime': 'local',
+                'localAuthMode': codexReadConfig['localAuthMode'],
+              };
+            case 'model/list':
+              codexModelListCount += 1;
+              return <String, dynamic>{
+                'data': <Map<String, dynamic>>[
+                  <String, dynamic>{'id': 'gpt-5.5-codex'},
+                  <String, dynamic>{'id': 'gpt-5.6-codex'},
+                ],
+              };
+            case 'config/local/models':
+              fetchProviderModelsArguments = Map<String, dynamic>.from(
+                (call.arguments as Map).cast<String, dynamic>(),
+              );
+              return <String, dynamic>{'models': fetchedProviderModels};
             default:
               return null;
           }
@@ -342,11 +379,146 @@ void main() {
       'baseUrl': 'https://new.example/v1',
       'model': 'gpt-5.6',
       'apiKey': 'new-key',
+      'officialModel': 'gpt-5.5',
+      'localAuthMode': 'api',
       'remoteEnabled': false,
       'remoteBridgeUrl': '',
       'remoteBridgeToken': '',
       'remoteCwd': '',
     });
-    expect(find.text('已自动保存，将使用本地 Alpine Codex。'), findsOneWidget);
+    expect(find.text('已自动保存，将使用本地自定义 API。'), findsOneWidget);
+  });
+
+  testWidgets('codex custom API fetches models and keeps model ID editable', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1080, 2200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    fetchedProviderModels = <Map<String, dynamic>>[
+      <String, dynamic>{'id': 'custom-codex-a'},
+      <String, dynamic>{'id': 'custom-codex-b'},
+    ];
+
+    await tester.pumpWidget(buildTestApp(const CodexSettingPage()));
+    await tester.pumpAndSettle();
+
+    final modelField = find.byKey(const Key('codex-config-model-field'));
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const Key('codex-config-base-url-field')),
+          )
+          .controller
+          ?.text,
+      'https://example.com/v1',
+    );
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const Key('codex-config-api-key-field')),
+          )
+          .controller
+          ?.text,
+      'test-key',
+    );
+    expect(tester.widget<TextField>(modelField).readOnly, isFalse);
+
+    await tester.tap(find.byKey(const Key('codex-config-api-model-refresh')));
+    await tester.pumpAndSettle();
+
+    expect(fetchProviderModelsArguments?['baseUrl'], 'https://example.com/v1');
+    expect(fetchProviderModelsArguments?['apiKey'], 'test-key');
+
+    await tester.tap(find.byKey(const Key('codex-config-api-model-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('custom-codex-b'));
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(modelField).controller?.text,
+      'custom-codex-b',
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('codex-config-base-url-field')),
+      'https://other.example.com/v1',
+    );
+    await tester.pump();
+
+    expect(
+      tester
+          .widget<PopupMenuButton<String>>(
+            find.byKey(const Key('codex-config-api-model-menu')),
+          )
+          .enabled,
+      isFalse,
+    );
+  });
+
+  testWidgets('codex ChatGPT mode uses the official model catalog', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1080, 2200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    codexReadConfig = <String, dynamic>{
+      ...codexReadConfig,
+      'localAuthMode': 'chatgpt',
+      'officialModel': 'gpt-5.5-codex',
+    };
+
+    await tester.pumpWidget(buildTestApp(const CodexSettingPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('codex-chatgpt-login-button')), findsOneWidget);
+    expect(find.byKey(const Key('codex-config-base-url-field')), findsNothing);
+    expect(find.byKey(const Key('codex-config-api-key-field')), findsNothing);
+
+    final officialField = find.byKey(
+      const Key('codex-config-official-model-field'),
+    );
+    expect(tester.widget<TextField>(officialField).readOnly, isTrue);
+
+    await tester.tap(
+      find.byKey(const Key('codex-config-official-model-refresh')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('codex-config-official-model-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('gpt-5.6-codex'));
+    await tester.pump();
+
+    expect(
+      tester.widget<TextField>(officialField).controller?.text,
+      'gpt-5.6-codex',
+    );
+  });
+
+  testWidgets('official model loading stops when auth mode save fails', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1080, 2200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    failCodexWrite = true;
+
+    await tester.pumpWidget(buildTestApp(const CodexSettingPage()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('codex-local-auth-chatgpt')));
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const Key('codex-config-official-model-refresh')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(codexWriteCount, 0);
+    expect(codexConnectCount, 0);
+    expect(codexModelListCount, 0);
+    expect(find.textContaining('Codex 配置保存失败'), findsOneWidget);
   });
 }

--- a/ui/test/services/codex_app_server_service_test.dart
+++ b/ui/test/services/codex_app_server_service_test.dart
@@ -142,6 +142,8 @@ void main() {
       return <String, dynamic>{
         'baseUrl': 'https://example.com/v1',
         'model': 'gpt-5.5',
+        'officialModel': 'gpt-5.5-codex',
+        'localAuthMode': 'chatgpt',
         'apiKey': 'key',
         'codexHome': '/root/.codex',
       };
@@ -152,10 +154,14 @@ void main() {
       baseUrl: ' https://example.com/v1 ',
       model: ' gpt-5.5 ',
       apiKey: ' key ',
+      officialModel: ' gpt-5.5-codex ',
+      localAuthMode: CodexLocalAuthMode.chatgpt,
     );
 
     expect(read.baseUrl, 'https://example.com/v1');
     expect(read.model, 'gpt-5.5');
+    expect(read.officialModel, 'gpt-5.5-codex');
+    expect(read.localAuthMode, CodexLocalAuthMode.chatgpt);
     expect(read.apiKey, 'key');
     expect(written.codexHome, '/root/.codex');
     expect(calls.map((call) => call.method), [
@@ -166,11 +172,127 @@ void main() {
       'baseUrl': 'https://example.com/v1',
       'model': 'gpt-5.5',
       'apiKey': 'key',
+      'officialModel': 'gpt-5.5-codex',
+      'localAuthMode': 'chatgpt',
       'remoteEnabled': false,
       'remoteBridgeUrl': '',
       'remoteBridgeToken': '',
       'remoteCwd': '',
     });
+  });
+
+  test('forwards ChatGPT device-code login lifecycle', () async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return <String, dynamic>{'ok': true};
+    });
+
+    await CodexAppServerService.startLogin(
+      type: CodexLoginType.chatgptDeviceCode,
+    );
+    await CodexAppServerService.cancelLogin(loginId: 'login-1');
+
+    expect(calls.map((call) => call.method), [
+      'account/login/start',
+      'account/login/cancel',
+    ]);
+    expect(calls[0].arguments, {'type': 'chatgptDeviceCode'});
+    expect(calls[1].arguments, {'loginId': 'login-1'});
+  });
+
+  test('forwards custom Codex model list credentials', () async {
+    MethodCall? capturedCall;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      capturedCall = call;
+      return <String, dynamic>{'models': <dynamic>[]};
+    });
+
+    await CodexAppServerService.listLocalApiModels(
+      baseUrl: ' https://example.com/v1 ',
+      apiKey: ' secret ',
+    );
+
+    expect(capturedCall?.method, 'config/local/models');
+    expect(capturedCall?.arguments, {
+      'baseUrl': 'https://example.com/v1',
+      'apiKey': 'secret',
+    });
+  });
+
+  test('keeps Codex model sources separate', () {
+    expect(
+      codexModelSourceKey(
+        const CodexStatus(
+          connected: true,
+          ready: true,
+          runtime: 'remote',
+          localAuthMode: CodexLocalAuthMode.api,
+        ),
+      ),
+      'remote',
+    );
+    expect(
+      codexModelSourceKey(
+        const CodexStatus(
+          connected: true,
+          ready: true,
+          runtime: 'local',
+          localAuthMode: CodexLocalAuthMode.chatgpt,
+        ),
+      ),
+      'local-chatgpt',
+    );
+    expect(
+      codexModelSourceKey(
+        const CodexStatus(
+          connected: true,
+          ready: true,
+          runtime: 'local',
+          localAuthMode: CodexLocalAuthMode.api,
+        ),
+      ),
+      'local-api',
+    );
+  });
+
+  test('local API requests always use the configured model', () {
+    final model = selectCodexRequestModel(
+      status: const CodexStatus(
+        connected: true,
+        ready: true,
+        runtime: 'local',
+        localAuthMode: CodexLocalAuthMode.api,
+      ),
+      overrideModel: 'remote-override',
+      activeModel: 'chatgpt-active',
+      scopedModel: 'api-scoped',
+      configuredApiModel: 'api-current',
+      activeModelSourceMatches: true,
+    );
+
+    expect(model, 'api-current');
+  });
+
+  test('model load results are rejected after source changes', () {
+    expect(
+      isCurrentCodexModelLoad(
+        requestId: 4,
+        activeRequestId: 4,
+        requestSource: 'remote',
+        currentSource: 'local-api',
+      ),
+      isFalse,
+    );
+    expect(
+      isCurrentCodexModelLoad(
+        requestId: 5,
+        activeRequestId: 5,
+        requestSource: 'local-api',
+        currentSource: 'local-api',
+      ),
+      isTrue,
+    );
   });
 
   test(


### PR DESCRIPTION
## Summary
- add local Alpine Codex ChatGPT device-code sign-in using Codex file credentials and plan-based usage
- keep ChatGPT auth separate from custom API credentials, migrate legacy config, and remove the legacy API key from auth.json
- add official model loading plus custom /models discovery with editable model IDs, source-isolated preferences, and reconnect without restarting the app
- preserve remote Bridge behavior and browser login while limiting the new provider flow to local Codex

## Test plan
- Dart analyze on all modified Dart files: no issues
- Flutter target tests: 18 passed
- Kotlin CodexAppServerProtocolPayloadTest: 23 passed
- Full Flutter suite: 23 existing failures, matching the same 23 failures on upstream b157e16