### PR TITLE
本地 Alpine Codex 文件系统浏览与管理

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/terminal/AlpineFileSystemService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/AlpineFileSystemService.kt
@@ -169,13 +169,8 @@ class AlpineFileSystemService(context: Context) {
 
     suspend fun createFile(path: String): Map<String, Any?> {
         val normalizedPath = normalizeMutablePath(path)
-        val parent = parentPath(normalizedPath)
         execute(
-            """
-                set -eu
-                mkdir -p -- ${shellQuote(parent)}
-                [ -e ${shellQuote(normalizedPath)} ] || : > ${shellQuote(normalizedPath)}
-            """.trimIndent(),
+            buildCreateFileCommand(normalizedPath),
             "alpine-fs-touch",
             MUTATION_TIMEOUT_MS
         )
@@ -249,6 +244,10 @@ class AlpineFileSystemService(context: Context) {
 
         internal fun decodeEditableUtf8(bytes: ByteArray): String? {
             if (bytes.any { it == 0.toByte() }) return null
+            return decodeStrictUtf8(bytes)
+        }
+
+        private fun decodeStrictUtf8(bytes: ByteArray): String? {
             return runCatching {
                 StandardCharsets.UTF_8
                     .newDecoder()
@@ -293,6 +292,23 @@ class AlpineFileSystemService(context: Context) {
             """.trimIndent()
         }
 
+        internal fun buildCreateFileCommand(path: String): String {
+            val target = normalizeMutablePath(path)
+            return """
+                set -eu
+                target=${shellQuote(target)}
+                mkdir -p -- ${shellQuote(parentPath(target))}
+                if [ -e "${'$'}target" ] || [ -L "${'$'}target" ]; then
+                  printf "Target already exists: %s\n" "${'$'}target" >&2
+                  exit 73
+                fi
+                (
+                  set -C
+                  : > "${'$'}target"
+                )
+            """.trimIndent()
+        }
+
         internal fun buildMoveCommand(sourcePath: String, targetPath: String): String {
             val source = normalizeMutablePath(sourcePath)
             val target = normalizeMutablePath(targetPath)
@@ -324,6 +340,9 @@ class AlpineFileSystemService(context: Context) {
                 .mapNotNull { line ->
                     val fields = line.split('|', limit = 11)
                     if (fields.size != 11) return@mapNotNull null
+                    val path = decodeField(fields[8])
+                    val name = decodeField(fields[9])
+                    val hasValidUtf8Path = path != null && name != null
                     mapOf(
                         "isDirectory" to (fields[0] == "1"),
                         "isFile" to (fields[1] == "1"),
@@ -331,11 +350,14 @@ class AlpineFileSystemService(context: Context) {
                         "size" to (fields[3].toLongOrNull() ?: 0L),
                         "modifiedAt" to (fields[4].toLongOrNull() ?: 0L),
                         "mode" to fields[5],
-                        "readable" to (fields[6] == "1"),
-                        "writable" to (fields[7] == "1"),
-                        "path" to decodeField(fields[8]),
-                        "name" to decodeField(fields[9]),
-                        "linkTarget" to decodeField(fields[10])
+                        "readable" to (hasValidUtf8Path && fields[6] == "1"),
+                        "writable" to (hasValidUtf8Path && fields[7] == "1"),
+                        "path" to path.orEmpty(),
+                        "name" to name.orEmpty(),
+                        "pathToken" to fields[8],
+                        "nameToken" to fields[9],
+                        "hasValidUtf8Path" to hasValidUtf8Path,
+                        "linkTarget" to decodeField(fields[10]).orEmpty()
                     )
                 }
                 .toList()
@@ -353,11 +375,11 @@ class AlpineFileSystemService(context: Context) {
             return if (separator <= 0) "/" else normalized.substring(0, separator)
         }
 
-        private fun decodeField(value: String): String {
+        private fun decodeField(value: String): String? {
             if (value.isEmpty()) return ""
             return runCatching {
-                Base64.getDecoder().decode(value).toString(StandardCharsets.UTF_8)
-            }.getOrDefault("")
+                Base64.getDecoder().decode(value)
+            }.getOrNull()?.let(::decodeStrictUtf8)
         }
 
         private fun shellQuote(value: String): String {

--- a/app/src/main/java/cn/com/omnimind/bot/terminal/AlpineFileSystemService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/AlpineFileSystemService.kt
@@ -5,6 +5,8 @@ import com.ai.assistance.operit.terminal.TerminalManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 import java.util.UUID
@@ -15,37 +17,7 @@ class AlpineFileSystemService(context: Context) {
 
     suspend fun list(path: String): Map<String, Any?> {
         val normalizedPath = normalizeAbsolutePath(path)
-        val command = """
-            set -eu
-            target=${shellQuote(normalizedPath)}
-            [ -d "${'$'}target" ]
-            find "${'$'}target" -mindepth 1 -maxdepth 1 -exec sh -c '
-              encode() { printf %s "${'$'}1" | base64 | tr -d "\n"; }
-              for item do
-                is_dir=0
-                is_file=0
-                is_link=0
-                [ -d "${'$'}item" ] && is_dir=1
-                [ -f "${'$'}item" ] && is_file=1
-                [ -L "${'$'}item" ] && is_link=1
-                size=${'$'}(stat -c %s -- "${'$'}item" 2>/dev/null || printf 0)
-                modified=${'$'}(stat -c %Y -- "${'$'}item" 2>/dev/null || printf 0)
-                mode=${'$'}(stat -c %a -- "${'$'}item" 2>/dev/null || printf "")
-                readable=0
-                writable=0
-                [ -r "${'$'}item" ] && readable=1
-                [ -w "${'$'}item" ] && writable=1
-                name=${'$'}{item##*/}
-                link_target=""
-                [ "${'$'}is_link" = 1 ] && link_target=${'$'}(readlink -- "${'$'}item" 2>/dev/null || true)
-                printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n" \
-                  "${'$'}is_dir" "${'$'}is_file" "${'$'}is_link" "${'$'}size" \
-                  "${'$'}modified" "${'$'}mode" "${'$'}readable" "${'$'}writable" \
-                  "${'$'}(encode "${'$'}item")" "${'$'}(encode "${'$'}name")" \
-                  "${'$'}(encode "${'$'}link_target")"
-              done
-            ' sh {} +
-        """.trimIndent()
+        val command = buildListCommand(normalizedPath)
         val output = execute(command, "alpine-fs-list", LIST_TIMEOUT_MS)
         return mapOf(
             "path" to normalizedPath,
@@ -61,24 +33,37 @@ class AlpineFileSystemService(context: Context) {
             target=${shellQuote(normalizedPath)}
             [ -f "${'$'}target" ]
             size=${'$'}(stat -c %s -- "${'$'}target")
-            printf "%s\n" "${'$'}size"
+            is_link=0
+            writable=0
+            [ -L "${'$'}target" ] && is_link=1
+            [ -w "${'$'}target" ] && writable=1
+            printf "%s|%s|%s\n" "${'$'}size" "${'$'}is_link" "${'$'}writable"
             head -c $safeLimit -- "${'$'}target" | base64
         """.trimIndent()
         val output = execute(command, "alpine-fs-read", READ_TIMEOUT_MS)
         val firstBreak = output.indexOf('\n')
         require(firstBreak >= 0) { "Invalid Alpine file response." }
-        val size = output.substring(0, firstBreak).trim().toLongOrNull() ?: 0L
+        val metadata = output.substring(0, firstBreak).split('|', limit = 3)
+        require(metadata.size == 3) { "Invalid Alpine file metadata." }
+        val size = metadata[0].toLongOrNull() ?: 0L
+        val isLink = metadata[1] == "1"
+        val writable = metadata[2] == "1"
         val encoded = output.substring(firstBreak + 1).filterNot(Char::isWhitespace)
         val bytes = if (encoded.isEmpty()) {
             ByteArray(0)
         } else {
             Base64.getMimeDecoder().decode(encoded)
         }
+        val content = decodeEditableUtf8(bytes)
+        val truncated = size > safeLimit
         return mapOf(
             "path" to normalizedPath,
             "size" to size,
-            "truncated" to (size > safeLimit),
-            "content" to bytes.toString(StandardCharsets.UTF_8)
+            "truncated" to truncated,
+            "isLink" to isLink,
+            "binary" to (content == null),
+            "editable" to (content != null && writable && !isLink && !truncated),
+            "content" to content.orEmpty()
         )
     }
 
@@ -88,6 +73,7 @@ class AlpineFileSystemService(context: Context) {
         require(bytes.size <= MAX_WRITE_BYTES) {
             "Text files larger than $MAX_WRITE_BYTES bytes are not supported by the editor."
         }
+        ensureWriteTargetEditable(normalizedPath)
         val parent = parentPath(normalizedPath)
         val transferDir = File(appContext.cacheDir, "alpine-fs-transfer").apply { mkdirs() }
         val transferFile = File(transferDir, UUID.randomUUID().toString())
@@ -104,9 +90,8 @@ class AlpineFileSystemService(context: Context) {
                 [ -r "${'$'}source" ]
                 mkdir -p "${'$'}parent"
                 if [ -L "${'$'}target" ]; then
-                  cat -- "${'$'}source" > "${'$'}target"
-                  stat -c %s -- "${'$'}target"
-                  exit 0
+                  printf "Refusing to replace a symbolic link: %s\n" "${'$'}target" >&2
+                  exit 73
                 fi
                 temporary="${'$'}target.omnibot-tmp-${'$'}${'$'}"
                 mode=""
@@ -128,6 +113,47 @@ class AlpineFileSystemService(context: Context) {
             withContext(Dispatchers.IO) {
                 transferFile.delete()
             }
+        }
+    }
+
+    private suspend fun ensureWriteTargetEditable(path: String) {
+        val command = """
+            set -eu
+            target=${shellQuote(path)}
+            if [ -L "${'$'}target" ]; then
+              printf "Refusing to replace a symbolic link: %s\n" "${'$'}target" >&2
+              exit 73
+            fi
+            if [ ! -e "${'$'}target" ]; then
+              printf "new\n"
+              exit 0
+            fi
+            [ -f "${'$'}target" ]
+            size=${'$'}(stat -c %s -- "${'$'}target")
+            if [ "${'$'}size" -gt $MAX_WRITE_BYTES ]; then
+              printf "Existing file is too large for text editing: %s\n" "${'$'}target" >&2
+              exit 73
+            fi
+            printf "existing|%s\n" "${'$'}size"
+            base64 < "${'$'}target"
+        """.trimIndent()
+        val output = execute(command, "alpine-fs-write-check", READ_TIMEOUT_MS)
+        val firstBreak = output.indexOf('\n')
+        val header = if (firstBreak >= 0) output.substring(0, firstBreak) else output.trimEnd()
+        if (header == "new") return
+        require(header.startsWith("existing|")) { "Invalid Alpine write preflight response." }
+        val encoded = if (firstBreak >= 0) {
+            output.substring(firstBreak + 1).filterNot(Char::isWhitespace)
+        } else {
+            ""
+        }
+        val existingBytes = if (encoded.isEmpty()) {
+            ByteArray(0)
+        } else {
+            Base64.getMimeDecoder().decode(encoded)
+        }
+        require(decodeEditableUtf8(existingBytes) != null) {
+            "Existing file is not valid UTF-8 text."
         }
     }
 
@@ -159,12 +185,11 @@ class AlpineFileSystemService(context: Context) {
     suspend fun move(sourcePath: String, targetPath: String): Map<String, Any?> {
         val source = normalizeMutablePath(sourcePath)
         val target = normalizeMutablePath(targetPath)
+        if (source == target) {
+            return mapOf("sourcePath" to source, "path" to target)
+        }
         execute(
-            """
-                set -eu
-                mkdir -p -- ${shellQuote(parentPath(target))}
-                mv -- ${shellQuote(source)} ${shellQuote(target)}
-            """.trimIndent(),
+            buildMoveCommand(source, target),
             "alpine-fs-move",
             MUTATION_TIMEOUT_MS
         )
@@ -207,13 +232,12 @@ class AlpineFileSystemService(context: Context) {
         private const val MUTATION_TIMEOUT_MS = 30_000L
 
         internal fun normalizeAbsolutePath(path: String): String {
-            val trimmed = path.trim().replace('\\', '/')
-            require(trimmed.startsWith('/')) { "An absolute Alpine path is required." }
-            require('\u0000' !in trimmed && '\n' !in trimmed && '\r' !in trimmed) {
+            require(path.startsWith('/')) { "An absolute Alpine path is required." }
+            require('\u0000' !in path && '\n' !in path && '\r' !in path) {
                 "Invalid Alpine path."
             }
             val segments = ArrayDeque<String>()
-            trimmed.split('/').forEach { segment ->
+            path.split('/').forEach { segment ->
                 when (segment) {
                     "", "." -> Unit
                     ".." -> if (segments.isNotEmpty()) segments.removeLast()
@@ -221,6 +245,76 @@ class AlpineFileSystemService(context: Context) {
                 }
             }
             return if (segments.isEmpty()) "/" else segments.joinToString(prefix = "/", separator = "/")
+        }
+
+        internal fun decodeEditableUtf8(bytes: ByteArray): String? {
+            if (bytes.any { it == 0.toByte() }) return null
+            return runCatching {
+                StandardCharsets.UTF_8
+                    .newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes))
+                    .toString()
+            }.getOrNull()
+        }
+
+        internal fun buildListCommand(path: String): String {
+            return """
+                set -eu
+                target=${shellQuote(normalizeAbsolutePath(path))}
+                [ -d "${'$'}target" ]
+                find -H "${'$'}target" -mindepth 1 -maxdepth 1 -exec sh -c '
+                  encode() { printf %s "${'$'}1" | base64 | tr -d "\n"; }
+                  for item do
+                    is_dir=0
+                    is_file=0
+                    is_link=0
+                    [ -d "${'$'}item" ] && is_dir=1
+                    [ -f "${'$'}item" ] && is_file=1
+                    [ -L "${'$'}item" ] && is_link=1
+                    size=${'$'}(stat -c %s -- "${'$'}item" 2>/dev/null || printf 0)
+                    modified=${'$'}(stat -c %Y -- "${'$'}item" 2>/dev/null || printf 0)
+                    mode=${'$'}(stat -c %a -- "${'$'}item" 2>/dev/null || printf "")
+                    readable=0
+                    writable=0
+                    [ -r "${'$'}item" ] && readable=1
+                    [ -w "${'$'}item" ] && writable=1
+                    name=${'$'}{item##*/}
+                    link_target=""
+                    [ "${'$'}is_link" = 1 ] && link_target=${'$'}(readlink -- "${'$'}item" 2>/dev/null || true)
+                    printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n" \
+                      "${'$'}is_dir" "${'$'}is_file" "${'$'}is_link" "${'$'}size" \
+                      "${'$'}modified" "${'$'}mode" "${'$'}readable" "${'$'}writable" \
+                      "${'$'}(encode "${'$'}item")" "${'$'}(encode "${'$'}name")" \
+                      "${'$'}(encode "${'$'}link_target")"
+                  done
+                ' sh {} +
+            """.trimIndent()
+        }
+
+        internal fun buildMoveCommand(sourcePath: String, targetPath: String): String {
+            val source = normalizeMutablePath(sourcePath)
+            val target = normalizeMutablePath(targetPath)
+            return """
+                set -eu
+                source=${shellQuote(source)}
+                target=${shellQuote(target)}
+                if [ ! -e "${'$'}source" ] && [ ! -L "${'$'}source" ]; then
+                  printf "Source does not exist: %s\n" "${'$'}source" >&2
+                  exit 72
+                fi
+                if [ -e "${'$'}target" ] || [ -L "${'$'}target" ]; then
+                  printf "Target already exists: %s\n" "${'$'}target" >&2
+                  exit 73
+                fi
+                mkdir -p -- ${shellQuote(parentPath(target))}
+                mv -n -- "${'$'}source" "${'$'}target"
+                if [ -e "${'$'}source" ] || [ -L "${'$'}source" ]; then
+                  printf "Target already exists: %s\n" "${'$'}target" >&2
+                  exit 73
+                fi
+            """.trimIndent()
         }
 
         internal fun parseListOutput(output: String): List<Map<String, Any?>> {

--- a/app/src/main/java/cn/com/omnimind/bot/terminal/AlpineFileSystemService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/AlpineFileSystemService.kt
@@ -1,0 +1,273 @@
+package cn.com.omnimind.bot.terminal
+
+import android.content.Context
+import com.ai.assistance.operit.terminal.TerminalManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.UUID
+
+class AlpineFileSystemService(context: Context) {
+    private val appContext = context.applicationContext
+    private val terminalManager = TerminalManager.getInstance(appContext)
+
+    suspend fun list(path: String): Map<String, Any?> {
+        val normalizedPath = normalizeAbsolutePath(path)
+        val command = """
+            set -eu
+            target=${shellQuote(normalizedPath)}
+            [ -d "${'$'}target" ]
+            find "${'$'}target" -mindepth 1 -maxdepth 1 -exec sh -c '
+              encode() { printf %s "${'$'}1" | base64 | tr -d "\n"; }
+              for item do
+                is_dir=0
+                is_file=0
+                is_link=0
+                [ -d "${'$'}item" ] && is_dir=1
+                [ -f "${'$'}item" ] && is_file=1
+                [ -L "${'$'}item" ] && is_link=1
+                size=${'$'}(stat -c %s -- "${'$'}item" 2>/dev/null || printf 0)
+                modified=${'$'}(stat -c %Y -- "${'$'}item" 2>/dev/null || printf 0)
+                mode=${'$'}(stat -c %a -- "${'$'}item" 2>/dev/null || printf "")
+                readable=0
+                writable=0
+                [ -r "${'$'}item" ] && readable=1
+                [ -w "${'$'}item" ] && writable=1
+                name=${'$'}{item##*/}
+                link_target=""
+                [ "${'$'}is_link" = 1 ] && link_target=${'$'}(readlink -- "${'$'}item" 2>/dev/null || true)
+                printf "%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n" \
+                  "${'$'}is_dir" "${'$'}is_file" "${'$'}is_link" "${'$'}size" \
+                  "${'$'}modified" "${'$'}mode" "${'$'}readable" "${'$'}writable" \
+                  "${'$'}(encode "${'$'}item")" "${'$'}(encode "${'$'}name")" \
+                  "${'$'}(encode "${'$'}link_target")"
+              done
+            ' sh {} +
+        """.trimIndent()
+        val output = execute(command, "alpine-fs-list", LIST_TIMEOUT_MS)
+        return mapOf(
+            "path" to normalizedPath,
+            "entries" to parseListOutput(output)
+        )
+    }
+
+    suspend fun read(path: String, maxBytes: Int = DEFAULT_MAX_READ_BYTES): Map<String, Any?> {
+        val normalizedPath = normalizeAbsolutePath(path)
+        val safeLimit = maxBytes.coerceIn(1, MAX_READ_BYTES)
+        val command = """
+            set -eu
+            target=${shellQuote(normalizedPath)}
+            [ -f "${'$'}target" ]
+            size=${'$'}(stat -c %s -- "${'$'}target")
+            printf "%s\n" "${'$'}size"
+            head -c $safeLimit -- "${'$'}target" | base64
+        """.trimIndent()
+        val output = execute(command, "alpine-fs-read", READ_TIMEOUT_MS)
+        val firstBreak = output.indexOf('\n')
+        require(firstBreak >= 0) { "Invalid Alpine file response." }
+        val size = output.substring(0, firstBreak).trim().toLongOrNull() ?: 0L
+        val encoded = output.substring(firstBreak + 1).filterNot(Char::isWhitespace)
+        val bytes = if (encoded.isEmpty()) {
+            ByteArray(0)
+        } else {
+            Base64.getMimeDecoder().decode(encoded)
+        }
+        return mapOf(
+            "path" to normalizedPath,
+            "size" to size,
+            "truncated" to (size > safeLimit),
+            "content" to bytes.toString(StandardCharsets.UTF_8)
+        )
+    }
+
+    suspend fun write(path: String, content: String): Map<String, Any?> {
+        val normalizedPath = normalizeMutablePath(path)
+        val bytes = content.toByteArray(StandardCharsets.UTF_8)
+        require(bytes.size <= MAX_WRITE_BYTES) {
+            "Text files larger than $MAX_WRITE_BYTES bytes are not supported by the editor."
+        }
+        val parent = parentPath(normalizedPath)
+        val transferDir = File(appContext.cacheDir, "alpine-fs-transfer").apply { mkdirs() }
+        val transferFile = File(transferDir, UUID.randomUUID().toString())
+        return try {
+            withContext(Dispatchers.IO) {
+                transferFile.writeBytes(bytes)
+                transferFile.setReadable(true, false)
+            }
+            val command = """
+                set -eu
+                target=${shellQuote(normalizedPath)}
+                parent=${shellQuote(parent)}
+                source=${shellQuote(transferFile.absolutePath)}
+                [ -r "${'$'}source" ]
+                mkdir -p "${'$'}parent"
+                if [ -L "${'$'}target" ]; then
+                  cat -- "${'$'}source" > "${'$'}target"
+                  stat -c %s -- "${'$'}target"
+                  exit 0
+                fi
+                temporary="${'$'}target.omnibot-tmp-${'$'}${'$'}"
+                mode=""
+                [ -e "${'$'}target" ] && mode=${'$'}(stat -c %a -- "${'$'}target" 2>/dev/null || true)
+                cat -- "${'$'}source" > "${'$'}temporary"
+                [ -n "${'$'}mode" ] && chmod "${'$'}mode" "${'$'}temporary"
+                mv -f -- "${'$'}temporary" "${'$'}target"
+                stat -c %s -- "${'$'}target"
+            """.trimIndent()
+            val output = execute(command, "alpine-fs-write", WRITE_TIMEOUT_MS)
+            mapOf(
+                "path" to normalizedPath,
+                "size" to (
+                    output.trim().lineSequence().lastOrNull()?.toLongOrNull()
+                        ?: bytes.size.toLong()
+                    )
+            )
+        } finally {
+            withContext(Dispatchers.IO) {
+                transferFile.delete()
+            }
+        }
+    }
+
+    suspend fun createDirectory(path: String): Map<String, Any?> {
+        val normalizedPath = normalizeMutablePath(path)
+        execute(
+            "set -eu\nmkdir -p -- ${shellQuote(normalizedPath)}",
+            "alpine-fs-mkdir",
+            MUTATION_TIMEOUT_MS
+        )
+        return mapOf("path" to normalizedPath, "isDirectory" to true)
+    }
+
+    suspend fun createFile(path: String): Map<String, Any?> {
+        val normalizedPath = normalizeMutablePath(path)
+        val parent = parentPath(normalizedPath)
+        execute(
+            """
+                set -eu
+                mkdir -p -- ${shellQuote(parent)}
+                [ -e ${shellQuote(normalizedPath)} ] || : > ${shellQuote(normalizedPath)}
+            """.trimIndent(),
+            "alpine-fs-touch",
+            MUTATION_TIMEOUT_MS
+        )
+        return mapOf("path" to normalizedPath, "isDirectory" to false)
+    }
+
+    suspend fun move(sourcePath: String, targetPath: String): Map<String, Any?> {
+        val source = normalizeMutablePath(sourcePath)
+        val target = normalizeMutablePath(targetPath)
+        execute(
+            """
+                set -eu
+                mkdir -p -- ${shellQuote(parentPath(target))}
+                mv -- ${shellQuote(source)} ${shellQuote(target)}
+            """.trimIndent(),
+            "alpine-fs-move",
+            MUTATION_TIMEOUT_MS
+        )
+        return mapOf("sourcePath" to source, "path" to target)
+    }
+
+    suspend fun delete(path: String): Map<String, Any?> {
+        val normalizedPath = normalizeMutablePath(path)
+        execute(
+            "set -eu\nrm -rf -- ${shellQuote(normalizedPath)}",
+            "alpine-fs-delete",
+            MUTATION_TIMEOUT_MS
+        )
+        return mapOf("path" to normalizedPath, "deleted" to true)
+    }
+
+    private suspend fun execute(command: String, executorKey: String, timeoutMs: Long): String {
+        val result = terminalManager.executeHiddenCommand(
+            command = command,
+            executorKey = executorKey,
+            timeoutMs = timeoutMs
+        )
+        if (!result.isOk || result.exitCode != 0) {
+            throw IllegalStateException(
+                result.error.ifBlank {
+                    result.rawOutputPreview.ifBlank { "Alpine file operation failed." }
+                }
+            )
+        }
+        return result.output
+    }
+
+    companion object {
+        private const val DEFAULT_MAX_READ_BYTES = 512 * 1024
+        private const val MAX_READ_BYTES = 1024 * 1024
+        private const val MAX_WRITE_BYTES = 1024 * 1024
+        private const val LIST_TIMEOUT_MS = 30_000L
+        private const val READ_TIMEOUT_MS = 30_000L
+        private const val WRITE_TIMEOUT_MS = 45_000L
+        private const val MUTATION_TIMEOUT_MS = 30_000L
+
+        internal fun normalizeAbsolutePath(path: String): String {
+            val trimmed = path.trim().replace('\\', '/')
+            require(trimmed.startsWith('/')) { "An absolute Alpine path is required." }
+            require('\u0000' !in trimmed && '\n' !in trimmed && '\r' !in trimmed) {
+                "Invalid Alpine path."
+            }
+            val segments = ArrayDeque<String>()
+            trimmed.split('/').forEach { segment ->
+                when (segment) {
+                    "", "." -> Unit
+                    ".." -> if (segments.isNotEmpty()) segments.removeLast()
+                    else -> segments.addLast(segment)
+                }
+            }
+            return if (segments.isEmpty()) "/" else segments.joinToString(prefix = "/", separator = "/")
+        }
+
+        internal fun parseListOutput(output: String): List<Map<String, Any?>> {
+            return output.lineSequence()
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .mapNotNull { line ->
+                    val fields = line.split('|', limit = 11)
+                    if (fields.size != 11) return@mapNotNull null
+                    mapOf(
+                        "isDirectory" to (fields[0] == "1"),
+                        "isFile" to (fields[1] == "1"),
+                        "isLink" to (fields[2] == "1"),
+                        "size" to (fields[3].toLongOrNull() ?: 0L),
+                        "modifiedAt" to (fields[4].toLongOrNull() ?: 0L),
+                        "mode" to fields[5],
+                        "readable" to (fields[6] == "1"),
+                        "writable" to (fields[7] == "1"),
+                        "path" to decodeField(fields[8]),
+                        "name" to decodeField(fields[9]),
+                        "linkTarget" to decodeField(fields[10])
+                    )
+                }
+                .toList()
+        }
+
+        private fun normalizeMutablePath(path: String): String {
+            val normalized = normalizeAbsolutePath(path)
+            require(normalized != "/") { "The Alpine root directory is not a mutable entry." }
+            return normalized
+        }
+
+        private fun parentPath(path: String): String {
+            val normalized = normalizeAbsolutePath(path)
+            val separator = normalized.lastIndexOf('/')
+            return if (separator <= 0) "/" else normalized.substring(0, separator)
+        }
+
+        private fun decodeField(value: String): String {
+            if (value.isEmpty()) return ""
+            return runCatching {
+                Base64.getDecoder().decode(value).toString(StandardCharsets.UTF_8)
+            }.getOrDefault("")
+        }
+
+        private fun shellQuote(value: String): String {
+            return "'" + value.replace("'", "'\"'\"'") + "'"
+        }
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AlpineFileSystemChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AlpineFileSystemChannel.kt
@@ -74,7 +74,7 @@ class AlpineFileSystemChannel {
     }
 
     private fun MethodCall.requiredPath(): String {
-        return argument<String>("path")?.trim().orEmpty().also {
+        return argument<String>("path").orEmpty().also {
             require(it.isNotEmpty()) { "path is required" }
         }
     }

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AlpineFileSystemChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AlpineFileSystemChannel.kt
@@ -1,0 +1,81 @@
+package cn.com.omnimind.bot.ui.channel
+
+import android.content.Context
+import cn.com.omnimind.bot.terminal.AlpineFileSystemService
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class AlpineFileSystemChannel {
+    companion object {
+        private const val CHANNEL_NAME = "cn.com.omnimind.bot/AlpineFileSystem"
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var appContext: Context? = null
+    private var channel: MethodChannel? = null
+
+    fun onCreate(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    fun setChannel(flutterEngine: FlutterEngine) {
+        channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL_NAME)
+        channel?.setMethodCallHandler(::handleMethodCall)
+    }
+
+    fun clear() {
+        channel?.setMethodCallHandler(null)
+        channel = null
+        appContext = null
+    }
+
+    private fun handleMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        val context = appContext
+        if (context == null) {
+            result.error("ALPINE_FS_CONTEXT_ERROR", "Context not initialized", null)
+            return
+        }
+        val service = AlpineFileSystemService(context)
+        scope.launch {
+            runCatching {
+                when (call.method) {
+                    "list" -> service.list(call.requiredPath())
+                    "read" -> service.read(
+                        path = call.requiredPath(),
+                        maxBytes = call.argument<Number>("maxBytes")?.toInt() ?: 512 * 1024
+                    )
+                    "write" -> service.write(
+                        path = call.requiredPath(),
+                        content = call.argument<String>("content").orEmpty()
+                    )
+                    "createDirectory" -> service.createDirectory(call.requiredPath())
+                    "createFile" -> service.createFile(call.requiredPath())
+                    "move" -> service.move(
+                        sourcePath = call.argument<String>("sourcePath").orEmpty(),
+                        targetPath = call.argument<String>("targetPath").orEmpty()
+                    )
+                    "delete" -> service.delete(call.requiredPath())
+                    else -> throw IllegalArgumentException("Unknown Alpine filesystem method: ${call.method}")
+                }
+            }.onSuccess(result::success)
+                .onFailure { error ->
+                    result.error(
+                        "ALPINE_FS_OPERATION_FAILED",
+                        error.message ?: error.javaClass.simpleName,
+                        null
+                    )
+                }
+        }
+    }
+
+    private fun MethodCall.requiredPath(): String {
+        return argument<String>("path")?.trim().orEmpty().also {
+            require(it.isNotEmpty()) { "path is required" }
+        }
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/ChannelManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/ChannelManager.kt
@@ -28,6 +28,7 @@ class ChannelManager {
     private var browserSessionChannel: BrowserSessionChannel = BrowserSessionChannel()
     private var storageUsageChannel: StorageUsageChannel = StorageUsageChannel()
     private var codexAppServerChannel: CodexAppServerChannel = CodexAppServerChannel()
+    private var alpineFileSystemChannel: AlpineFileSystemChannel = AlpineFileSystemChannel()
     fun getUIRouterChannel(): UIRouterChannel {
         return uiRouterChannel
     }
@@ -55,6 +56,7 @@ class ChannelManager {
         browserSessionChannel.setChannel(flutterEngine)
         storageUsageChannel.setChannel(flutterEngine)
         codexAppServerChannel.setChannel(flutterEngine)
+        alpineFileSystemChannel.setChannel(flutterEngine)
     }
 
     fun onCreate(context: Context) {
@@ -72,6 +74,7 @@ class ChannelManager {
         overlayChannel.onCreate(context)
         storageUsageChannel.onCreate(context)
         codexAppServerChannel.onCreate(context)
+        alpineFileSystemChannel.onCreate(context)
     }
 
     fun clearChannel() {
@@ -93,6 +96,7 @@ class ChannelManager {
         browserSessionChannel.clear()
         storageUsageChannel.clear()
         codexAppServerChannel.clear()
+        alpineFileSystemChannel.clear()
     }
 
 

--- a/app/src/test/java/cn/com/omnimind/bot/terminal/AlpineFileSystemServiceTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/terminal/AlpineFileSystemServiceTest.kt
@@ -2,6 +2,7 @@ package cn.com.omnimind.bot.terminal
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.nio.charset.StandardCharsets
@@ -17,6 +18,55 @@ class AlpineFileSystemServiceTest {
             )
         )
         assertEquals("/", AlpineFileSystemService.normalizeAbsolutePath("/../../"))
+        assertEquals(
+            "/root/file ",
+            AlpineFileSystemService.normalizeAbsolutePath("/root/file ")
+        )
+        assertEquals(
+            "/root/a\\b",
+            AlpineFileSystemService.normalizeAbsolutePath("/root/a\\b")
+        )
+    }
+
+    @Test
+    fun editableUtf8DecoderRejectsBinaryAndMalformedInput() {
+        assertEquals(
+            "配置内容",
+            AlpineFileSystemService.decodeEditableUtf8(
+                "配置内容".toByteArray(StandardCharsets.UTF_8)
+            )
+        )
+        assertNull(
+            AlpineFileSystemService.decodeEditableUtf8(
+                byteArrayOf(0x7F, 0x45, 0x4C, 0x46, 0x00)
+            )
+        )
+        assertNull(
+            AlpineFileSystemService.decodeEditableUtf8(
+                byteArrayOf(0xC3.toByte(), 0x28)
+            )
+        )
+    }
+
+    @Test
+    fun listCommandFollowsOnlyTheRequestedDirectorySymlink() {
+        val command = AlpineFileSystemService.buildListCommand("/var/run")
+
+        assertTrue(command.contains("find -H \"\$target\""))
+        assertTrue(command.contains("[ -L \"\$item\" ]"))
+    }
+
+    @Test
+    fun moveCommandRejectsExistingFilesDirectoriesAndBrokenLinks() {
+        val command = AlpineFileSystemService.buildMoveCommand(
+            "/root/source ",
+            "/root/a\\b"
+        )
+
+        assertTrue(command.contains("[ -e \"\$target\" ] || [ -L \"\$target\" ]"))
+        assertTrue(command.contains("Target already exists"))
+        assertTrue(command.contains("source='/root/source '"))
+        assertTrue(command.contains("target='/root/a\\b'"))
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/terminal/AlpineFileSystemServiceTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/terminal/AlpineFileSystemServiceTest.kt
@@ -2,6 +2,7 @@ package cn.com.omnimind.bot.terminal
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -70,6 +71,16 @@ class AlpineFileSystemServiceTest {
     }
 
     @Test
+    fun createFileCommandRejectsBrokenLinksAndUsesNoClobberRedirection() {
+        val command = AlpineFileSystemService.buildCreateFileCommand("/root/new-file")
+
+        assertTrue(command.contains("[ -e \"\$target\" ] || [ -L \"\$target\" ]"))
+        assertTrue(command.contains("Target already exists"))
+        assertTrue(command.contains("set -C"))
+        assertTrue(command.contains(": > \"\$target\""))
+    }
+
+    @Test
     fun parseListOutputDecodesNamesAndMetadata() {
         val path = encode("/root/.codex")
         val name = encode(".codex")
@@ -87,7 +98,45 @@ class AlpineFileSystemServiceTest {
         assertEquals(4096L, entry["size"])
     }
 
+    @Test
+    fun parseListOutputDoesNotAliasInvalidUtf8WithReplacementCharacterName() {
+        val invalidName = byteArrayOf(0xFF.toByte())
+        val invalidPath = "/root/".toByteArray(StandardCharsets.UTF_8) + invalidName
+        val replacementName = "\uFFFD"
+        val output = buildString {
+            append("0|1|0|1|0|600|1|1|")
+            append(encode(invalidPath))
+            append('|')
+            append(encode(invalidName))
+            append("|\n")
+            append("0|1|0|1|0|600|1|1|")
+            append(encode("/root/$replacementName"))
+            append('|')
+            append(encode(replacementName))
+            append("|\n")
+        }
+
+        val entries = AlpineFileSystemService.parseListOutput(output)
+
+        assertEquals(2, entries.size)
+        val invalidEntry = entries[0]
+        val replacementEntry = entries[1]
+        assertFalse(invalidEntry["hasValidUtf8Path"] as Boolean)
+        assertEquals("", invalidEntry["path"])
+        assertEquals("", invalidEntry["name"])
+        assertFalse(invalidEntry["readable"] as Boolean)
+        assertFalse(invalidEntry["writable"] as Boolean)
+        assertTrue(replacementEntry["hasValidUtf8Path"] as Boolean)
+        assertEquals("/root/$replacementName", replacementEntry["path"])
+        assertEquals(replacementName, replacementEntry["name"])
+        assertNotEquals(invalidEntry["pathToken"], replacementEntry["pathToken"])
+    }
+
     private fun encode(value: String): String {
         return Base64.getEncoder().encodeToString(value.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun encode(value: ByteArray): String {
+        return Base64.getEncoder().encodeToString(value)
     }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/terminal/AlpineFileSystemServiceTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/terminal/AlpineFileSystemServiceTest.kt
@@ -1,0 +1,43 @@
+package cn.com.omnimind.bot.terminal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class AlpineFileSystemServiceTest {
+    @Test
+    fun normalizeAbsolutePathCollapsesDotSegments() {
+        assertEquals(
+            "/root/.codex/config.toml",
+            AlpineFileSystemService.normalizeAbsolutePath(
+                "/root/project/../.codex/./config.toml/"
+            )
+        )
+        assertEquals("/", AlpineFileSystemService.normalizeAbsolutePath("/../../"))
+    }
+
+    @Test
+    fun parseListOutputDecodesNamesAndMetadata() {
+        val path = encode("/root/.codex")
+        val name = encode(".codex")
+        val output = "1|0|0|4096|123456|700|1|1|$path|$name|\n"
+
+        val entries = AlpineFileSystemService.parseListOutput(output)
+
+        assertEquals(1, entries.size)
+        val entry = entries.single()
+        assertEquals("/root/.codex", entry["path"])
+        assertEquals(".codex", entry["name"])
+        assertTrue(entry["isDirectory"] as Boolean)
+        assertFalse(entry["isFile"] as Boolean)
+        assertEquals("700", entry["mode"])
+        assertEquals(4096L, entry["size"])
+    }
+
+    private fun encode(value: String): String {
+        return Base64.getEncoder().encodeToString(value.toByteArray(StandardCharsets.UTF_8))
+    }
+}

--- a/ui/lib/features/home/pages/codex/alpine_file_system_page.dart
+++ b/ui/lib/features/home/pages/codex/alpine_file_system_page.dart
@@ -361,7 +361,7 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
         itemBuilder: (context, index) {
           final entry = _entries[index];
           return ListTile(
-            key: ValueKey('alpine-fs-entry-${entry.path}'),
+            key: ValueKey('alpine-fs-entry-${entry.entryId}'),
             leading: Icon(
               entry.isDirectory
                   ? Icons.folder_rounded
@@ -370,7 +370,12 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
                   : Icons.insert_drive_file_outlined,
             ),
             title: Text(
-              entry.name,
+              entry.hasValidUtf8Path
+                  ? entry.name
+                  : _text(
+                      zh: '非 UTF-8 文件名（${entry.nameToken}）',
+                      en: 'Non-UTF-8 filename (${entry.nameToken})',
+                    ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
@@ -379,36 +384,46 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
-            onTap: entry.isDirectory
+            onTap: !entry.hasValidUtf8Path
+                ? null
+                : entry.isDirectory
                 ? () => _openDirectory(entry.path)
                 : entry.readable
                 ? () => unawaited(_openFile(entry))
                 : null,
-            trailing: PopupMenuButton<String>(
-              onSelected: (value) {
-                if (value == 'copy') {
-                  Clipboard.setData(ClipboardData(text: entry.path));
-                } else if (value == 'rename') {
-                  unawaited(_rename(entry));
-                } else if (value == 'delete') {
-                  unawaited(_delete(entry));
-                }
-              },
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: 'copy',
-                  child: Text(_text(zh: '复制路径', en: 'Copy path')),
-                ),
-                PopupMenuItem(
-                  value: 'rename',
-                  child: Text(_text(zh: '重命名', en: 'Rename')),
-                ),
-                PopupMenuItem(
-                  value: 'delete',
-                  child: Text(_text(zh: '删除', en: 'Delete')),
-                ),
-              ],
-            ),
+            trailing: entry.hasValidUtf8Path
+                ? PopupMenuButton<String>(
+                    onSelected: (value) {
+                      if (value == 'copy') {
+                        Clipboard.setData(ClipboardData(text: entry.path));
+                      } else if (value == 'rename') {
+                        unawaited(_rename(entry));
+                      } else if (value == 'delete') {
+                        unawaited(_delete(entry));
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      PopupMenuItem(
+                        value: 'copy',
+                        child: Text(_text(zh: '复制路径', en: 'Copy path')),
+                      ),
+                      PopupMenuItem(
+                        value: 'rename',
+                        child: Text(_text(zh: '重命名', en: 'Rename')),
+                      ),
+                      PopupMenuItem(
+                        value: 'delete',
+                        child: Text(_text(zh: '删除', en: 'Delete')),
+                      ),
+                    ],
+                  )
+                : Tooltip(
+                    message: _text(
+                      zh: '文件名不是有效 UTF-8，已禁用文件操作',
+                      en: 'File operations are disabled for non-UTF-8 names',
+                    ),
+                    child: const Icon(Icons.block_rounded),
+                  ),
           );
         },
       ),
@@ -417,6 +432,8 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
 
   String _entrySubtitle(AlpineFileEntry entry) {
     final parts = <String>[
+      if (!entry.hasValidUtf8Path)
+        _text(zh: '文件操作已禁用', en: 'File operations disabled'),
       if (entry.mode.isNotEmpty) entry.mode,
       if (!entry.isDirectory) _formatBytes(entry.size),
       if (entry.isLink && entry.linkTarget.isNotEmpty) '→ ${entry.linkTarget}',

--- a/ui/lib/features/home/pages/codex/alpine_file_system_page.dart
+++ b/ui/lib/features/home/pages/codex/alpine_file_system_page.dart
@@ -1,0 +1,577 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:ui/services/alpine_file_system_service.dart';
+import 'package:ui/theme/theme_context.dart';
+
+class AlpineFileSystemPage extends StatefulWidget {
+  const AlpineFileSystemPage({super.key, this.initialPath = '/'});
+
+  final String initialPath;
+
+  @override
+  State<AlpineFileSystemPage> createState() => _AlpineFileSystemPageState();
+}
+
+class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
+  late String _path;
+  List<AlpineFileEntry> _entries = const <AlpineFileEntry>[];
+  bool _loading = true;
+  String? _error;
+
+  bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
+  String _text({required String zh, required String en}) =>
+      _isEnglish ? en : zh;
+
+  @override
+  void initState() {
+    super.initState();
+    _path = _normalizePath(widget.initialPath);
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final entries = await AlpineFileSystemService.list(_path);
+      if (!mounted) return;
+      setState(() {
+        _entries = entries;
+        _loading = false;
+      });
+    } on PlatformException catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = error.message ?? error.code;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = error.toString();
+      });
+    }
+  }
+
+  void _openDirectory(String path) {
+    setState(() => _path = _normalizePath(path));
+    unawaited(_load());
+  }
+
+  void _openParent() {
+    if (_path == '/') return;
+    final index = _path.lastIndexOf('/');
+    _openDirectory(index <= 0 ? '/' : _path.substring(0, index));
+  }
+
+  Future<void> _jumpToPath() async {
+    final controller = TextEditingController(text: _path);
+    final selected = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(_text(zh: '打开路径', en: 'Open path')),
+        content: TextField(
+          key: const Key('alpine-fs-path-field'),
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: '/root/.codex'),
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(_text(zh: '取消', en: 'Cancel')),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: Text(_text(zh: '打开', en: 'Open')),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (selected == null || selected.trim().isEmpty || !mounted) return;
+    _openDirectory(selected);
+  }
+
+  Future<void> _createEntry({required bool directory}) async {
+    final name = await _promptName(
+      title: directory
+          ? _text(zh: '新建文件夹', en: 'New folder')
+          : _text(zh: '新建文件', en: 'New file'),
+    );
+    if (name == null) return;
+    final target = _joinPath(_path, name);
+    await _runMutation(() async {
+      if (directory) {
+        await AlpineFileSystemService.createDirectory(target);
+      } else {
+        await AlpineFileSystemService.createFile(target);
+      }
+    });
+  }
+
+  Future<void> _rename(AlpineFileEntry entry) async {
+    final name = await _promptName(
+      title: _text(zh: '重命名', en: 'Rename'),
+      initialValue: entry.name,
+    );
+    if (name == null || name == entry.name) return;
+    await _runMutation(
+      () => AlpineFileSystemService.move(entry.path, _joinPath(_path, name)),
+    );
+  }
+
+  Future<void> _delete(AlpineFileEntry entry) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(_text(zh: '删除项目', en: 'Delete item')),
+        content: Text(
+          _text(
+            zh: '确定删除 ${entry.path}？目录会递归删除。',
+            en: 'Delete ${entry.path}? Directories are removed recursively.',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(_text(zh: '取消', en: 'Cancel')),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(_text(zh: '删除', en: 'Delete')),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await _runMutation(() => AlpineFileSystemService.delete(entry.path));
+  }
+
+  Future<String?> _promptName({
+    required String title,
+    String initialValue = '',
+  }) async {
+    final controller = TextEditingController(text: initialValue);
+    final value = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(title),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(
+            labelText: _text(zh: '名称', en: 'Name'),
+          ),
+          onSubmitted: (value) => Navigator.of(context).pop(value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(_text(zh: '取消', en: 'Cancel')),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(controller.text),
+            child: Text(_text(zh: '确定', en: 'OK')),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    final normalized = value?.trim();
+    if (normalized == null ||
+        normalized.isEmpty ||
+        normalized == '.' ||
+        normalized == '..' ||
+        normalized.contains('/')) {
+      return null;
+    }
+    return normalized;
+  }
+
+  Future<void> _runMutation(Future<void> Function() action) async {
+    try {
+      await action();
+      if (!mounted) return;
+      await _load();
+    } on PlatformException catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message ?? error.code)));
+    }
+  }
+
+  Future<void> _openFile(AlpineFileEntry entry) async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => _AlpineTextFilePage(entry: entry),
+      ),
+    );
+    if (mounted) unawaited(_load());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = context.omniPalette;
+    return PopScope(
+      canPop: _path == '/',
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _openParent();
+      },
+      child: Scaffold(
+        backgroundColor: palette.pageBackground,
+        appBar: AppBar(
+          title: Text(_text(zh: 'Alpine 文件系统', en: 'Alpine filesystem')),
+          actions: [
+            IconButton(
+              key: const Key('alpine-fs-jump-button'),
+              tooltip: _text(zh: '打开路径', en: 'Open path'),
+              onPressed: _jumpToPath,
+              icon: const Icon(Icons.route_rounded),
+            ),
+            IconButton(
+              tooltip: _text(zh: '刷新', en: 'Refresh'),
+              onPressed: _load,
+              icon: const Icon(Icons.refresh_rounded),
+            ),
+          ],
+        ),
+        body: Column(
+          children: [
+            _buildBreadcrumbs(),
+            Expanded(child: _buildBody()),
+          ],
+        ),
+        floatingActionButton: PopupMenuButton<String>(
+          tooltip: _text(zh: '新建', en: 'Create'),
+          onSelected: (value) =>
+              unawaited(_createEntry(directory: value == 'directory')),
+          itemBuilder: (context) => [
+            PopupMenuItem(
+              value: 'file',
+              child: ListTile(
+                leading: const Icon(Icons.note_add_outlined),
+                title: Text(_text(zh: '新建文件', en: 'New file')),
+              ),
+            ),
+            PopupMenuItem(
+              value: 'directory',
+              child: ListTile(
+                leading: const Icon(Icons.create_new_folder_outlined),
+                title: Text(_text(zh: '新建文件夹', en: 'New folder')),
+              ),
+            ),
+          ],
+          child: const FloatingActionButton(
+            onPressed: null,
+            child: Icon(Icons.add_rounded),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBreadcrumbs() {
+    final segments = _path == '/'
+        ? const <String>[]
+        : _path.substring(1).split('/');
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            ActionChip(
+              label: const Text('/'),
+              onPressed: _path == '/' ? null : () => _openDirectory('/'),
+            ),
+            for (var index = 0; index < segments.length; index++) ...[
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 3),
+                child: Icon(Icons.chevron_right_rounded, size: 18),
+              ),
+              ActionChip(
+                label: Text(segments[index]),
+                onPressed: index == segments.length - 1
+                    ? null
+                    : () => _openDirectory(
+                        '/${segments.take(index + 1).join('/')}',
+                      ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!, textAlign: TextAlign.center),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: _load,
+                child: Text(_text(zh: '重试', en: 'Retry')),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    if (_entries.isEmpty) {
+      return Center(
+        child: Text(_text(zh: '目录为空', en: 'Empty directory')),
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.builder(
+        itemCount: _entries.length,
+        itemBuilder: (context, index) {
+          final entry = _entries[index];
+          return ListTile(
+            key: ValueKey('alpine-fs-entry-${entry.path}'),
+            leading: Icon(
+              entry.isDirectory
+                  ? Icons.folder_rounded
+                  : entry.isLink
+                  ? Icons.link_rounded
+                  : Icons.insert_drive_file_outlined,
+            ),
+            title: Text(
+              entry.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            subtitle: Text(
+              _entrySubtitle(entry),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            onTap: entry.isDirectory
+                ? () => _openDirectory(entry.path)
+                : entry.readable
+                ? () => unawaited(_openFile(entry))
+                : null,
+            trailing: PopupMenuButton<String>(
+              onSelected: (value) {
+                if (value == 'copy') {
+                  Clipboard.setData(ClipboardData(text: entry.path));
+                } else if (value == 'rename') {
+                  unawaited(_rename(entry));
+                } else if (value == 'delete') {
+                  unawaited(_delete(entry));
+                }
+              },
+              itemBuilder: (context) => [
+                PopupMenuItem(
+                  value: 'copy',
+                  child: Text(_text(zh: '复制路径', en: 'Copy path')),
+                ),
+                PopupMenuItem(
+                  value: 'rename',
+                  child: Text(_text(zh: '重命名', en: 'Rename')),
+                ),
+                PopupMenuItem(
+                  value: 'delete',
+                  child: Text(_text(zh: '删除', en: 'Delete')),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  String _entrySubtitle(AlpineFileEntry entry) {
+    final parts = <String>[
+      if (entry.mode.isNotEmpty) entry.mode,
+      if (!entry.isDirectory) _formatBytes(entry.size),
+      if (entry.isLink && entry.linkTarget.isNotEmpty) '→ ${entry.linkTarget}',
+    ];
+    return parts.join(' · ');
+  }
+
+  static String _normalizePath(String value) {
+    final parts = <String>[];
+    for (final segment in value.trim().replaceAll('\\', '/').split('/')) {
+      if (segment.isEmpty || segment == '.') continue;
+      if (segment == '..') {
+        if (parts.isNotEmpty) parts.removeLast();
+      } else {
+        parts.add(segment);
+      }
+    }
+    return parts.isEmpty ? '/' : '/${parts.join('/')}';
+  }
+
+  static String _joinPath(String parent, String name) =>
+      parent == '/' ? '/$name' : '$parent/$name';
+
+  static String _formatBytes(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}
+
+class _AlpineTextFilePage extends StatefulWidget {
+  const _AlpineTextFilePage({required this.entry});
+
+  final AlpineFileEntry entry;
+
+  @override
+  State<_AlpineTextFilePage> createState() => _AlpineTextFilePageState();
+}
+
+class _AlpineTextFilePageState extends State<_AlpineTextFilePage> {
+  final TextEditingController _controller = TextEditingController();
+  bool _loading = true;
+  bool _saving = false;
+  bool _truncated = false;
+  String? _error;
+
+  bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
+  String _text({required String zh, required String en}) =>
+      _isEnglish ? en : zh;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      final value = await AlpineFileSystemService.read(widget.entry.path);
+      if (!mounted) return;
+      _controller.text = value.content;
+      setState(() {
+        _loading = false;
+        _truncated = value.truncated;
+      });
+    } on PlatformException catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = error.message ?? error.code;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    setState(() => _saving = true);
+    try {
+      await AlpineFileSystemService.write(widget.entry.path, _controller.text);
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_text(zh: '已保存', en: 'Saved')),
+        ),
+      );
+    } on PlatformException catch (error) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message ?? error.code)));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.entry.name),
+        actions: [
+          IconButton(
+            tooltip: _text(zh: '复制路径', en: 'Copy path'),
+            onPressed: () =>
+                Clipboard.setData(ClipboardData(text: widget.entry.path)),
+            icon: const Icon(Icons.content_copy_rounded),
+          ),
+          IconButton(
+            key: const Key('alpine-fs-save-button'),
+            tooltip: _text(zh: '保存', en: 'Save'),
+            onPressed: _loading || _saving || _truncated ? null : _save,
+            icon: _saving
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.save_rounded),
+          ),
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(_error!),
+              ),
+            )
+          : Column(
+              children: [
+                if (_truncated)
+                  MaterialBanner(
+                    content: Text(
+                      _text(
+                        zh: '文件超过 1 MB，当前只显示前 1 MB。',
+                        en: 'The file is larger than 1 MB. Only the first 1 MB is shown.',
+                      ),
+                    ),
+                    actions: const <Widget>[SizedBox.shrink()],
+                  ),
+                Expanded(
+                  child: TextField(
+                    key: const Key('alpine-fs-editor'),
+                    controller: _controller,
+                    readOnly: _truncated || !widget.entry.writable,
+                    expands: true,
+                    maxLines: null,
+                    minLines: null,
+                    textAlignVertical: TextAlignVertical.top,
+                    style: const TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      height: 1.4,
+                    ),
+                    decoration: const InputDecoration(
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.all(14),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/ui/lib/features/home/pages/codex/alpine_file_system_page.dart
+++ b/ui/lib/features/home/pages/codex/alpine_file_system_page.dart
@@ -19,6 +19,7 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
   List<AlpineFileEntry> _entries = const <AlpineFileEntry>[];
   bool _loading = true;
   String? _error;
+  int _loadGeneration = 0;
 
   bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
   String _text({required String zh, required String en}) =>
@@ -27,30 +28,38 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
   @override
   void initState() {
     super.initState();
-    _path = _normalizePath(widget.initialPath);
+    _path = AlpineFileSystemService.normalizePath(widget.initialPath);
     unawaited(_load());
   }
 
   Future<void> _load() async {
+    final requestedPath = _path;
+    final generation = ++_loadGeneration;
     setState(() {
       _loading = true;
       _error = null;
     });
     try {
-      final entries = await AlpineFileSystemService.list(_path);
-      if (!mounted) return;
+      final entries = await AlpineFileSystemService.list(requestedPath);
+      if (!mounted || generation != _loadGeneration || requestedPath != _path) {
+        return;
+      }
       setState(() {
         _entries = entries;
         _loading = false;
       });
     } on PlatformException catch (error) {
-      if (!mounted) return;
+      if (!mounted || generation != _loadGeneration || requestedPath != _path) {
+        return;
+      }
       setState(() {
         _loading = false;
         _error = error.message ?? error.code;
       });
     } catch (error) {
-      if (!mounted) return;
+      if (!mounted || generation != _loadGeneration || requestedPath != _path) {
+        return;
+      }
       setState(() {
         _loading = false;
         _error = error.toString();
@@ -59,7 +68,8 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
   }
 
   void _openDirectory(String path) {
-    setState(() => _path = _normalizePath(path));
+    final normalizedPath = AlpineFileSystemService.normalizePath(path);
+    setState(() => _path = normalizedPath);
     unawaited(_load());
   }
 
@@ -94,9 +104,15 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
         ],
       ),
     );
-    controller.dispose();
-    if (selected == null || selected.trim().isEmpty || !mounted) return;
-    _openDirectory(selected);
+    WidgetsBinding.instance.addPostFrameCallback((_) => controller.dispose());
+    if (selected == null || selected.isEmpty || !mounted) return;
+    try {
+      _openDirectory(selected);
+    } on FormatException catch (error) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
+    }
   }
 
   Future<void> _createEntry({required bool directory}) async {
@@ -106,7 +122,7 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
           : _text(zh: '新建文件', en: 'New file'),
     );
     if (name == null) return;
-    final target = _joinPath(_path, name);
+    final target = AlpineFileSystemService.joinPath(_path, name);
     await _runMutation(() async {
       if (directory) {
         await AlpineFileSystemService.createDirectory(target);
@@ -123,7 +139,10 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
     );
     if (name == null || name == entry.name) return;
     await _runMutation(
-      () => AlpineFileSystemService.move(entry.path, _joinPath(_path, name)),
+      () => AlpineFileSystemService.move(
+        entry.path,
+        AlpineFileSystemService.joinPath(_path, name),
+      ),
     );
   }
 
@@ -183,16 +202,11 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
         ],
       ),
     );
-    controller.dispose();
-    final normalized = value?.trim();
-    if (normalized == null ||
-        normalized.isEmpty ||
-        normalized == '.' ||
-        normalized == '..' ||
-        normalized.contains('/')) {
+    WidgetsBinding.instance.addPostFrameCallback((_) => controller.dispose());
+    if (value == null || !AlpineFileSystemService.isValidEntryName(value)) {
       return null;
     }
-    return normalized;
+    return value;
   }
 
   Future<void> _runMutation(Future<void> Function() action) async {
@@ -410,22 +424,6 @@ class _AlpineFileSystemPageState extends State<AlpineFileSystemPage> {
     return parts.join(' · ');
   }
 
-  static String _normalizePath(String value) {
-    final parts = <String>[];
-    for (final segment in value.trim().replaceAll('\\', '/').split('/')) {
-      if (segment.isEmpty || segment == '.') continue;
-      if (segment == '..') {
-        if (parts.isNotEmpty) parts.removeLast();
-      } else {
-        parts.add(segment);
-      }
-    }
-    return parts.isEmpty ? '/' : '/${parts.join('/')}';
-  }
-
-  static String _joinPath(String parent, String name) =>
-      parent == '/' ? '/$name' : '$parent/$name';
-
   static String _formatBytes(int bytes) {
     if (bytes < 1024) return '$bytes B';
     if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
@@ -447,6 +445,9 @@ class _AlpineTextFilePageState extends State<_AlpineTextFilePage> {
   bool _loading = true;
   bool _saving = false;
   bool _truncated = false;
+  bool _editable = false;
+  bool _binary = false;
+  bool _isLink = false;
   String? _error;
 
   bool get _isEnglish => Localizations.localeOf(context).languageCode == 'en';
@@ -473,6 +474,9 @@ class _AlpineTextFilePageState extends State<_AlpineTextFilePage> {
       setState(() {
         _loading = false;
         _truncated = value.truncated;
+        _editable = value.editable;
+        _binary = value.binary;
+        _isLink = value.isLink;
       });
     } on PlatformException catch (error) {
       if (!mounted) return;
@@ -518,7 +522,7 @@ class _AlpineTextFilePageState extends State<_AlpineTextFilePage> {
           IconButton(
             key: const Key('alpine-fs-save-button'),
             tooltip: _text(zh: '保存', en: 'Save'),
-            onPressed: _loading || _saving || _truncated ? null : _save,
+            onPressed: _loading || _saving || !_editable ? null : _save,
             icon: _saving
                 ? const SizedBox(
                     width: 18,
@@ -550,11 +554,31 @@ class _AlpineTextFilePageState extends State<_AlpineTextFilePage> {
                     ),
                     actions: const <Widget>[SizedBox.shrink()],
                   ),
+                if (_binary)
+                  MaterialBanner(
+                    content: Text(
+                      _text(
+                        zh: '该文件不是有效 UTF-8 文本，已按只读方式打开。',
+                        en: 'This file is not valid UTF-8 text and is opened read-only.',
+                      ),
+                    ),
+                    actions: const <Widget>[SizedBox.shrink()],
+                  ),
+                if (_isLink)
+                  MaterialBanner(
+                    content: Text(
+                      _text(
+                        zh: '该路径是软链接，为避免覆盖链接目标，仅提供只读查看。',
+                        en: 'This path is a symbolic link and is read-only to protect its target.',
+                      ),
+                    ),
+                    actions: const <Widget>[SizedBox.shrink()],
+                  ),
                 Expanded(
                   child: TextField(
                     key: const Key('alpine-fs-editor'),
                     controller: _controller,
-                    readOnly: _truncated || !widget.entry.writable,
+                    readOnly: !_editable,
                     expands: true,
                     maxLines: null,
                     minLines: null,

--- a/ui/lib/features/home/pages/codex/codex_setting_page.dart
+++ b/ui/lib/features/home/pages/codex/codex_setting_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter_switch/flutter_switch.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:ui/features/home/pages/codex/codex_bridge_qr_scanner_page.dart';
 import 'package:ui/features/home/pages/codex/codex_remote_directory_picker.dart';
+import 'package:ui/features/home/pages/codex/alpine_file_system_page.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
 import 'package:ui/services/codex_app_server_service.dart';
 import 'package:ui/theme/app_colors.dart';
@@ -1210,6 +1211,26 @@ class _CodexSettingPageState extends State<CodexSettingPage> {
                           ),
                         ),
                         const SizedBox(height: 8),
+                        OutlinedButton.icon(
+                          key: const Key('codex-open-alpine-filesystem-button'),
+                          onPressed: () {
+                            Navigator.of(context).push<void>(
+                              MaterialPageRoute<void>(
+                                builder: (_) => const AlpineFileSystemPage(
+                                  initialPath: '/',
+                                ),
+                              ),
+                            );
+                          },
+                          icon: const Icon(Icons.folder_open_rounded, size: 18),
+                          label: Text(
+                            _localeText(
+                              zh: '管理 Alpine 文件系统',
+                              en: 'Manage Alpine filesystem',
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
                         _buildLocalAuthModeSelector(),
                         const SizedBox(height: 12),
                         if (_isChatGptMode) ...[

--- a/ui/lib/services/alpine_file_system_service.dart
+++ b/ui/lib/services/alpine_file_system_service.dart
@@ -50,12 +50,18 @@ class AlpineFileContent {
     required this.content,
     required this.size,
     required this.truncated,
+    required this.editable,
+    required this.binary,
+    required this.isLink,
   });
 
   final String path;
   final String content;
   final int size;
   final bool truncated;
+  final bool editable;
+  final bool binary;
+  final bool isLink;
 
   factory AlpineFileContent.fromMap(Map<dynamic, dynamic> map) {
     return AlpineFileContent(
@@ -63,6 +69,9 @@ class AlpineFileContent {
       content: (map['content'] ?? '').toString(),
       size: (map['size'] as num?)?.toInt() ?? 0,
       truncated: map['truncated'] == true,
+      editable: map['editable'] == true,
+      binary: map['binary'] == true,
+      isLink: map['isLink'] == true,
     );
   }
 }
@@ -131,5 +140,44 @@ class AlpineFileSystemService {
     await _channel.invokeMethod<Object?>('delete', <String, dynamic>{
       'path': path,
     });
+  }
+
+  static String normalizePath(String value) {
+    if (!value.startsWith('/')) {
+      throw const FormatException('An absolute Alpine path is required.');
+    }
+    if (value.contains('\u0000') ||
+        value.contains('\n') ||
+        value.contains('\r')) {
+      throw const FormatException('Invalid Alpine path.');
+    }
+    final parts = <String>[];
+    for (final segment in value.split('/')) {
+      if (segment.isEmpty || segment == '.') continue;
+      if (segment == '..') {
+        if (parts.isNotEmpty) parts.removeLast();
+      } else {
+        parts.add(segment);
+      }
+    }
+    return parts.isEmpty ? '/' : '/${parts.join('/')}';
+  }
+
+  static String joinPath(String parent, String name) {
+    final normalizedParent = normalizePath(parent);
+    if (!isValidEntryName(name)) {
+      throw const FormatException('Invalid Alpine file name.');
+    }
+    return normalizedParent == '/' ? '/$name' : '$normalizedParent/$name';
+  }
+
+  static bool isValidEntryName(String value) {
+    return value.isNotEmpty &&
+        value != '.' &&
+        value != '..' &&
+        !value.contains('/') &&
+        !value.contains('\u0000') &&
+        !value.contains('\n') &&
+        !value.contains('\r');
   }
 }

--- a/ui/lib/services/alpine_file_system_service.dart
+++ b/ui/lib/services/alpine_file_system_service.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/services.dart';
+
+class AlpineFileEntry {
+  const AlpineFileEntry({
+    required this.path,
+    required this.name,
+    required this.isDirectory,
+    required this.isFile,
+    required this.isLink,
+    required this.size,
+    required this.modifiedAt,
+    required this.mode,
+    required this.readable,
+    required this.writable,
+    required this.linkTarget,
+  });
+
+  final String path;
+  final String name;
+  final bool isDirectory;
+  final bool isFile;
+  final bool isLink;
+  final int size;
+  final int modifiedAt;
+  final String mode;
+  final bool readable;
+  final bool writable;
+  final String linkTarget;
+
+  factory AlpineFileEntry.fromMap(Map<dynamic, dynamic> map) {
+    return AlpineFileEntry(
+      path: (map['path'] ?? '').toString(),
+      name: (map['name'] ?? '').toString(),
+      isDirectory: map['isDirectory'] == true,
+      isFile: map['isFile'] == true,
+      isLink: map['isLink'] == true,
+      size: (map['size'] as num?)?.toInt() ?? 0,
+      modifiedAt: (map['modifiedAt'] as num?)?.toInt() ?? 0,
+      mode: (map['mode'] ?? '').toString(),
+      readable: map['readable'] == true,
+      writable: map['writable'] == true,
+      linkTarget: (map['linkTarget'] ?? '').toString(),
+    );
+  }
+}
+
+class AlpineFileContent {
+  const AlpineFileContent({
+    required this.path,
+    required this.content,
+    required this.size,
+    required this.truncated,
+  });
+
+  final String path;
+  final String content;
+  final int size;
+  final bool truncated;
+
+  factory AlpineFileContent.fromMap(Map<dynamic, dynamic> map) {
+    return AlpineFileContent(
+      path: (map['path'] ?? '').toString(),
+      content: (map['content'] ?? '').toString(),
+      size: (map['size'] as num?)?.toInt() ?? 0,
+      truncated: map['truncated'] == true,
+    );
+  }
+}
+
+class AlpineFileSystemService {
+  static const MethodChannel _channel = MethodChannel(
+    'cn.com.omnimind.bot/AlpineFileSystem',
+  );
+
+  static Future<List<AlpineFileEntry>> list(String path) async {
+    final result = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+      'list',
+      <String, dynamic>{'path': path},
+    );
+    final entries = result?['entries'];
+    if (entries is! List) return const <AlpineFileEntry>[];
+    final parsed = entries
+        .whereType<Map>()
+        .map(AlpineFileEntry.fromMap)
+        .toList(growable: false);
+    parsed.sort((a, b) {
+      if (a.isDirectory != b.isDirectory) return a.isDirectory ? -1 : 1;
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    });
+    return parsed;
+  }
+
+  static Future<AlpineFileContent> read(
+    String path, {
+    int maxBytes = 1024 * 1024,
+  }) async {
+    final result = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+      'read',
+      <String, dynamic>{'path': path, 'maxBytes': maxBytes},
+    );
+    return AlpineFileContent.fromMap(result ?? const <dynamic, dynamic>{});
+  }
+
+  static Future<void> write(String path, String content) async {
+    await _channel.invokeMethod<Object?>('write', <String, dynamic>{
+      'path': path,
+      'content': content,
+    });
+  }
+
+  static Future<void> createDirectory(String path) async {
+    await _channel.invokeMethod<Object?>('createDirectory', <String, dynamic>{
+      'path': path,
+    });
+  }
+
+  static Future<void> createFile(String path) async {
+    await _channel.invokeMethod<Object?>('createFile', <String, dynamic>{
+      'path': path,
+    });
+  }
+
+  static Future<void> move(String sourcePath, String targetPath) async {
+    await _channel.invokeMethod<Object?>('move', <String, dynamic>{
+      'sourcePath': sourcePath,
+      'targetPath': targetPath,
+    });
+  }
+
+  static Future<void> delete(String path) async {
+    await _channel.invokeMethod<Object?>('delete', <String, dynamic>{
+      'path': path,
+    });
+  }
+}

--- a/ui/lib/services/alpine_file_system_service.dart
+++ b/ui/lib/services/alpine_file_system_service.dart
@@ -13,6 +13,9 @@ class AlpineFileEntry {
     required this.readable,
     required this.writable,
     required this.linkTarget,
+    required this.pathToken,
+    required this.nameToken,
+    required this.hasValidUtf8Path,
   });
 
   final String path;
@@ -26,6 +29,11 @@ class AlpineFileEntry {
   final bool readable;
   final bool writable;
   final String linkTarget;
+  final String pathToken;
+  final String nameToken;
+  final bool hasValidUtf8Path;
+
+  String get entryId => hasValidUtf8Path ? path : pathToken;
 
   factory AlpineFileEntry.fromMap(Map<dynamic, dynamic> map) {
     return AlpineFileEntry(
@@ -40,6 +48,9 @@ class AlpineFileEntry {
       readable: map['readable'] == true,
       writable: map['writable'] == true,
       linkTarget: (map['linkTarget'] ?? '').toString(),
+      pathToken: (map['pathToken'] ?? map['path'] ?? '').toString(),
+      nameToken: (map['nameToken'] ?? '').toString(),
+      hasValidUtf8Path: map['hasValidUtf8Path'] != false,
     );
   }
 }

--- a/ui/test/features/home/pages/codex/alpine_file_system_page_test.dart
+++ b/ui/test/features/home/pages/codex/alpine_file_system_page_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/codex/alpine_file_system_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('cn.com.omnimind.bot/AlpineFileSystem');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  testWidgets('browses Alpine root and opens a directory', (tester) async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      final path = (call.arguments as Map)['path'];
+      return <String, dynamic>{
+        'path': path,
+        'entries': path == '/'
+            ? <Map<String, dynamic>>[
+                _entry(path: '/root', name: 'root', directory: true),
+                _entry(
+                  path: '/etc/os-release',
+                  name: 'os-release',
+                  directory: false,
+                ),
+              ]
+            : <Map<String, dynamic>>[
+                _entry(path: '/root/.codex', name: '.codex', directory: true),
+              ],
+      };
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: AlpineFileSystemPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('root'), findsOneWidget);
+    expect(find.text('os-release'), findsOneWidget);
+
+    await tester.tap(find.text('root'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('.codex'), findsOneWidget);
+    expect(calls.map((call) => call.method), <String>['list', 'list']);
+    expect((calls.last.arguments as Map)['path'], '/root');
+  });
+
+  testWidgets('opens and saves a writable Alpine text file', (tester) async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'read') {
+        return <String, dynamic>{
+          'path': '/root/.codex/config.toml',
+          'content': 'model = "gpt-test"',
+          'size': 18,
+          'truncated': false,
+        };
+      }
+      if (call.method == 'write') {
+        return <String, dynamic>{'path': '/root/.codex/config.toml'};
+      }
+      return <String, dynamic>{
+        'path': '/root/.codex',
+        'entries': <Map<String, dynamic>>[
+          _entry(
+            path: '/root/.codex/config.toml',
+            name: 'config.toml',
+            directory: false,
+          ),
+        ],
+      };
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AlpineFileSystemPage(initialPath: '/root/.codex'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('config.toml'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('model = "gpt-test"'), findsOneWidget);
+    await tester.enterText(
+      find.byKey(const Key('alpine-fs-editor')),
+      'model = "gpt-updated"',
+    );
+    await tester.tap(find.byKey(const Key('alpine-fs-save-button')));
+    await tester.pumpAndSettle();
+
+    final writeCall = calls.firstWhere((call) => call.method == 'write');
+    expect(writeCall.arguments, <String, dynamic>{
+      'path': '/root/.codex/config.toml',
+      'content': 'model = "gpt-updated"',
+    });
+  });
+}
+
+Map<String, dynamic> _entry({
+  required String path,
+  required String name,
+  required bool directory,
+}) {
+  return <String, dynamic>{
+    'path': path,
+    'name': name,
+    'isDirectory': directory,
+    'isFile': !directory,
+    'isLink': false,
+    'size': directory ? 4096 : 18,
+    'modifiedAt': 0,
+    'mode': directory ? '755' : '644',
+    'readable': true,
+    'writable': true,
+    'linkTarget': '',
+  };
+}

--- a/ui/test/features/home/pages/codex/alpine_file_system_page_test.dart
+++ b/ui/test/features/home/pages/codex/alpine_file_system_page_test.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ui/features/home/pages/codex/alpine_file_system_page.dart';
+import 'package:ui/services/alpine_file_system_service.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -60,6 +63,9 @@ void main() {
           'content': 'model = "gpt-test"',
           'size': 18,
           'truncated': false,
+          'editable': true,
+          'binary': false,
+          'isLink': false,
         };
       }
       if (call.method == 'write') {
@@ -100,24 +106,211 @@ void main() {
       'content': 'model = "gpt-updated"',
     });
   });
+
+  test('preserves trailing spaces and backslashes in Linux paths', () {
+    expect(AlpineFileSystemService.normalizePath('/root/file '), '/root/file ');
+    expect(AlpineFileSystemService.normalizePath(r'/root/a\b'), r'/root/a\b');
+    expect(AlpineFileSystemService.joinPath('/root', r'a\b '), r'/root/a\b ');
+  });
+
+  testWidgets('keeps binary and malformed UTF-8 files read-only', (
+    tester,
+  ) async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'read') {
+        return <String, dynamic>{
+          'path': '/root/libbinary.so',
+          'content': '',
+          'size': 32,
+          'truncated': false,
+          'editable': false,
+          'binary': true,
+          'isLink': false,
+        };
+      }
+      return <String, dynamic>{
+        'path': '/root',
+        'entries': <Map<String, dynamic>>[
+          _entry(
+            path: '/root/libbinary.so',
+            name: 'libbinary.so',
+            directory: false,
+          ),
+        ],
+      };
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AlpineFileSystemPage(initialPath: '/root')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('libbinary.so'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('not valid UTF-8 text'), findsOneWidget);
+    final editor = tester.widget<TextField>(
+      find.byKey(const Key('alpine-fs-editor')),
+    );
+    expect(editor.readOnly, isTrue);
+    final saveButton = tester.widget<IconButton>(
+      find.byKey(const Key('alpine-fs-save-button')),
+    );
+    expect(saveButton.onPressed, isNull);
+    expect(calls.where((call) => call.method == 'write'), isEmpty);
+  });
+
+  testWidgets('opens a directory symlink using its logical path', (
+    tester,
+  ) async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      final path = (call.arguments as Map)['path'];
+      return <String, dynamic>{
+        'path': path,
+        'entries': path == '/'
+            ? <Map<String, dynamic>>[
+                _entry(
+                  path: '/var/run',
+                  name: 'run',
+                  directory: true,
+                  isLink: true,
+                  linkTarget: '../run',
+                ),
+              ]
+            : <Map<String, dynamic>>[
+                _entry(
+                  path: '/var/run/service',
+                  name: 'service',
+                  directory: false,
+                ),
+              ],
+      };
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: AlpineFileSystemPage()));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('run'));
+    await tester.pumpAndSettle();
+
+    expect((calls.last.arguments as Map)['path'], '/var/run');
+    expect(find.text('service'), findsOneWidget);
+  });
+
+  testWidgets('discards stale directory responses', (tester) async {
+    final rootResponse = Completer<Map<String, dynamic>>();
+    final nestedResponse = Completer<Map<String, dynamic>>();
+    messenger.setMockMethodCallHandler(channel, (call) {
+      final path = (call.arguments as Map)['path'];
+      return path == '/' ? rootResponse.future : nestedResponse.future;
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: AlpineFileSystemPage()));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('alpine-fs-jump-button')));
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const Key('alpine-fs-path-field')),
+      '/root',
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pump();
+
+    nestedResponse.complete(<String, dynamic>{
+      'path': '/root',
+      'entries': <Map<String, dynamic>>[
+        _entry(
+          path: '/root/current.txt',
+          name: 'current.txt',
+          directory: false,
+        ),
+      ],
+    });
+    await tester.pump();
+    expect(find.text('current.txt'), findsOneWidget);
+
+    rootResponse.complete(<String, dynamic>{
+      'path': '/',
+      'entries': <Map<String, dynamic>>[
+        _entry(path: '/stale.txt', name: 'stale.txt', directory: false),
+      ],
+    });
+    await tester.pump();
+
+    expect(find.text('current.txt'), findsOneWidget);
+    expect(find.text('stale.txt'), findsNothing);
+  });
+
+  testWidgets('surfaces rename conflicts without reloading the directory', (
+    tester,
+  ) async {
+    final calls = <MethodCall>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      if (call.method == 'move') {
+        throw PlatformException(
+          code: 'ALPINE_FS_OPERATION_FAILED',
+          message: 'Target already exists: /root/existing.txt',
+        );
+      }
+      return <String, dynamic>{
+        'path': '/root',
+        'entries': <Map<String, dynamic>>[
+          _entry(
+            path: '/root/source.txt',
+            name: 'source.txt',
+            directory: false,
+          ),
+        ],
+      };
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AlpineFileSystemPage(initialPath: '/root')),
+    );
+    await tester.pumpAndSettle();
+
+    final entry = find.byKey(
+      const ValueKey('alpine-fs-entry-/root/source.txt'),
+    );
+    await tester.tap(
+      find.descendant(
+        of: entry,
+        matching: find.byType(PopupMenuButton<String>),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Rename'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'existing.txt');
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Target already exists'), findsOneWidget);
+    expect(calls.where((call) => call.method == 'list').length, 1);
+  });
 }
 
 Map<String, dynamic> _entry({
   required String path,
   required String name,
   required bool directory,
+  bool isLink = false,
+  String linkTarget = '',
 }) {
   return <String, dynamic>{
     'path': path,
     'name': name,
     'isDirectory': directory,
     'isFile': !directory,
-    'isLink': false,
+    'isLink': isLink,
     'size': directory ? 4096 : 18,
     'modifiedAt': 0,
     'mode': directory ? '755' : '644',
     'readable': true,
     'writable': true,
-    'linkTarget': '',
+    'linkTarget': linkTarget,
   };
 }

--- a/ui/test/features/home/pages/codex/alpine_file_system_page_test.dart
+++ b/ui/test/features/home/pages/codex/alpine_file_system_page_test.dart
@@ -291,6 +291,74 @@ void main() {
     expect(find.textContaining('Target already exists'), findsOneWidget);
     expect(calls.where((call) => call.method == 'list').length, 1);
   });
+
+  testWidgets(
+    'disables invalid UTF-8 paths without aliasing replacement-character names',
+    (tester) async {
+      final calls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        if (call.method == 'read') {
+          return <String, dynamic>{
+            'path': '/root/\uFFFD',
+            'content': 'literal replacement character',
+            'size': 29,
+            'truncated': false,
+            'editable': true,
+            'binary': false,
+            'isLink': false,
+          };
+        }
+        return <String, dynamic>{
+          'path': '/root',
+          'entries': <Map<String, dynamic>>[
+            _entry(
+              path: '',
+              name: '',
+              directory: false,
+              pathToken: 'L3Jvb3Qv/w==',
+              nameToken: '/w==',
+              hasValidUtf8Path: false,
+            ),
+            _entry(path: '/root/\uFFFD', name: '\uFFFD', directory: false),
+          ],
+        };
+      });
+
+      await tester.pumpWidget(
+        const MaterialApp(home: AlpineFileSystemPage(initialPath: '/root')),
+      );
+      await tester.pumpAndSettle();
+
+      final invalidEntry = find.byKey(
+        const ValueKey('alpine-fs-entry-L3Jvb3Qv/w=='),
+      );
+      expect(
+        find.descendant(
+          of: invalidEntry,
+          matching: find.textContaining('Non-UTF-8 filename'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: invalidEntry,
+          matching: find.byType(PopupMenuButton<String>),
+        ),
+        findsNothing,
+      );
+
+      await tester.tap(invalidEntry);
+      await tester.pumpAndSettle();
+      expect(calls.where((call) => call.method == 'read'), isEmpty);
+
+      await tester.tap(find.text('\uFFFD'));
+      await tester.pumpAndSettle();
+      final readCall = calls.singleWhere((call) => call.method == 'read');
+      expect((readCall.arguments as Map)['path'], '/root/\uFFFD');
+      expect(find.text('literal replacement character'), findsOneWidget);
+    },
+  );
 }
 
 Map<String, dynamic> _entry({
@@ -299,6 +367,9 @@ Map<String, dynamic> _entry({
   required bool directory,
   bool isLink = false,
   String linkTarget = '',
+  String? pathToken,
+  String nameToken = '',
+  bool hasValidUtf8Path = true,
 }) {
   return <String, dynamic>{
     'path': path,
@@ -312,5 +383,8 @@ Map<String, dynamic> _entry({
     'readable': true,
     'writable': true,
     'linkTarget': linkTarget,
+    'pathToken': pathToken ?? path,
+    'nameToken': nameToken,
+    'hasValidUtf8Path': hasValidUtf8Path,
   };
 }


### PR DESCRIPTION
## 功能

为本地 Alpine Codex 增加完整文件系统管理入口：

- 从 `/` 浏览 Alpine / PRoot 文件系统
- 支持 `/root`、`/etc`、`/usr`、`/workspace` 及挂载目录
- 文本文件读取、编辑与保存
- 新建文件和目录
- 重命名、移动与递归删除
- 复制 Linux 绝对路径
- 显示权限、大小和软链接目标
- 从 Codex 设置页直接进入文件系统管理

## 实现

- 文件操作通过 `TerminalManager` 在 Alpine 内执行，保持 PRoot 挂载及软链接语义
- Flutter 与原生层通过独立 MethodChannel 通信
- 文件名和列表字段使用 Base64 编码传输，兼容中文及特殊字符
- 文本保存使用应用缓存临时文件传入 Alpine，避免 Shell 参数长度限制
- 单文件编辑上限为 1 MB，超出时只读预览前 1 MB

## 改动范围

仅涉及本地 Alpine 文件管理及 Codex 设置入口，不修改 Agent provider、远程 Bridge 和模型配置逻辑。

## 验证

- Flutter 定向静态分析：通过
- Alpine 文件系统 Flutter 页面测试：2/2 通过
- Codex 相关 Flutter 回归测试：16/16 通过
- Kotlin `AlpineFileSystemServiceTest`：通过
- `:app:testDevelopStandardDebugUnitTest` 定向任务：通过

Windows 环境下 `prepareEmbeddedTerminalRuntime` 的 tar 解包存在上游路径兼容问题，定向 Android 测试通过跳过该解包任务执行。