### PR TITLE
fix: make subagent expert routing actionable

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -62,7 +62,9 @@ class AgentOrchestrator(
         val initialMessages: List<ChatCompletionMessage>,
         val executionEnv: AgentExecutionEnvironment,
         val conversationId: Long? = null,
-        val contextCompactor: AgentConversationContextCompactor? = null
+        val contextCompactor: AgentConversationContextCompactor? = null,
+        val maxModelRounds: Int? = null,
+        val maxCompletionTokens: Int = 16384
     )
 
     private val json = Json {
@@ -132,6 +134,17 @@ class AgentOrchestrator(
 
         try {
             roundLoop@ while (true) {
+                val maxModelRounds = input.maxModelRounds?.coerceAtLeast(1)
+                if (maxModelRounds != null && completedModelRounds >= maxModelRounds) {
+                    val message = t(
+                        "Agent 已达到 $maxModelRounds 轮模型调用上限。",
+                        "Agent reached the $maxModelRounds-round model-call limit."
+                    )
+                    callback.onError(message, false)
+                    terminalError = AgentResult.Error(message)
+                    terminated = true
+                    break@roundLoop
+                }
                 completedModelRounds += 1
                 val round = completedModelRounds
                 val assistantContentPrefix = accumulatedAssistantContent
@@ -153,7 +166,7 @@ class AgentOrchestrator(
                         request = ChatCompletionRequest(
                             messages = memory.snapshot(),
                             model = model,
-                            maxCompletionTokens = 16384,
+                            maxCompletionTokens = input.maxCompletionTokens.coerceIn(1, 16384),
                             stream = true,
                             streamOptions = ChatCompletionStreamOptions(includeUsage = true),
                             enableThinking = if (disableThinking) false else null,

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentSystemPrompt.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentSystemPrompt.kt
@@ -198,6 +198,9 @@ object AgentSystemPrompt {
                 - 如果项目已有 `pyproject.toml` 或 `uv.lock`，优先考虑 `uv sync`、`uv run` 这类工作流，而不是污染系统 Python。
                 - 查询当前有哪些 skills、某类 skill 是否已安装，优先用 `skills_list`。
                 - 如果某个已安装 skill 看起来相关，但本轮没有注入它的正文，使用 `skills_read` 读取对应 `SKILL.md`，不要凭索引信息臆测细节。
+                - 当任务包含两个或更多相互独立、可并行的工作流，或存在边界清晰的检索/规划/记忆整理子任务时，主动使用 `subagent_dispatch`，不要等用户明确要求分派。
+                - 分派时为每个子任务写完整、自足的 instruction，并选择合适的 profileId：`explorer` 用于只读检索与查证，`planner` 用于只输出计划，`memory-curator` 用于记忆整理，`general` 用于其他可读写工作区的任务。
+                - 简单任务、只有一个紧密耦合步骤的任务、必须串行共享中间状态的任务不要分派。终端、高权限、删除以及需要用户确认的动作仍由父 Agent 处理。
                 - 记忆纪律（重要）：记忆工具统一使用 `memory_*`——短期写 `memory_write_daily`，长期写 `memory_upsert_longterm`，检索用 `memory_search`，整理用 `memory_rollup_day`。
                 - 短期记忆要“宁可多写”：只要本轮出现下列任一情况，就在给出最终回复前调用 `memory_write_daily` 落一条简短记录——用户偏好/习惯/画像、关键决定及理由、任务目标与进度、外部标识（路径/ID/账号别名/链接）、被用户纠正的行为或事实、踩坑与解决办法。
                 - 每条短期记忆一句话、客观具体；不确定要不要记时，默认记到短期。
@@ -262,6 +265,9 @@ object AgentSystemPrompt {
                 - If the project already has `pyproject.toml` or `uv.lock`, prefer workflows such as `uv sync` and `uv run` instead of polluting system Python.
                 - Use `skills_list` first when you need to know which skills are installed or whether a category of skill exists.
                 - If an installed skill seems relevant but its full body was not injected in this turn, use `skills_read` to load the corresponding `SKILL.md` instead of guessing from the index.
+                - Proactively use `subagent_dispatch` when a task contains two or more independent workstreams that can run in parallel, or when it has a clearly bounded research, planning, or memory-curation subtask. Do not wait for the user to explicitly request delegation.
+                - Give every subtask complete, self-contained instructions and choose an appropriate profileId: use `explorer` for read-only research and verification, `planner` for plan-only work, `memory-curator` for memory organization, and `general` for other workspace tasks that may read or write files.
+                - Do not dispatch trivial work, a single tightly coupled step, or work that must share intermediate state sequentially. The parent agent remains responsible for terminal, privileged, destructive, and user-confirmed actions.
                 - Memory discipline (important): use `memory_*` for memory — `memory_write_daily` (short-term), `memory_upsert_longterm` (long-term), `memory_search` (retrieval), `memory_rollup_day` (rollup).
                 - Bias toward writing SHORT-term memory: whenever this turn surfaces any of the following, call `memory_write_daily` before your final reply — user preferences/habits/profile, key decisions and rationale, task goals and progress, external identifiers (paths/IDs/account aliases/links), behaviors or facts the user corrected, pitfalls and their fixes.
                 - Keep each short-term note to one concrete sentence; when unsure whether to record something, default to writing it to short-term.

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/SubagentDispatcher.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/SubagentDispatcher.kt
@@ -186,7 +186,11 @@ class SubagentDispatcher(
                     initialMessages = listOf(systemMessage, userMessage),
                     executionEnv = subEnv,
                     conversationId = null,
-                    contextCompactor = null
+                    contextCompactor = null,
+                    maxModelRounds = spec.budgetRounds
+                        ?.coerceIn(1, profile.maxRounds)
+                        ?: profile.maxRounds,
+                    maxCompletionTokens = profile.maxOutputTokens
                 )
             )
             when (result) {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentToolDefinitions.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentToolDefinitions.kt
@@ -498,11 +498,18 @@ object AgentToolDefinitions {
         "整理后等待工具结果，再决定是否补充长期记忆。" to
             "Wait for the tool result after the rollup, then decide whether to add more long-term memory.",
         "可选日期，格式 YYYY-MM-DD。" to "Optional date in YYYY-MM-DD format.",
-        "把多个可并行的小任务分派给 subagent 集群执行，并返回聚合结果。" to
-            "Dispatch multiple parallelizable subtasks to the subagent cluster and return the aggregated result.",
+        "把多个相互独立、可并行的小任务主动分派给具有隔离上下文的 subagent，并返回聚合结果。简单任务或必须严格串行共享中间状态的任务不要分派。" to
+            "Proactively dispatch multiple independent, parallelizable subtasks to subagents with isolated contexts and return the aggregated result. Do not dispatch trivial tasks or tasks that must share intermediate state in strict sequence.",
         "分派后等待工具结果，再汇总给用户。" to
             "Wait for the tool result after dispatching, then summarize it for the user.",
-        "需要并行执行的子任务列表。" to "List of subtasks to execute in parallel.",
+        "需要并行执行的子任务列表。每项都要包含自足的 instruction，并按任务性质选择 profileId。" to
+            "List of subtasks to execute in parallel. Each item must contain a self-contained instruction and choose a profileId appropriate for the task.",
+        "子任务的完整、自足指令，不要依赖主会话中未写入此处的上下文。" to
+            "Complete, self-contained instructions for the subtask. Do not rely on main-conversation context that is not included here.",
+        "专家类型：general 可读写工作区；explorer 只读检索与查证；memory-curator 整理记忆；planner 只输出计划。" to
+            "Expert type: general can read and write the workspace; explorer performs read-only research and verification; memory-curator organizes memory; planner only produces a plan.",
+        "未给子任务指定 profileId 时使用的专家类型，默认 general。" to
+            "Expert type used when a subtask omits profileId. Defaults to general.",
         "并发度，默认 2，范围 1-6。" to "Concurrency level. Default 2, range 1-6.",
         "结果聚合要求，可选。" to "Optional instructions for result aggregation.",
         "创建新的定时任务。`targetKind=subagent` 为唯一支持的执行类型。执行后等待工具结果，再决定是否回复用户；`subagentPrompt` 必须写成任务触发时要立即执行的动作，不要重复填写“每天几点提醒我/定时去做”这类调度描述。" to
@@ -2031,7 +2038,10 @@ object AgentToolDefinitions {
             put("name", "subagent_dispatch")
             put("displayName", "分派子任务")
             put("toolType", "subagent")
-            put("description", "把多个可并行的小任务分派给 subagent 集群执行，并返回聚合结果。")
+            put(
+                "description",
+                "把多个相互独立、可并行的小任务主动分派给具有隔离上下文的 subagent，并返回聚合结果。简单任务或必须严格串行共享中间状态的任务不要分派。"
+            )
             put("postToolRule", "分派后等待工具结果，再汇总给用户。")
             putJsonObject("parameters") {
                 put("type", "object")
@@ -2039,9 +2049,50 @@ object AgentToolDefinitions {
                     putJsonObject("tasks") {
                         put("type", "array")
                         putJsonObject("items") {
-                            put("type", "string")
+                            put("type", "object")
+                            putJsonObject("properties") {
+                                putJsonObject("instruction") {
+                                    put("type", "string")
+                                    put(
+                                        "description",
+                                        "子任务的完整、自足指令，不要依赖主会话中未写入此处的上下文。"
+                                    )
+                                }
+                                putJsonObject("profileId") {
+                                    put("type", "string")
+                                    putJsonArray("enum") {
+                                        add("general")
+                                        add("explorer")
+                                        add("memory-curator")
+                                        add("planner")
+                                    }
+                                    put(
+                                        "description",
+                                        "专家类型：general 可读写工作区；explorer 只读检索与查证；memory-curator 整理记忆；planner 只输出计划。"
+                                    )
+                                }
+                            }
+                            putJsonArray("required") {
+                                add("instruction")
+                            }
                         }
-                        put("description", "需要并行执行的子任务列表。")
+                        put(
+                            "description",
+                            "需要并行执行的子任务列表。每项都要包含自足的 instruction，并按任务性质选择 profileId。"
+                        )
+                    }
+                    putJsonObject("defaultProfileId") {
+                        put("type", "string")
+                        putJsonArray("enum") {
+                            add("general")
+                            add("explorer")
+                            add("memory-curator")
+                            add("planner")
+                        }
+                        put(
+                            "description",
+                            "未给子任务指定 profileId 时使用的专家类型，默认 general。"
+                        )
                     }
                     putJsonObject("concurrency") {
                         put("type", "integer")

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentOrchestratorTest.kt
@@ -82,6 +82,44 @@ class AgentOrchestratorTest {
     }
 
     @Test
+    fun inputLimitsModelRoundsAndCompletionTokens() = runBlocking {
+        val llmClient = FakeLlmClient(
+            turns = listOf(
+                assistantTurn(toolCalls = listOf(toolCall("file_read")))
+            )
+        )
+        val toolExecutor = FakeToolExecutor(
+            results = mapOf(
+                "file_read" to listOf(
+                    ToolExecutionResult.ContextResult(
+                        toolName = "file_read",
+                        summaryText = "read",
+                        previewJson = "{}",
+                        rawResultJson = "{}",
+                        success = true
+                    )
+                )
+            )
+        )
+        val callback = RecordingCallback()
+
+        val result = createOrchestrator(llmClient, toolExecutor).run(
+            AgentOrchestrator.Input(
+                callback = callback,
+                initialMessages = initialMessages("读取文件后继续"),
+                executionEnv = FakeExecutionEnvironment("读取文件后继续"),
+                maxModelRounds = 1,
+                maxCompletionTokens = 4096
+            )
+        )
+
+        assertTrue(result is AgentResult.Error)
+        assertEquals(1, llmClient.requests.size)
+        assertEquals(4096, llmClient.requests.single().maxCompletionTokens)
+        assertTrue(callback.errors.single().contains("1 轮模型调用上限"))
+    }
+
+    @Test
     fun failedToolResultCanNaturallyBecomeTextReply() = runBlocking {
         val llmClient = FakeLlmClient(
             turns = listOf(

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentSystemPromptTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentSystemPromptTest.kt
@@ -37,6 +37,9 @@ class AgentSystemPromptTest {
         assertTrue(prompt.contains("--break-system-packages"))
         assertTrue(prompt.contains("shell.exec"))
         assertTrue(prompt.contains("android_privileged_session_*"))
+        assertTrue(prompt.contains("主动使用 `subagent_dispatch`"))
+        assertTrue(prompt.contains("完整、自足的 instruction"))
+        assertTrue(prompt.contains("终端、高权限、删除以及需要用户确认的动作仍由父 Agent 处理"))
     }
 
     @Test
@@ -80,6 +83,9 @@ class AgentSystemPromptTest {
         assertTrue(prompt.contains("Skills:"))
         assertTrue(prompt.contains("action=shell.exec"))
         assertTrue(prompt.contains("android_privileged_session_*"))
+        assertTrue(prompt.contains("Proactively use `subagent_dispatch`"))
+        assertTrue(prompt.contains("complete, self-contained instructions"))
+        assertTrue(prompt.contains("The parent agent remains responsible"))
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentToolDefinitionsSubagentTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentToolDefinitionsSubagentTest.kt
@@ -1,0 +1,72 @@
+package cn.com.omnimind.bot.agent
+
+import cn.com.omnimind.baselib.i18n.PromptLocale
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentToolDefinitionsSubagentTest {
+
+    @Test
+    fun `subagent schema exposes expert profile selection`() {
+        val function = subagentFunction(PromptLocale.ZH_CN)
+        val parameters = function["parameters"] as JsonObject
+        val properties = parameters["properties"] as JsonObject
+        val tasks = properties["tasks"] as JsonObject
+        val item = tasks["items"] as JsonObject
+        val itemProperties = item["properties"] as JsonObject
+        val profile = itemProperties["profileId"] as JsonObject
+        val defaultProfile = properties["defaultProfileId"] as JsonObject
+        val profileIds = (profile["enum"] as JsonArray).map {
+            it.jsonPrimitive.contentOrNull
+        }
+
+        assertEquals("object", item["type"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(listOf("instruction"), (item["required"] as JsonArray).map {
+            it.jsonPrimitive.contentOrNull
+        })
+        assertEquals(
+            listOf("general", "explorer", "memory-curator", "planner"),
+            profileIds
+        )
+        assertEquals(profile["enum"], defaultProfile["enum"])
+        assertTrue(
+            function["description"]?.jsonPrimitive?.contentOrNull
+                ?.contains("隔离上下文") == true
+        )
+    }
+
+    @Test
+    fun `english subagent schema explains delegation boundaries`() {
+        val function = subagentFunction(PromptLocale.EN_US)
+        val parameters = function["parameters"] as JsonObject
+        val properties = parameters["properties"] as JsonObject
+        val tasks = properties["tasks"] as JsonObject
+        val item = tasks["items"] as JsonObject
+        val itemProperties = item["properties"] as JsonObject
+        val instruction = itemProperties["instruction"] as JsonObject
+        val profile = itemProperties["profileId"] as JsonObject
+
+        assertTrue(
+            function["description"]?.jsonPrimitive?.contentOrNull
+                ?.contains("isolated contexts") == true
+        )
+        assertTrue(
+            instruction["description"]?.jsonPrimitive?.contentOrNull
+                ?.contains("self-contained") == true
+        )
+        assertTrue(
+            profile["description"]?.jsonPrimitive?.contentOrNull
+                ?.contains("read-only research") == true
+        )
+    }
+
+    private fun subagentFunction(locale: PromptLocale): JsonObject {
+        val definition = AgentToolDefinitions.subagentTools(locale).single()
+        return definition["function"] as JsonObject
+    }
+}


### PR DESCRIPTION
## Summary

- teach the main Agent to proactively dispatch independent work while avoiding trivial or tightly coupled tasks
- expose built-in expert profile selection in the model-visible `subagent_dispatch` schema
- require self-contained subtask instructions so isolated contexts receive the facts they need
- enforce each profile's existing model-round and completion-token budgets
- preserve the legacy string-array task format in the runtime handler

## Issue assessment

Issue #442 identifies a real prompt/schema gap, but several premises are stale on current `main`: subagents already run in separate orchestrators with only their own system and user messages, and multiple subtasks already execute concurrently.

This change addresses the actionable gaps without adding a second MCP/LLM stack. It intentionally keeps terminal and privileged tools behind the parent/user confirmation boundary, and does not add an automatic maintenance-model call after every task.

## Validation

- `./gradlew --no-daemon :app:testDevelopStandardDebugUnitTest`
- `./gradlew --no-daemon :app:assembleDevelopStandardDebug -Ptarget=lib/main_standard.dart`
- `git diff --check`

Relates to #442.
