### PR TITLE
feat(ui): 全局适配底部手势导航沉浸

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,7 @@ android {
     defaultConfig {
         applicationId = "cn.com.omnimind.bot"
         minSdk = 29
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "0.5.6.11"
         buildConfigField("String", "IMAGE_BASE_URL", buildConfigString(omnibotImageBaseUrl))

--- a/app/src/main/java/cn/com/omnimind/bot/activity/MainActivity.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/activity/MainActivity.kt
@@ -4,8 +4,11 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.App
@@ -56,6 +59,7 @@ class MainActivity : FlutterActivity() {
         applyResponsiveOrientation()
         applySoftInputResizeMode()
         super.onCreate(savedInstanceState)
+        applyEdgeToEdgeWindow()
         TaskRuntimeSettings.attachActivity(this)
         TaskRuntimeSettings.consumeTaskCompletionNotificationIntent(this, intent)
 
@@ -117,6 +121,15 @@ class MainActivity : FlutterActivity() {
 
     private fun applySoftInputResizeMode() {
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+    }
+
+    private fun applyEdgeToEdgeWindow() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        @Suppress("DEPRECATION")
+        window.navigationBarColor = Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/res/values-night-v31/themes.xml
+++ b/app/src/main/res/values-night-v31/themes.xml
@@ -8,7 +8,8 @@
         <item name="android:windowSplashScreenAnimationDuration">200</item>
         <item name="android:windowBackground">@drawable/splash_background_dark</item>
         <item name="android:statusBarColor">#151617</item>
-        <item name="android:navigationBarColor">#151617</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     </style>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.OmnibotApp" parent="android:Theme.Material.NoActionBar" />
+    <style name="Theme.OmnibotApp" parent="android:Theme.Material.NoActionBar">
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
 
     <style name="Theme.OmnibotApp.Splash" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowBackground">@drawable/splash_background_dark</item>
         <item name="android:statusBarColor">#151617</item>
-        <item name="android:navigationBarColor">#151617</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
         <item name="android:windowLightStatusBar">false</item>
     </style>
 

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -10,7 +10,8 @@
        <!-- 主窗口：使用与低版本相同的背景 -->
        <item name="android:windowBackground">@drawable/splash_background_dark</item>
        <item name="android:statusBarColor">#151617</item>
-       <item name="android:navigationBarColor">#151617</item>
+       <item name="android:navigationBarColor">@android:color/transparent</item>
+       <item name="android:enforceNavigationBarContrast">false</item>
        <item name="android:windowLightStatusBar">false</item>
        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
    </style>
@@ -22,7 +23,8 @@
        <item name="android:windowSplashScreenAnimationDuration">200</item>
        <item name="android:windowBackground">@drawable/splash_background_dark</item>
        <item name="android:statusBarColor">#151617</item>
-       <item name="android:navigationBarColor">#151617</item>
+       <item name="android:navigationBarColor">@android:color/transparent</item>
+       <item name="android:enforceNavigationBarContrast">false</item>
        <item name="android:windowLightStatusBar">false</item>
        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
    </style>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.OmnibotApp" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.OmnibotApp" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
 
     <style name="Theme.OmnibotApp.Splash" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowBackground">@drawable/splash_background_dark</item>
         <item name="android:statusBarColor">#151617</item>
-        <item name="android:navigationBarColor">#151617</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
         <item name="android:windowLightStatusBar">false</item>
     </style>
 
     <style name="Theme.OmnibotApp.Splash.Dark" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowBackground">@drawable/splash_background_dark</item>
         <item name="android:statusBarColor">#151617</item>
-        <item name="android:navigationBarColor">#151617</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
         <item name="android:windowLightStatusBar">false</item>
     </style>
 

--- a/ui/lib/features/home/pages/agent/agent_config_page.dart
+++ b/ui/lib/features/home/pages/agent/agent_config_page.dart
@@ -310,12 +310,16 @@ class _AgentConfigPageState extends State<AgentConfigPage> {
         ),
         body: SafeArea(
           top: false,
+          bottom: false,
           child: _loading
               ? const Center(child: CircularProgressIndicator())
               : _error != null && _agent == null
               ? _ErrorState(error: _error!, onRetry: _load)
               : ListView(
-                  padding: const EdgeInsets.fromLTRB(18, 12, 18, 28),
+                  padding: edgeToEdgeScrollPadding(
+                    context,
+                    const EdgeInsets.fromLTRB(18, 12, 18, 28),
+                  ),
                   children: [
                     SettingsSectionTitle(
                       label: _pageTitle,

--- a/ui/lib/features/home/pages/agent/agent_mode_setting_page.dart
+++ b/ui/lib/features/home/pages/agent/agent_mode_setting_page.dart
@@ -253,6 +253,7 @@ class _AgentModeSettingPageState extends State<AgentModeSettingPage> {
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: _loading
             ? const Center(child: CircularProgressIndicator())
             : _error != null && (_catalog?.agents.isEmpty ?? true)
@@ -273,7 +274,10 @@ class _AgentModeSettingPageState extends State<AgentModeSettingPage> {
                 ),
               )
             : ListView(
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 28),
+                padding: edgeToEdgeScrollPadding(
+                  context,
+                  const EdgeInsets.fromLTRB(18, 12, 18, 28),
+                ),
                 children: [
                   SettingsSectionTitle(
                     label: _text('托管 Agent', 'Managed Agents'),
@@ -767,10 +771,7 @@ class _RemoteBridgeCard extends StatelessWidget {
                   ],
                 ),
               ),
-              Icon(
-                Icons.chevron_right_rounded,
-                color: palette.textTertiary,
-              ),
+              Icon(Icons.chevron_right_rounded, color: palette.textTertiary),
             ],
           ),
         ),

--- a/ui/lib/features/home/pages/agent/agent_sessions_page.dart
+++ b/ui/lib/features/home/pages/agent/agent_sessions_page.dart
@@ -721,6 +721,8 @@ class _AgentSessionsPageState extends State<AgentSessionsPage> {
       backgroundColor: palette.pageBackground,
       appBar: CommonAppBar(title: _title, primary: true),
       body: SafeArea(
+        top: false,
+        bottom: false,
         child: RefreshIndicator(onRefresh: _loadSessions, child: _buildBody()),
       ),
     );
@@ -742,7 +744,10 @@ class _AgentSessionsPageState extends State<AgentSessionsPage> {
     final visibleSessions = _filteredSessions;
     return ListView(
       physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.fromLTRB(18, 12, 18, 32),
+      padding: edgeToEdgeScrollPadding(
+        context,
+        const EdgeInsets.fromLTRB(18, 12, 18, 32),
+      ),
       children: [
         _buildOverviewPanel(),
         if (_error != null) ...[
@@ -1468,6 +1473,7 @@ class _AgentSessionWorkspacePage extends StatelessWidget {
       appBar: CommonAppBar(title: title, primary: true),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: CodexRemoteWorkspaceBrowser(
           workspacePath: workspacePath,
           remoteBridgeUrl: remoteBridgeUrl,

--- a/ui/lib/features/home/pages/agent/codex_remote_workspace_browser.dart
+++ b/ui/lib/features/home/pages/agent/codex_remote_workspace_browser.dart
@@ -746,6 +746,7 @@ class CodexRemoteWorkspaceBrowserState
     final palette = context.omniPalette;
     return ListView(
       physics: const AlwaysScrollableScrollPhysics(),
+      padding: edgeToEdgeScrollPadding(context, EdgeInsets.zero),
       children: [
         SizedBox(
           height: 280,
@@ -811,7 +812,10 @@ class CodexRemoteWorkspaceBrowserState
             )
           : ListView.builder(
               physics: const AlwaysScrollableScrollPhysics(),
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+              padding: edgeToEdgeScrollPadding(
+                context,
+                const EdgeInsets.fromLTRB(16, 12, 16, 16),
+              ),
               itemCount: itemCount,
               itemBuilder: (context, index) {
                 final isFirst = index == 0;

--- a/ui/lib/features/home/pages/agent/remote_codex_setting_page.dart
+++ b/ui/lib/features/home/pages/agent/remote_codex_setting_page.dart
@@ -327,10 +327,14 @@ class _RemoteCodexSettingPageState extends State<RemoteCodexSettingPage> {
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: _loading
             ? const Center(child: CircularProgressIndicator())
             : ListView(
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 28),
+                padding: edgeToEdgeScrollPadding(
+                  context,
+                  const EdgeInsets.fromLTRB(18, 12, 18, 28),
+                ),
                 children: [
                   SettingsSectionTitle(
                     label: _text('Codex 远程运行', 'Remote Codex runtime'),

--- a/ui/lib/features/home/pages/authorize/authorize_page.dart
+++ b/ui/lib/features/home/pages/authorize/authorize_page.dart
@@ -165,6 +165,7 @@ class _AuthorizePageState extends State<AuthorizePage>
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: Column(
           children: [
             Expanded(
@@ -219,9 +220,9 @@ class _AuthorizePageState extends State<AuthorizePage>
                 ),
               ),
             ),
-            Container(
-              padding: const EdgeInsets.fromLTRB(62, 16, 62, 34),
-              decoration: BoxDecoration(color: palette.pageBackground),
+            SafeArea(
+              top: false,
+              minimum: const EdgeInsets.fromLTRB(62, 16, 62, 16),
               child: ValueListenableBuilder<bool>(
                 valueListenable: _canContinue,
                 builder: (context, authorized, child) {

--- a/ui/lib/features/home/pages/authorize_setting/authorize_setting_page.dart
+++ b/ui/lib/features/home/pages/authorize_setting/authorize_setting_page.dart
@@ -4,6 +4,7 @@ import 'package:ui/l10n/l10n.dart';
 import 'package:ui/services/special_permission.dart';
 import 'package:ui/theme/theme_context.dart';
 import 'package:ui/utils/cache_util.dart';
+import 'package:ui/utils/ui.dart';
 import 'package:ui/widgets/common_app_bar.dart';
 import 'package:ui/widgets/settings_section_title.dart';
 
@@ -254,8 +255,12 @@ class _AuthorizeSettingPageState extends State<AuthorizeSettingPage>
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: ListView.separated(
-          padding: const EdgeInsets.fromLTRB(18, 12, 18, 28),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(18, 12, 18, 28),
+          ),
           itemCount: sections.length + 1,
           separatorBuilder: (_, __) => const SizedBox(height: 24),
           itemBuilder: (context, index) {

--- a/ui/lib/features/home/pages/chat_history/chat_history_page.dart
+++ b/ui/lib/features/home/pages/chat_history/chat_history_page.dart
@@ -352,7 +352,7 @@ class _ChatHistoryPageState extends State<ChatHistoryPage> {
     }
 
     return ListView.builder(
-      padding: const EdgeInsets.all(16),
+      padding: edgeToEdgeScrollPadding(context, const EdgeInsets.all(16)),
       itemCount: _conversations.length,
       itemBuilder: (context, index) {
         final conversation = _conversations[index];

--- a/ui/lib/features/home/pages/logs/quick_logs_page.dart
+++ b/ui/lib/features/home/pages/logs/quick_logs_page.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:ui/l10n/legacy_text_localizer.dart';
 import 'package:ui/services/quick_log_service.dart';
 import 'package:ui/theme/theme_context.dart';
+import 'package:ui/utils/ui.dart';
 import 'package:ui/widgets/common_app_bar.dart';
 
 class QuickLogsPage extends StatefulWidget {
@@ -55,7 +56,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
         _isLoading = false;
       });
       _showMessage(
-        _t('\u52a0\u8f7d\u65e5\u5fd7\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5', 'Failed to load logs. Please try again.'),
+        _t(
+          '\u52a0\u8f7d\u65e5\u5fd7\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5',
+          'Failed to load logs. Please try again.',
+        ),
       );
     }
   }
@@ -64,7 +68,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
     final content = _composerController.text.trim();
     if (content.isEmpty) {
       _showMessage(
-        _t('\u5148\u5199\u70b9\u5185\u5bb9\u518d\u4fdd\u5b58\u5427', 'Write something before saving.'),
+        _t(
+          '\u5148\u5199\u70b9\u5185\u5bb9\u518d\u4fdd\u5b58\u5427',
+          'Write something before saving.',
+        ),
       );
       return;
     }
@@ -85,7 +92,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
     } catch (_) {
       if (!mounted) return;
       _showMessage(
-        _t('\u4fdd\u5b58\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5', 'Save failed. Please try again.'),
+        _t(
+          '\u4fdd\u5b58\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5',
+          'Save failed. Please try again.',
+        ),
       );
     } finally {
       if (mounted) {
@@ -108,7 +118,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
             controller: controller,
             maxLines: 6,
             decoration: InputDecoration(
-              hintText: _t('\u4fee\u6539\u8fd9\u6761\u65e5\u5fd7', 'Update this log'),
+              hintText: _t(
+                '\u4fee\u6539\u8fd9\u6761\u65e5\u5fd7',
+                'Update this log',
+              ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(14),
                 borderSide: BorderSide(color: palette.accentPrimary),
@@ -124,7 +137,8 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
               child: Text(_t('\u53d6\u6d88', 'Cancel')),
             ),
             FilledButton(
-              onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+              onPressed: () =>
+                  Navigator.of(context).pop(controller.text.trim()),
               child: Text(_t('\u4fdd\u5b58', 'Save')),
             ),
           ],
@@ -143,7 +157,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
     } catch (_) {
       if (!mounted) return;
       _showMessage(
-        _t('\u66f4\u65b0\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5', 'Update failed. Please try again.'),
+        _t(
+          '\u66f4\u65b0\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5',
+          'Update failed. Please try again.',
+        ),
       );
     }
   }
@@ -153,7 +170,12 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: Text(_t('\u5220\u9664\u8fd9\u6761\u65e5\u5fd7\uff1f', 'Delete this log?')),
+          title: Text(
+            _t(
+              '\u5220\u9664\u8fd9\u6761\u65e5\u5fd7\uff1f',
+              'Delete this log?',
+            ),
+          ),
           content: Text(
             _t(
               '\u5df2\u540c\u6b65\u5230\u77ed\u671f\u8bb0\u5fc6\u7684\u5185\u5bb9\u4e0d\u4f1a\u56de\u6eda\uff0c\u4f46\u8fd9\u6761\u65e5\u5fd7\u4f1a\u4ece\u5217\u8868\u79fb\u9664\u3002',
@@ -184,7 +206,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
     } catch (_) {
       if (!mounted) return;
       _showMessage(
-        _t('\u5220\u9664\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5', 'Delete failed. Please try again.'),
+        _t(
+          '\u5220\u9664\u5931\u8d25\uff0c\u8bf7\u7a0d\u540e\u91cd\u8bd5',
+          'Delete failed. Please try again.',
+        ),
       );
     }
   }
@@ -196,9 +221,9 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
   }
 
   String _formatTime(int millis) {
-    return DateFormat('yyyy-MM-dd HH:mm').format(
-      DateTime.fromMillisecondsSinceEpoch(millis),
-    );
+    return DateFormat(
+      'yyyy-MM-dd HH:mm',
+    ).format(DateTime.fromMillisecondsSinceEpoch(millis));
   }
 
   String _sourceLabel(String source) {
@@ -231,7 +256,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
         onRefresh: _loadLogs,
         child: ListView(
           physics: const AlwaysScrollableScrollPhysics(),
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          ),
           children: [
             Container(
               padding: const EdgeInsets.all(18),
@@ -249,7 +277,9 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
                         width: 40,
                         height: 40,
                         decoration: BoxDecoration(
-                          color: const Color(0xFF0EA5E9).withValues(alpha: 0.12),
+                          color: const Color(
+                            0xFF0EA5E9,
+                          ).withValues(alpha: 0.12),
                           borderRadius: BorderRadius.circular(14),
                         ),
                         child: const Icon(
@@ -263,7 +293,10 @@ class _QuickLogsPageState extends State<QuickLogsPage> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              _t('\u968f\u624b\u8bb0\u4e00\u6761', 'Capture a quick note'),
+                              _t(
+                                '\u968f\u624b\u8bb0\u4e00\u6761',
+                                'Capture a quick note',
+                              ),
                               style: TextStyle(
                                 fontSize: 17,
                                 fontWeight: FontWeight.w700,
@@ -518,7 +551,9 @@ class _QuickLogCard extends StatelessWidget {
             children: [
               _QuickLogTag(
                 label: sourceLabel,
-                backgroundColor: const Color(0xFF0EA5E9).withValues(alpha: 0.12),
+                backgroundColor: const Color(
+                  0xFF0EA5E9,
+                ).withValues(alpha: 0.12),
                 textColor: const Color(0xFF0284C7),
               ),
               _QuickLogTag(

--- a/ui/lib/features/home/pages/mcp/remote_mcp_servers_page.dart
+++ b/ui/lib/features/home/pages/mcp/remote_mcp_servers_page.dart
@@ -151,7 +151,9 @@ class _RemoteMcpServersPageState extends State<RemoteMcpServersPage> {
         _servers.removeWhere((item) => item.id == server.id);
       });
       showToast(
-        Localizations.localeOf(context).languageCode == 'en' ? 'Deleted' : '已删除',
+        Localizations.localeOf(context).languageCode == 'en'
+            ? 'Deleted'
+            : '已删除',
       );
     } catch (e) {
       showToast(
@@ -238,7 +240,10 @@ class _RemoteMcpServersPageState extends State<RemoteMcpServersPage> {
           : RefreshIndicator(
               onRefresh: _loadServers,
               child: ListView(
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                padding: edgeToEdgeScrollPadding(
+                  context,
+                  const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                ),
                 children: [
                   SettingsSectionTitle(
                     label: Localizations.localeOf(context).languageCode == 'en'
@@ -258,7 +263,7 @@ class _RemoteMcpServersPageState extends State<RemoteMcpServersPage> {
   Widget _buildEmpty() {
     final palette = context.omniPalette;
     return ListView(
-      padding: const EdgeInsets.all(24),
+      padding: edgeToEdgeScrollPadding(context, const EdgeInsets.all(24)),
       children: [
         const SizedBox(height: 120),
         Icon(
@@ -515,11 +520,11 @@ class _RemoteMcpServerEditorSheetState
           Text(
             widget.server == null
                 ? (Localizations.localeOf(context).languageCode == 'en'
-                    ? 'Add MCP Service'
-                    : '添加 MCP 服务')
+                      ? 'Add MCP Service'
+                      : '添加 MCP 服务')
                 : (Localizations.localeOf(context).languageCode == 'en'
-                    ? 'Edit MCP Service'
-                    : '编辑 MCP 服务'),
+                      ? 'Edit MCP Service'
+                      : '编辑 MCP 服务'),
             style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
           ),
           const SizedBox(height: 16),

--- a/ui/lib/features/home/pages/model_provider_setting/model_provider_setting_page.dart
+++ b/ui/lib/features/home/pages/model_provider_setting/model_provider_setting_page.dart
@@ -2874,10 +2874,14 @@ class _ModelProviderSettingPageState extends State<ModelProviderSettingPage> {
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: _isLoading
             ? const Center(child: CircularProgressIndicator())
             : ListView(
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                padding: edgeToEdgeScrollPadding(
+                  context,
+                  const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                ),
                 children: [
                   SettingsSectionTitle(
                     label: context.l10n.modelProviderConfigTitle,

--- a/ui/lib/features/home/pages/permission_guide/permission_guide_detail_page.dart
+++ b/ui/lib/features/home/pages/permission_guide/permission_guide_detail_page.dart
@@ -62,8 +62,7 @@ class _PermissionGuideDetailPageState extends State<PermissionGuideDetailPage> {
     final topic = _topic!;
     final brandInfo = PermissionGuideRepository.brandInfo(_selectedBrand);
     final steps = topic.stepsFor(_selectedBrand);
-    final brands = PermissionGuideRepository
-        .selectableBrands()
+    final brands = PermissionGuideRepository.selectableBrands()
         .where((brand) => topic.supportsBrand(brand.id))
         .toList(growable: false);
 
@@ -72,48 +71,52 @@ class _PermissionGuideDetailPageState extends State<PermissionGuideDetailPage> {
       appBar: CommonAppBar(title: topic.title, primary: true),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                children: [
-                  _buildSummaryCard(topic, brandInfo),
-                  const SizedBox(height: 16),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      for (final brand in brands)
-                        ChoiceChip(
-                          label: Text(brand.name),
-                          selected: brand.id == _selectedBrand,
-                          selectedColor: const Color(0xFFE8F2FF),
-                          backgroundColor: Colors.white,
-                          side: BorderSide(
-                            color: brand.id == _selectedBrand
-                                ? AppColors.buttonPrimary
-                                : Colors.transparent,
-                          ),
-                          labelStyle: TextStyle(
-                            color: brand.id == _selectedBrand
-                                ? AppColors.buttonPrimary
-                                : AppColors.text,
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
-                          ),
-                          onSelected: (_) {
-                            setState(() {
-                              _selectedBrand = brand.id;
-                            });
-                          },
-                        ),
-                    ],
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          ),
+          children: [
+            _buildSummaryCard(topic, brandInfo),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final brand in brands)
+                  ChoiceChip(
+                    label: Text(brand.name),
+                    selected: brand.id == _selectedBrand,
+                    selectedColor: const Color(0xFFE8F2FF),
+                    backgroundColor: Colors.white,
+                    side: BorderSide(
+                      color: brand.id == _selectedBrand
+                          ? AppColors.buttonPrimary
+                          : Colors.transparent,
+                    ),
+                    labelStyle: TextStyle(
+                      color: brand.id == _selectedBrand
+                          ? AppColors.buttonPrimary
+                          : AppColors.text,
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    onSelected: (_) {
+                      setState(() {
+                        _selectedBrand = brand.id;
+                      });
+                    },
                   ),
-                  const SizedBox(height: 16),
-                  for (var i = 0; i < steps.length; i++) ...[
-                    _buildStepCard(i + 1, steps[i]),
-                    const SizedBox(height: 12),
-                  ],
-                ],
-              ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            for (var i = 0; i < steps.length; i++) ...[
+              _buildStepCard(i + 1, steps[i]),
+              const SizedBox(height: 12),
+            ],
+          ],
+        ),
       ),
       bottomNavigationBar: SafeArea(
         minimum: const EdgeInsets.fromLTRB(16, 0, 16, 16),
@@ -160,11 +163,7 @@ class _PermissionGuideDetailPageState extends State<PermissionGuideDetailPage> {
               borderRadius: BorderRadius.circular(14),
             ),
             alignment: Alignment.center,
-            child: SvgPicture.asset(
-              topic.iconPath,
-              width: 26,
-              height: 26,
-            ),
+            child: SvgPicture.asset(topic.iconPath, width: 26, height: 26),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -280,10 +279,7 @@ class _PermissionGuideDetailPageState extends State<PermissionGuideDetailPage> {
                     alignment: Alignment.center,
                     child: const Text(
                       '示意图暂不可用',
-                      style: TextStyle(
-                        color: AppColors.text70,
-                        fontSize: 12,
-                      ),
+                      style: TextStyle(color: AppColors.text70, fontSize: 12),
                     ),
                   );
                 },

--- a/ui/lib/features/home/pages/permission_guide/permission_guide_page.dart
+++ b/ui/lib/features/home/pages/permission_guide/permission_guide_page.dart
@@ -4,15 +4,13 @@ import 'package:ui/core/router/go_router_manager.dart';
 import 'package:ui/features/home/pages/permission_guide/permission_guide_data.dart';
 import 'package:ui/features/home/pages/permission_guide/permission_guide_routes.dart';
 import 'package:ui/theme/app_colors.dart';
+import 'package:ui/utils/ui.dart';
 import 'package:ui/widgets/common_app_bar.dart';
 
 class PermissionGuidePage extends StatefulWidget {
   final String? initialBrand;
 
-  const PermissionGuidePage({
-    super.key,
-    this.initialBrand,
-  });
+  const PermissionGuidePage({super.key, this.initialBrand});
 
   @override
   State<PermissionGuidePage> createState() => _PermissionGuidePageState();
@@ -57,8 +55,12 @@ class _PermissionGuidePageState extends State<PermissionGuidePage> {
       appBar: const CommonAppBar(title: '权限开通指引', primary: true),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          ),
           children: [
             _buildHeroCard(brandInfo),
             const SizedBox(height: 16),
@@ -91,10 +93,7 @@ class _PermissionGuidePageState extends State<PermissionGuidePage> {
         gradient: const LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [
-            Color(0xFFF5FAFF),
-            Color(0xFFE8F1FF),
-          ],
+          colors: [Color(0xFFF5FAFF), Color(0xFFE8F1FF)],
         ),
         boxShadow: [
           BoxShadow(
@@ -150,10 +149,7 @@ class _PermissionGuidePageState extends State<PermissionGuidePage> {
                 const SizedBox(height: 8),
                 Text(
                   '示例系统：${brandInfo.osLabel}',
-                  style: const TextStyle(
-                    color: AppColors.text70,
-                    fontSize: 12,
-                  ),
+                  style: const TextStyle(color: AppColors.text70, fontSize: 12),
                 ),
               ],
             ),
@@ -203,10 +199,7 @@ class _PermissionGuidePageState extends State<PermissionGuidePage> {
     );
   }
 
-  Widget _buildTopicCard(
-    PermissionGuideTopicInfo topic,
-    String brandId,
-  ) {
+  Widget _buildTopicCard(PermissionGuideTopicInfo topic, String brandId) {
     return Material(
       color: Colors.white,
       borderRadius: BorderRadius.circular(18),
@@ -214,10 +207,7 @@ class _PermissionGuidePageState extends State<PermissionGuidePage> {
         borderRadius: BorderRadius.circular(18),
         onTap: () {
           GoRouterManager.push(
-            PermissionGuideRoutes.detail(
-              brand: brandId,
-              type: topic.id,
-            ),
+            PermissionGuideRoutes.detail(brand: brandId, type: topic.id),
           );
         },
         child: Padding(
@@ -232,11 +222,7 @@ class _PermissionGuidePageState extends State<PermissionGuidePage> {
                   borderRadius: BorderRadius.circular(12),
                 ),
                 alignment: Alignment.center,
-                child: SvgPicture.asset(
-                  topic.iconPath,
-                  width: 24,
-                  height: 24,
-                ),
+                child: SvgPicture.asset(topic.iconPath, width: 24, height: 24),
               ),
               const SizedBox(width: 12),
               Expanded(

--- a/ui/lib/features/home/pages/scene_model_setting/scene_model_setting_page.dart
+++ b/ui/lib/features/home/pages/scene_model_setting/scene_model_setting_page.dart
@@ -1292,10 +1292,14 @@ class _SceneModelSettingPageState extends State<SceneModelSettingPage> {
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: _isLoading
             ? const Center(child: CircularProgressIndicator())
             : ListView(
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                padding: edgeToEdgeScrollPadding(
+                  context,
+                  const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                ),
                 children: [
                   SettingsSectionTitle(
                     label: context.l10n.sceneModelMapping,

--- a/ui/lib/features/home/pages/settings/background_setting_page.dart
+++ b/ui/lib/features/home/pages/settings/background_setting_page.dart
@@ -504,8 +504,12 @@ class _BackgroundSettingPageState extends State<BackgroundSettingPage> {
       appBar: CommonAppBar(title: context.l10n.appearanceTitle, primary: true),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: SingleChildScrollView(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(16, 12, 16, 24),
+          ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/ui/lib/features/home/pages/settings/experience_misc_setting_page.dart
+++ b/ui/lib/features/home/pages/settings/experience_misc_setting_page.dart
@@ -320,8 +320,13 @@ class _ExperienceMiscSettingPageState
       backgroundColor: palette.pageBackground,
       appBar: CommonAppBar(title: context.trLegacy('杂项'), primary: true),
       body: SafeArea(
+        top: false,
+        bottom: false,
         child: ListView.separated(
-          padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          ),
           itemCount: sections.length,
           separatorBuilder: (_, __) => const SizedBox(height: 24),
           itemBuilder: (context, index) {

--- a/ui/lib/features/home/pages/settings/home_setting_page.dart
+++ b/ui/lib/features/home/pages/settings/home_setting_page.dart
@@ -143,8 +143,13 @@ class _HomeSettingPageState extends State<HomeSettingPage> {
       backgroundColor: palette.pageBackground,
       appBar: CommonAppBar(title: context.trLegacy('首页设置'), primary: true),
       body: SafeArea(
+        top: false,
+        bottom: false,
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          ),
           children: [
             _buildSectionTitle(context.trLegacy('首页问候')),
             _SettingSurface(

--- a/ui/lib/features/home/pages/settings/open_with_omnibot_setting_page.dart
+++ b/ui/lib/features/home/pages/settings/open_with_omnibot_setting_page.dart
@@ -148,8 +148,13 @@ class _OpenWithOmnibotSettingPageState
       backgroundColor: palette.pageBackground,
       appBar: CommonAppBar(title: context.trLegacy('使用小万打开'), primary: true),
       body: SafeArea(
+        top: false,
+        bottom: false,
         child: ListView.separated(
-          padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          ),
           itemCount: sections.length,
           separatorBuilder: (_, __) => const SizedBox(height: 24),
           itemBuilder: (context, index) {

--- a/ui/lib/features/home/pages/settings/settings_page.dart
+++ b/ui/lib/features/home/pages/settings/settings_page.dart
@@ -269,8 +269,13 @@ class _SettingsPageState extends State<SettingsPage> {
       backgroundColor: palette.pageBackground,
       appBar: CommonAppBar(title: context.l10n.settingsTitle, primary: true),
       body: SafeArea(
+        top: false,
+        bottom: false,
         child: ListView.separated(
-          padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          padding: edgeToEdgeScrollPadding(
+            context,
+            const EdgeInsets.fromLTRB(18, 10, 18, 28),
+          ),
           itemCount: sections.length,
           separatorBuilder: (_, __) => const SizedBox(height: 24),
           itemBuilder: (context, index) {

--- a/ui/lib/features/home/pages/settings/storage_usage_page.dart
+++ b/ui/lib/features/home/pages/settings/storage_usage_page.dart
@@ -353,7 +353,10 @@ class _StorageUsagePageState extends State<StorageUsagePage> {
               color: palette.accentPrimary,
               onRefresh: _loadSummary,
               child: ListView(
-                padding: const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                padding: edgeToEdgeScrollPadding(
+                  context,
+                  const EdgeInsets.fromLTRB(18, 12, 18, 24),
+                ),
                 children: [
                   SettingsSectionTitle(
                     label: _t(context, '存储概览', 'Storage overview'),

--- a/ui/lib/features/home/pages/settings/workspace_memory_setting_page.dart
+++ b/ui/lib/features/home/pages/settings/workspace_memory_setting_page.dart
@@ -211,7 +211,10 @@ class _WorkspaceMemorySettingPageState
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : ListView(
-              padding: const EdgeInsets.fromLTRB(18, 12, 18, 28),
+              padding: edgeToEdgeScrollPadding(
+                context,
+                const EdgeInsets.fromLTRB(18, 12, 18, 28),
+              ),
               children: [
                 SettingsSectionTitle(
                   label: context.l10n.workspaceMemoryCapability,

--- a/ui/lib/features/home/pages/skill_store/skill_store_page.dart
+++ b/ui/lib/features/home/pages/skill_store/skill_store_page.dart
@@ -293,6 +293,8 @@ class _SkillStorePageState extends State<SkillStorePage> {
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : SafeArea(
+              top: false,
+              bottom: false,
               child: Column(
                 children: [
                   Padding(
@@ -329,7 +331,10 @@ class _SkillStorePageState extends State<SkillStorePage> {
     final palette = context.omniPalette;
     return ListView.separated(
       physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.fromLTRB(18, 4, 18, 24),
+      padding: edgeToEdgeScrollPadding(
+        context,
+        const EdgeInsets.fromLTRB(18, 4, 18, 24),
+      ),
       itemCount: visibleSkills.length,
       separatorBuilder: (context, index) {
         return Padding(
@@ -350,7 +355,10 @@ class _SkillStorePageState extends State<SkillStorePage> {
   Widget _buildStateList({required Widget child}) {
     return ListView(
       physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.fromLTRB(18, 24, 18, 24),
+      padding: edgeToEdgeScrollPadding(
+        context,
+        const EdgeInsets.fromLTRB(18, 24, 18, 24),
+      ),
       children: [SizedBox(height: 160, child: child)],
     );
   }

--- a/ui/lib/features/home/pages/terms/terms_page.dart
+++ b/ui/lib/features/home/pages/terms/terms_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:ui/utils/ui.dart';
 import 'package:ui/widgets/common_app_bar.dart';
+
 // 条款页面
 class TermsPage extends StatelessWidget {
   final String title;
@@ -11,7 +13,7 @@ class TermsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     const primaryBlack = Color(0xFF333333);
     const darkGrey = Color(0xFF666666);
-    
+
     return Scaffold(
       appBar: CommonAppBar(
         title: title,
@@ -20,14 +22,9 @@ class TermsPage extends StatelessWidget {
           Navigator.pop(context);
         },
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: SingleChildScrollView(
-          child: Text(
-            content,
-            style: TextStyle(fontSize: 12.0, color: darkGrey),
-          ),
-        ),
+      body: SingleChildScrollView(
+        padding: edgeToEdgeScrollPadding(context, const EdgeInsets.all(16)),
+        child: Text(content, style: TextStyle(fontSize: 12.0, color: darkGrey)),
       ),
     );
   }

--- a/ui/lib/features/home/pages/termux_setting/termux_setting_page.dart
+++ b/ui/lib/features/home/pages/termux_setting/termux_setting_page.dart
@@ -787,13 +787,17 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: RefreshIndicator(
           onRefresh: () async {
             await _refreshInventory();
             await _refreshAutoStartTasks();
           },
           child: ListView(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+            padding: edgeToEdgeScrollPadding(
+              context,
+              const EdgeInsets.fromLTRB(16, 12, 16, 24),
+            ),
             children: [
               _buildDistributionCard(),
               const SizedBox(height: 14),

--- a/ui/lib/features/home/pages/webview/webview_page.dart
+++ b/ui/lib/features/home/pages/webview/webview_page.dart
@@ -303,6 +303,7 @@ class _WebViewPageState extends State<WebViewPage> {
             : null,
         body: SafeArea(
           top: !widget.showAppBar,
+          bottom: false,
           child: Stack(
             children: [
               // WebView内容

--- a/ui/lib/features/memory/pages/memory_detail/memory_detail_page.dart
+++ b/ui/lib/features/memory/pages/memory_detail/memory_detail_page.dart
@@ -36,11 +36,11 @@ class MemoryDetailPage extends StatelessWidget {
                 backgroundColor: Colors.transparent,
                 insetPadding: EdgeInsets.all(0),
                 child: ImageUtil.buildImage(
-                  memory.imagePath??'',
+                  memory.imagePath ?? '',
                   width: MediaQuery.of(context).size.width,
                   fit: BoxFit.contain,
                 ),
-              )
+              ),
             ),
             Padding(
               padding: const EdgeInsets.only(bottom: 40, top: 10),
@@ -62,7 +62,10 @@ class MemoryDetailPage extends StatelessWidget {
                           width: 12,
                           height: 12,
                           alignment: Alignment.center,
-                          colorFilter: ColorFilter.mode(Color(0xff808080), BlendMode.srcIn),
+                          colorFilter: ColorFilter.mode(
+                            Color(0xff808080),
+                            BlendMode.srcIn,
+                          ),
                         ),
                       ),
                       const SizedBox(width: 8),
@@ -75,28 +78,32 @@ class MemoryDetailPage extends StatelessWidget {
                             color: Color(0xff808080),
                             fontSize: 14,
                             fontWeight: FontWeight.w500,
-                            decoration: TextDecoration.none
+                            decoration: TextDecoration.none,
                           ),
-                        )
-                      )
+                        ),
+                      ),
                     ],
                   ),
-                )
+                ),
               ),
-            )
+            ),
           ],
         );
       },
     );
   }
 
-  void _showContextMenu(MemoryCardModel vm, BuildContext context, Offset position) async {
+  void _showContextMenu(
+    MemoryCardModel vm,
+    BuildContext context,
+    Offset position,
+  ) async {
     final action = await showRecordContextMenu(
-      context: context, 
-      position: position, 
+      context: context,
+      position: position,
       deleteLabel: '删除',
       deleteIconAsset: 'assets/memory/memory_delete.svg',
-      showEdit: false
+      showEdit: false,
     );
     switch (action) {
       case RecordMenuAction.delete:
@@ -152,7 +159,7 @@ class MemoryDetailPage extends StatelessWidget {
       ),
       body: SafeArea(
         top: false,
-        bottom: true,
+        bottom: false,
         child: Stack(
           children: [
             // 上半部分图片：添加点击弹窗
@@ -186,14 +193,14 @@ class MemoryDetailPage extends StatelessWidget {
                     topLeft: Radius.circular(18),
                     topRight: Radius.circular(18),
                   ),
-                boxShadow: [
-                  BoxShadow(
-                    color: AppColors.text05,
-                    blurRadius: 8.76,
-                    offset: Offset(0, -3.50),
-                    spreadRadius: 1,
-                  )
-                ],
+                  boxShadow: [
+                    BoxShadow(
+                      color: AppColors.text05,
+                      blurRadius: 8.76,
+                      offset: Offset(0, -3.50),
+                      spreadRadius: 1,
+                    ),
+                  ],
                 ),
                 child: Stack(
                   children: [
@@ -226,12 +233,12 @@ class MemoryDetailPage extends StatelessWidget {
                       ),
                     ),
                   ],
-                )
+                ),
               ),
-            )
+            ),
           ],
         ),
-      )
+      ),
     );
   }
 
@@ -261,10 +268,7 @@ class MemoryDetailPage extends StatelessWidget {
         await Gal.putImage(file.path, album: _albumName);
       } else {
         final bytes = await rootBundle.load(imagePath);
-        await Gal.putImageBytes(
-          bytes.buffer.asUint8List(),
-          album: _albumName,
-        );
+        await Gal.putImageBytes(bytes.buffer.asUint8List(), album: _albumName);
       }
 
       showToast('保存成功', type: ToastType.success);

--- a/ui/lib/features/memory/pages/memory_detail/widgets/detail_content.dart
+++ b/ui/lib/features/memory/pages/memory_detail/widgets/detail_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ui/utils/ui.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
@@ -47,9 +48,9 @@ class DetailContent extends StatelessWidget {
               letterSpacing: AppTextStyles.letterSpacingWide,
             ),
           ),
-          
+
           const SizedBox(height: 10),
-          
+
           // 应用标签和时间
           Row(
             children: [
@@ -58,7 +59,7 @@ class DetailContent extends StatelessWidget {
                 child: Row(
                   children: [
                     // 渲染tags中的数据
-                    if (tags != null && tags!.isNotEmpty)...[
+                    if (tags != null && tags!.isNotEmpty) ...[
                       Wrap(
                         spacing: 6,
                         runSpacing: 6,
@@ -71,20 +72,12 @@ class DetailContent extends StatelessWidget {
                           );
                         }).toList(),
                       ),
-                    ] else if(appName != null && appName!.isNotEmpty)... [
+                    ] else if (appName != null && appName!.isNotEmpty) ...[
                       if (appSvgPath != null) ...[
-                        SvgPicture.asset(
-                          appSvgPath!,
-                          width: 14,
-                          height: 14,
-                        ),
+                        SvgPicture.asset(appSvgPath!, width: 14, height: 14),
                         const SizedBox(width: 4),
-                      ] else if (appIconProvider != null)...[
-                        Image(
-                          image: appIconProvider!,
-                          width: 14,
-                          height: 14,
-                        ),
+                      ] else if (appIconProvider != null) ...[
+                        Image(image: appIconProvider!, width: 14, height: 14),
                         const SizedBox(width: 4),
                       ],
                       Text(
@@ -98,11 +91,7 @@ class DetailContent extends StatelessWidget {
                         ),
                       ),
                     ] else ...[
-                      Icon(
-                        Icons.apps,
-                        size: 14,
-                        color: Color(0xFF666666),
-                      ),
+                      Icon(Icons.apps, size: 14, color: Color(0xFF666666)),
                       const SizedBox(width: 2),
                       Text(
                         '未知应用',
@@ -140,14 +129,18 @@ class DetailContent extends StatelessWidget {
               const AiGeneratedBadge(),
             ],
           ),
-          
+
           const SizedBox(height: 16),
-          
+
           // 正文内容
           Expanded(
             child: SingleChildScrollView(
+              padding: edgeToEdgeScrollPadding(
+                context,
+                const EdgeInsets.only(bottom: 25),
+              ),
               child: Padding(
-                padding: const EdgeInsets.only(bottom: 25),
+                padding: EdgeInsets.zero,
                 child: MarkdownBody(
                   data: content,
                   styleSheet: MarkdownStyleSheet(
@@ -218,10 +211,7 @@ class DetailContent extends StatelessWidget {
                     blockquoteDecoration: BoxDecoration(
                       color: AppColors.text10,
                       border: Border(
-                        left: BorderSide(
-                          color: AppColors.text20,
-                          width: 4,
-                        ),
+                        left: BorderSide(color: AppColors.text20, width: 4),
                       ),
                     ),
                     listBullet: TextStyle(
@@ -234,7 +224,7 @@ class DetailContent extends StatelessWidget {
                     listBulletPadding: const EdgeInsets.only(right: 8),
                   ),
                 ),
-              )
+              ),
             ),
           ),
         ],

--- a/ui/lib/features/my/pages/about/about_page.dart
+++ b/ui/lib/features/my/pages/about/about_page.dart
@@ -703,36 +703,38 @@ class _AboutPageState extends State<AboutPage> {
       ),
       body: SafeArea(
         top: false,
+        bottom: false,
         child: LayoutBuilder(
           builder: (context, constraints) {
             final compact = constraints.maxHeight < 760;
-            return Padding(
-              padding: EdgeInsets.fromLTRB(
-                24,
-                compact ? 8 : 18,
-                24,
-                compact ? 12 : 22,
-              ),
-              child: Center(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 420),
-                  child: SingleChildScrollView(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        SizedBox(height: compact ? 4 : 12),
-                        _buildHero(compact),
-                        SizedBox(height: compact ? 16 : 20),
-                        _buildUpdateSection(
-                          compact,
-                          updateButtonGradient,
-                          updateButtonTextColor,
-                        ),
-                        SizedBox(height: compact ? 18 : 24),
-                        _buildPreferenceSection(compact),
-                        SizedBox(height: compact ? 8 : 16),
-                      ],
+            return Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 468),
+                child: SingleChildScrollView(
+                  padding: edgeToEdgeScrollPadding(
+                    context,
+                    EdgeInsets.fromLTRB(
+                      24,
+                      compact ? 8 : 18,
+                      24,
+                      compact ? 12 : 22,
                     ),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      SizedBox(height: compact ? 4 : 12),
+                      _buildHero(compact),
+                      SizedBox(height: compact ? 16 : 20),
+                      _buildUpdateSection(
+                        compact,
+                        updateButtonGradient,
+                        updateButtonTextColor,
+                      ),
+                      SizedBox(height: compact ? 18 : 24),
+                      _buildPreferenceSection(compact),
+                      SizedBox(height: compact ? 8 : 16),
+                    ],
                   ),
                 ),
               ),

--- a/ui/lib/features/my/pages/about/ai_request_logs_page.dart
+++ b/ui/lib/features/my/pages/about/ai_request_logs_page.dart
@@ -569,7 +569,10 @@ class _AiRequestLogsPageState extends State<AiRequestLogsPage> {
       onRefresh: _loadLogs,
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+        padding: edgeToEdgeScrollPadding(
+          context,
+          const EdgeInsets.fromLTRB(18, 10, 18, 28),
+        ),
         children: [
           if (_logs.isNotEmpty) ...[
             _buildOverviewSection(context),

--- a/ui/lib/features/my/pages/about/runtime_logs_page.dart
+++ b/ui/lib/features/my/pages/about/runtime_logs_page.dart
@@ -93,9 +93,7 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
       context: context,
       builder: (context) => AlertDialog(
         title: Text(LegacyTextLocalizer.localize('确定删除吗？')),
-        content: Text(
-          LegacyTextLocalizer.localize('删除后该内容将不可找回'),
-        ),
+        content: Text(LegacyTextLocalizer.localize('删除后该内容将不可找回')),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -113,27 +111,18 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
     try {
       await RuntimeLogService.clear();
       if (!mounted) return;
-      showToast(
-        LegacyTextLocalizer.localize('已删除'),
-        type: ToastType.success,
-      );
+      showToast(LegacyTextLocalizer.localize('已删除'), type: ToastType.success);
       _loadLogs();
     } catch (e) {
       if (!mounted) return;
-      showToast(
-        LegacyTextLocalizer.localize('删除失败'),
-        type: ToastType.error,
-      );
+      showToast(LegacyTextLocalizer.localize('删除失败'), type: ToastType.error);
     }
   }
 
   Future<void> _copyText(String text) async {
     await Clipboard.setData(ClipboardData(text: text));
     if (!mounted) return;
-    showToast(
-      LegacyTextLocalizer.localize('已复制'),
-      type: ToastType.success,
-    );
+    showToast(LegacyTextLocalizer.localize('已复制'), type: ToastType.success);
   }
 
   String _buildExportText(List<RuntimeLogEntry> logs) {
@@ -222,7 +211,9 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
               child: _buildOverviewMetric(
                 context,
                 label: LegacyTextLocalizer.localize('最近一条'),
-                value: _logs.isEmpty ? '-' : _formatDateTime(_logs.first.createdAt).substring(5, 10),
+                value: _logs.isEmpty
+                    ? '-'
+                    : _formatDateTime(_logs.first.createdAt).substring(5, 10),
                 alignEnd: true,
               ),
             ),
@@ -347,10 +338,7 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
         child: Container(
           width: 6,
           height: 6,
-          decoration: BoxDecoration(
-            color: markerColor,
-            shape: BoxShape.circle,
-          ),
+          decoration: BoxDecoration(color: markerColor, shape: BoxShape.circle),
         ),
       ),
     );
@@ -397,8 +385,9 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
                                     vertical: 2,
                                   ),
                                   decoration: BoxDecoration(
-                                    color: _levelColor(log.level)
-                                        .withValues(alpha: 0.12),
+                                    color: _levelColor(
+                                      log.level,
+                                    ).withValues(alpha: 0.12),
                                     borderRadius: BorderRadius.circular(4),
                                   ),
                                   child: Text(
@@ -420,8 +409,9 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
                                       vertical: 2,
                                     ),
                                     decoration: BoxDecoration(
-                                      color: const Color(0xFFD93025)
-                                          .withValues(alpha: 0.12),
+                                      color: const Color(
+                                        0xFFD93025,
+                                      ).withValues(alpha: 0.12),
                                       borderRadius: BorderRadius.circular(4),
                                     ),
                                     child: Text(
@@ -511,8 +501,7 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
                                   ),
                                 ),
                                 TextButton(
-                                  onPressed: () =>
-                                      _copyText(log.stackTrace!),
+                                  onPressed: () => _copyText(log.stackTrace!),
                                   style: TextButton.styleFrom(
                                     padding: const EdgeInsets.symmetric(
                                       horizontal: 8,
@@ -534,10 +523,12 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
                               padding: const EdgeInsets.all(10),
                               decoration: BoxDecoration(
                                 color: context.isDarkTheme
-                                    ? palette.surfaceSecondary
-                                        .withValues(alpha: 0.62)
-                                    : palette.surfaceSecondary
-                                        .withValues(alpha: 0.82),
+                                    ? palette.surfaceSecondary.withValues(
+                                        alpha: 0.62,
+                                      )
+                                    : palette.surfaceSecondary.withValues(
+                                        alpha: 0.82,
+                                      ),
                                 borderRadius: BorderRadius.circular(10),
                               ),
                               child: SelectableText(
@@ -597,7 +588,10 @@ class _RuntimeLogsPageState extends State<RuntimeLogsPage> {
       onRefresh: _loadLogs,
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.fromLTRB(18, 10, 18, 28),
+        padding: edgeToEdgeScrollPadding(
+          context,
+          const EdgeInsets.fromLTRB(18, 10, 18, 28),
+        ),
         children: [
           if (_logs.isNotEmpty) ...[
             _buildOverviewSection(context),

--- a/ui/lib/features/my/pages/my/my_page.dart
+++ b/ui/lib/features/my/pages/my/my_page.dart
@@ -8,6 +8,7 @@ import 'package:ui/features/my/pages/my/widgets/setting_tile.dart';
 import 'package:ui/theme/app_colors.dart';
 import 'package:ui/core/router/go_router_manager.dart';
 import 'package:ui/utils/cache_util.dart';
+import 'package:ui/utils/ui.dart';
 
 class MyPage extends StatefulWidget {
   const MyPage({super.key});
@@ -80,6 +81,7 @@ class MyPageState extends State<MyPage> {
       backgroundColor: bg,
       body: SafeArea(
         top: false,
+        bottom: false,
         child: Stack(
           children: [
             Positioned.fill(
@@ -113,7 +115,10 @@ class MyPageState extends State<MyPage> {
                   Expanded(
                     child: ListView(
                       controller: _scrollController,
-                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      padding: edgeToEdgeScrollPadding(
+                        context,
+                        const EdgeInsets.fromLTRB(24, 0, 24, 40),
+                      ),
                       children: [
                         // 第一组： 震动
                         SettingSection(
@@ -166,7 +171,6 @@ class MyPageState extends State<MyPage> {
                           ],
                         ),
                         const SizedBox(height: 32),
-                        const SizedBox(height: 40),
                       ],
                     ),
                   ),

--- a/ui/lib/features/my/pages/theme_color/theme_color_page.dart
+++ b/ui/lib/features/my/pages/theme_color/theme_color_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ui/l10n/l10n.dart';
 import 'package:ui/theme/theme_context.dart';
+import 'package:ui/utils/ui.dart';
 import 'package:ui/widgets/common_app_bar.dart';
 import 'package:ui/widgets/theme_mode_setting_card.dart';
 
@@ -15,7 +16,10 @@ class ThemeColorPage extends StatelessWidget {
       backgroundColor: palette.pageBackground,
       appBar: CommonAppBar(title: context.l10n.themeModeTitle, primary: true),
       body: ListView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: edgeToEdgeScrollPadding(
+          context,
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        ),
         children: [const ThemeModeSettingCard()],
       ),
     );

--- a/ui/lib/features/task/pages/scheduled_tasks/scheduled_task_list_page.dart
+++ b/ui/lib/features/task/pages/scheduled_tasks/scheduled_task_list_page.dart
@@ -601,7 +601,7 @@ class _ScheduledTaskListPageState extends State<ScheduledTaskListPage> {
     }
 
     return ListView.builder(
-      padding: const EdgeInsets.all(16),
+      padding: edgeToEdgeScrollPadding(context, const EdgeInsets.all(16)),
       itemCount: _exactAlarms.length,
       itemBuilder: (context, index) {
         final alarm = _exactAlarms[index];
@@ -697,7 +697,7 @@ class _ScheduledTaskListPageState extends State<ScheduledTaskListPage> {
 
   Widget _buildTaskList() {
     return ListView.builder(
-      padding: const EdgeInsets.all(16),
+      padding: edgeToEdgeScrollPadding(context, const EdgeInsets.all(16)),
       itemCount: _scheduledTasks.length,
       itemBuilder: (context, index) {
         final task = _scheduledTasks[index];

--- a/ui/lib/utils/ui.dart
+++ b/ui/lib/utils/ui.dart
@@ -1125,3 +1125,15 @@ class _CustomLoadingWidgetState extends State<_CustomLoadingWidget>
     );
   }
 }
+
+/// Adds the physical bottom system inset to a scroll view's content padding.
+///
+/// Full-screen page scrollables should use this together with
+/// `SafeArea(bottom: false)`: the viewport can then extend behind the gesture
+/// navigation handle, while the final item can still scroll to a safe resting
+/// position above it.
+EdgeInsets edgeToEdgeScrollPadding(BuildContext context, EdgeInsets padding) {
+  return padding.copyWith(
+    bottom: padding.bottom + MediaQuery.viewPaddingOf(context).bottom,
+  );
+}

--- a/ui/test/utils/ui_edge_to_edge_test.dart
+++ b/ui/test/utils/ui_edge_to_edge_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/utils/ui.dart';
+
+void main() {
+  testWidgets('edge-to-edge scroll padding keeps the final item gesture-safe', (
+    tester,
+  ) async {
+    EdgeInsets? resolvedPadding;
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(viewPadding: EdgeInsets.only(bottom: 24)),
+        child: Builder(
+          builder: (context) {
+            resolvedPadding = edgeToEdgeScrollPadding(
+              context,
+              const EdgeInsets.fromLTRB(18, 10, 18, 28),
+            );
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+
+    expect(resolvedPadding, const EdgeInsets.fromLTRB(18, 10, 18, 52));
+  });
+}


### PR DESCRIPTION
## 变更摘要

全局适配 Android 底部手势导航沉浸。

页面内容现在可以延伸并滚动到系统手势导航区域，同时保持系统小白条可见；滚动结束后，列表末项和固定底部操作仍保留安全距离，不会被系统导航区域遮挡。

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构
- [ ] 文档更新
- [x] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

无

## 主要改动

1. 为 Android 主窗口启用 edge-to-edge，并将系统导航栏设置为透明。
2. 新增统一的底部滚动安全间距处理，避免不同页面重复适配或遗漏。
3. 全局适配设置、Agent、模型配置、权限、技能商店、日志、记忆等主要滚动页面。
4. 保持系统手势小白条可见，同时保护固定按钮、输入区域和列表末项。
5. 将 target SDK 升级至 35，适配 Android 15 及以上的 edge-to-edge 行为。

## 实现说明

此前部分页面在滚动容器外使用底部 `SafeArea`，滚动视口会在系统导航区域上方结束。

本次将系统底部 inset 统一放入滚动内容的末尾 padding：

- 滚动过程中，内容可以进入手势导航区域。
- 滚动结束后，末项仍可停在小白条上方。
- 固定底部操作继续使用安全区域保护。
- 不隐藏系统导航栏或手势小白条。

## 测试说明

- [x] 已本地编译通过
- [x] 已执行相关测试
- [x] 已手动验证关键路径

测试细节：

```text
flutter analyze --no-fatal-warnings --no-fatal-infos

flutter test \
  test/utils/ui_edge_to_edge_test.dart \
  test/features/home/pages/settings/settings_page_test.dart

./gradlew --no-daemon \
  :app:testDevelopStandardDebugUnitTest \
  :app:assembleDevelopStandardDebug \
  -Ptarget=lib/main_standard.dart
```

手动验证环境：

- 设备：RMX5200
- 系统：Android 16
- 手势导航小白条保持显示
- 页面内容可滚动进入手势导航区域
- 滚动结束后末项保留安全距离
- 固定底部操作未被遮挡

## UI 变更

### 滚动过程中

内容可以进入系统手势导航区域，小白条保持显示。

<img width="1440" height="316" alt="滚动过程中内容进入系统手势导航区域" src="https://github.com/user-attachments/assets/4f69c128-d02c-4f41-8f6e-5108e2e01cc1" />

### 滚动结束后

列表末项可以停留在小白条上方，不会被遮挡。

<img width="1438" height="312" alt="滚动结束后末项保留安全距离" src="https://github.com/user-attachments/assets/11d38c6a-f3c9-4781-b186-557a0420401f" />

## 风险与回滚

潜在风险主要是不同 Android 导航模式及厂商系统对系统栏的呈现差异，建议 Review 时关注：

- 手势导航与三键导航
- 浅色与深色主题
- Android 10 至 Android 16
- 带固定底部按钮或输入框的页面

如需回滚，可恢复窗口导航栏配置、页面底部 SafeArea 以及 target SDK 设置。

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [x] 已补充底部 inset 自动化测试
- [x] 已确认没有隐藏系统导航栏
- [x] 已确认不会影响固定底部操作
