### PR TITLE
fix(agent): 修复 Claude Code 消息错位与思考内容显示

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/ConversationSnapshotOrdering.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/ConversationSnapshotOrdering.kt
@@ -195,8 +195,15 @@ internal object ConversationSnapshotOrdering {
             return null
         }
         val prefix = normalized.takeWhile(Char::isDigit)
-        return prefix.toLongOrNull()
+        // Legacy task ids begin with an epoch timestamp, while ACP/WebChat
+        // turns use UUIDs. A UUID such as `7abc...` used to be interpreted as
+        // timestamp 7, randomly moving the whole turn ahead of or behind other
+        // turns. Only accept a prefix long enough to be a real epoch value.
+        return prefix.takeIf { it.length >= MIN_TIMESTAMP_PREFIX_LENGTH }
+            ?.toLongOrNull()
     }
+
+    private const val MIN_TIMESTAMP_PREFIX_LENGTH = 10
 
     private fun comparePreparedMessages(
         left: PreparedMessage,

--- a/app/src/test/java/cn/com/omnimind/bot/agent/ConversationSnapshotOrderingTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/ConversationSnapshotOrderingTest.kt
@@ -387,6 +387,45 @@ class ConversationSnapshotOrderingTest {
         )
     }
 
+    @Test
+    fun `prepareForStorage does not treat uuid prefixes as timestamps`() {
+        val messages = listOf(
+            assistantMessage(
+                id = "1fedcba0-0000-0000-0000-000000000000-agent-message",
+                createAt = "2026-07-26T08:52:03.000",
+                text = "第二轮助手"
+            ),
+            userMessage(
+                id = "1aaaaaa0-0000-0000-0000-000000000000-user",
+                createAt = "2026-07-26T08:52:02.000",
+                text = "第二轮用户"
+            ),
+            assistantMessage(
+                id = "9fedcba0-0000-0000-0000-000000000000-agent-message",
+                createAt = "2026-07-26T08:52:01.000",
+                text = "第一轮助手"
+            ),
+            userMessage(
+                id = "9aaaaaa0-0000-0000-0000-000000000000-user",
+                createAt = "2026-07-26T08:52:00.000",
+                text = "第一轮用户"
+            )
+        )
+
+        val orderedIds = ConversationSnapshotOrdering.prepareForStorage(messages)
+            .map { it.payload["id"] }
+
+        assertEquals(
+            listOf(
+                "9aaaaaa0-0000-0000-0000-000000000000-user",
+                "9fedcba0-0000-0000-0000-000000000000-agent-message",
+                "1aaaaaa0-0000-0000-0000-000000000000-user",
+                "1fedcba0-0000-0000-0000-000000000000-agent-message"
+            ),
+            orderedIds
+        )
+    }
+
     private fun userMessage(
         id: String,
         createAt: String,

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AcpSessionUpdateMapperTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AcpSessionUpdateMapperTest.kt
@@ -42,6 +42,18 @@ class AcpSessionUpdateMapperTest {
     }
 
     @Test
+    fun agentThoughtChunkUsesTheReasoningDeltaContract() {
+        val event = SessionUpdate.AgentThoughtChunk(
+            content = ContentBlock.Text("先检查消息顺序"),
+            messageId = MessageId("msg_thinking")
+        ).toAcpUiEvent("thread-1")
+
+        assertEquals("item/reasoning/delta", event?.method)
+        assertEquals("msg_thinking", event?.params?.get("itemId"))
+        assertEquals("先检查消息顺序", event?.params?.get("delta"))
+    }
+
+    @Test
     fun toolCallUpdateOnlyCompletesOnATerminalStatus() {
         fun methodFor(status: ToolCallStatus?): String? = SessionUpdate.ToolCallUpdate(
             toolCallId = ToolCallId("call-1"),

--- a/app/src/test/java/cn/com/omnimind/bot/webchat/WebConversationCreationTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/webchat/WebConversationCreationTest.kt
@@ -93,7 +93,7 @@ class WebConversationCreationTest {
             "thinking",
             parseWebAgentEvent(
                 mapOf(
-                    "method" to "item/reasoning/textDelta",
+                    "method" to "item/reasoning/delta",
                     "turnId" to "turn-1",
                     "params" to mapOf(
                         "itemId" to "reasoning-1",

--- a/ui/lib/services/agent_event_reducer.dart
+++ b/ui/lib/services/agent_event_reducer.dart
@@ -2535,7 +2535,8 @@ class _AgentQuestion {
 }
 
 bool _isReasoningMethod(String method) {
-  return method == 'item/reasoning/summaryPartAdded' ||
+  return method == 'item/reasoning/delta' ||
+      method == 'item/reasoning/summaryPartAdded' ||
       method == 'item/reasoning/summaryTextDelta' ||
       method == 'item/reasoning/textDelta';
 }

--- a/ui/test/services/agent_event_reducer_test.dart
+++ b/ui/test/services/agent_event_reducer_test.dart
@@ -116,6 +116,30 @@ void main() {
     expect(cardData['isLoading'], isTrue);
   });
 
+  test('maps ACP agent thought chunks into deep thinking card', () {
+    final result = reducer.reduce(
+      runtime: runtime,
+      event: {
+        'turnId': 'turn-claude',
+        'message': {
+          'method': 'item/reasoning/delta',
+          'params': {
+            'turnId': 'turn-claude',
+            'itemId': 'claude-message-1',
+            'delta': '先确认用户消息与当前轮次',
+          },
+        },
+      },
+    );
+
+    expect(result.handled, isTrue);
+    final message = runtime.messages.single;
+    expect(message.id, 'claude-message-1-agent-thinking');
+    expect(message.cardData?['type'], 'deep_thinking');
+    expect(message.cardData?['taskID'], 'turn-claude');
+    expect(message.cardData?['thinkingContent'], '先确认用户消息与当前轮次');
+  });
+
   test('maps command output deltas into terminal tool card', () {
     reducer.reduce(
       runtime: runtime,


### PR DESCRIPTION
## 变更摘要

修复 Claude Code 会话中用户消息与模型回复跨轮错位的问题，并补齐 ACP 思考增量事件的展示支持。修复后消息保持正确轮次顺序，思考内容可在处理状态区域展开查看。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [x] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

无

## 主要改动

1. 收紧消息 ID 时间戳解析规则，仅将至少 10 位的纯数字前缀视为时间戳，避免 UUID 前缀被误判后改变消息排序。
2. 将 ACP `item/reasoning/delta` 识别为思考事件，并映射到现有 `deep_thinking` 展示卡片。
3. 补充 Kotlin 消息排序测试及 Dart reasoning 事件回归测试，覆盖 UUID、多轮消息和思考增量场景。

## 测试说明

- [x] 已本地编译通过
- [x] 已执行相关测试
- [x] 已手动验证关键路径

测试细节：

```text
git diff --check origin/main...HEAD

cd ui
flutter test test/services/agent_event_reducer_test.dart
# 82 项测试通过

./gradlew --no-daemon :app:testDevelopStandardDebugUnitTest \
  --tests 'cn.com.omnimind.bot.agent.ConversationSnapshotOrderingTest' \
  --tests 'cn.com.omnimind.bot.agent.runtime.AcpSessionUpdateMapperTest' \
  --tests 'cn.com.omnimind.bot.webchat.WebConversationCreationTest'
# BUILD SUCCESSFUL

./gradlew --no-daemon :app:assembleDevelopStandardDebug \
  -Ptarget=lib/main_standard.dart
# BUILD SUCCESSFUL
```

此前执行全量 `flutter test` 的结果为 550 项通过、27 项失败；失败集中在既有 artifact preview、chat app bar、activity strip 与背景组件测试，聚焦本次修改的 reducer 测试全部通过。`flutter analyze --no-fatal-warnings --no-fatal-infos` 退出码为 0，并报告 276 项既有提示。

## UI 变更

### 修复前

用户消息与模型回复出现跨轮错位，且无法展开查看思考内容。

<img width="420" alt="修复前：消息跨轮错位且思考内容缺失" src="https://github.com/user-attachments/assets/61e713d7-5699-4203-8707-3537372e28bc" />

### 修复后

消息恢复正确轮次顺序，处理状态下可以展开查看思考内容。

<img width="420" alt="修复后：消息顺序正确且可显示思考内容" src="https://github.com/user-attachments/assets/079e000b-8b98-4298-865b-6a311048c9bb" />

## 风险与回滚

- 排序规则仍兼容秒级、毫秒级及更长的数字时间戳，但不再把短数字前缀当作时间戳。
- 思考内容依赖上游 ACP 实际发送文本；仅提供签名而无文本时不会生成可展示内容。
- 如需回滚，可撤销本 PR 的单个提交，恢复原有排序解析和 reasoning 事件识别逻辑。

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [x] 已确认无需更新 README、配置或公开接口文档
- [x] 已确认不会影响无关模块
