### PR TITLE
chore(build): 精简 Release 包并收窄 R8 规则

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -184,7 +184,8 @@ android {
                 "META-INF/LICENSE",
                 "META-INF/LICENSE.txt",
                 "META-INF/NOTICE",
-                "META-INF/NOTICE.txt"
+                "META-INF/NOTICE.txt",
+                "DebugProbesKt.bin"
             )
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,221 +1,92 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
+# Project-specific R8 rules.
 #
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Android framework components, JNI methods, WebView JavaScript interfaces,
+# Parcelable implementations, and common Android libraries are covered by the
+# optimized Android defaults or by dependency consumer rules. Keep this file
+# limited to reflection that is owned by this application.
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# Runtime metadata used by Gson, Kotlin, and reflective generic type lookup.
+-keepattributes RuntimeVisibleAnnotations,RuntimeInvisibleAnnotations,AnnotationDefault
+-keepattributes Signature,InnerClasses,EnclosingMethod
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
-# 保持应用包名相关类不被混淆
--keep class cn.com.omnimind.bot.** {*;}
-
-# 保留AndroidX/AppCompat核心类，避免混淆导致主题依赖丢失
--keep class androidx.appcompat.** { *; }
--keep interface androidx.appcompat.** { *; }
--keep class com.google.android.material.** { *; }
--keep interface com.google.android.material.** { *; }
-# 保留主题相关的属性和样式类
--keep class android.support.v7.** { *; }
--keep interface android.support.v7.** { *; }
--keepattributes *Annotation*
--keepattributes Signature
-# 保留Activity的子类，避免混淆后MIUI无法识别AppCompatActivity
--keep public class * extends androidx.appcompat.app.AppCompatActivity
--keep public class * extends android.app.Activity
-# 保留资源相关的类，避免资源压缩导致主题资源缺失
--keep class * extends android.content.res.Resources
--keep class * extends android.content.res.TypedArray
-# 保持Flutter WebView相关类不被混淆
--keep class io.flutter.plugins.webviewflutter.** { *; }
--dontwarn io.flutter.plugins.webviewflutter.**
--keep class com.webview_** { *; }
--keep class dev.flutter.pigeon.** { *; }
--keep class android.webkit.** { *; }
-
-## flutter 相关
--keep class io.flutter.** { *; }
--dontwarn io.flutter.embedding.**
--ignorewarnings
-
-# 保持Activity生命周期方法不被混淆
--keep class * extends android.app.Activity {
-    protected void onCreate(android.os.Bundle);
-    protected void onStart();
-    protected void onResume();
-    protected void onPause();
-    protected void onStop();
-    protected void onDestroy();
-    protected void onSaveInstanceState(android.os.Bundle);
-    protected void onRestoreInstanceState(android.os.Bundle);
+# OkHttpManager resolves this value by its binary class and field names.
+-keep class cn.com.omnimind.bot.BuildConfig {
+    public static final java.lang.String BASE_URL;
 }
 
-# 保持包管理器相关类不被混淆，防止NameNotFoundException
--keep class android.content.pm.** {*;}
--keep class android.app.ApplicationPackageManager {*;}
-
-# 特别保护硬编码的包名字符串不被混淆
--keepclassmembernames class * {
-    public static final java.lang.String *;
-}
--keepclassmembers class ** {
-    public static final java.lang.String APPLICATION_ID;
-    public static final java.lang.String BUILD_TYPE;
-    public static final java.lang.String FLAVOR;
-    public static final int VERSION_CODE;
-    public static final java.lang.String VERSION_NAME;
-}
-
-# 保持Context相关类不被混淆
--keep class android.content.Context { *; }
--keep class android.content.ContextWrapper { *; }
-
-# 保持Kotlin相关类不被混淆 (精简版)
--keep class kotlin.Metadata { *; }
--keepclassmembers class **$WhenMappings {
+# Gson persists these unannotated Kotlin models. Keep only their instance field
+# names; classes, constructors, methods, and service/store fields remain
+# eligible for shrinking and optimization. Prefer @SerializedName on new
+# persisted fields.
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.runtime.AcpAgentProfile {
     <fields>;
 }
--keepclassmembers class kotlin.Metadata {
-    public <methods>;
-}
-
-# 保持AndroidX相关类不被混淆 (精简版)
--dontwarn androidx.**
-
-# 保持Google相关库不被混淆 (精简版)
--dontwarn com.google.**
-
-# 保持JetBrains相关库不被混淆
--dontwarn org.jetbrains.**
-
-# 保持Room数据库相关类不被混淆 (精简版)
--keep class androidx.room.** { *; }
--dontwarn androidx.room.**
-
-# 保持Gson相关类不被混淆 (精简版)
-# 仅保留实际使用的类，而不是整个包
--dontwarn com.google.gson.**
-
-# 保持OkHttp相关类不被混淆 (精简版)
--dontwarn okhttp3.**
-
-# 保持数据类不被混淆
--keep class cn.com.omnimind.baselib.database.** {
-    <fields>;
-    <methods>;
-    public <init>(...);
-}
-
-# 保持cn.com.omnimind.assists.api.bean包下所有data类不被混淆
--keep class cn.com.omnimind.assists.api.bean.** {
-    <fields>;
-    <methods>;
-    public <init>(...);
-}
-
-# 保持枚举类不被混淆
--keep class cn.com.omnimind.baselib.util.OmniLog$Level { *; }
--keep class cn.com.omnimind.assists.api.enums.TaskType { *; }
--keep enum cn.com.omnimind.** { *; }
-
-# Kotlinx Serialization 保护规则 (精简版)
--keepclassmembers class * {
-    *** Companion;
-}
-
-# 保护所有带有 @Serializable 注解的类
--keep @kotlinx.serialization.Serializable class * {
-    <init>(...);
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.runtime.AcpAgentHealth {
     <fields>;
 }
--keepclassmembers @kotlinx.serialization.Serializable class * {
-    <init>(...);
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.BuiltinSkillManifest {
     <fields>;
 }
-# 保留 Kotlin 序列化生成的 Companion 类（含 serializer() 方法）
--keep class **$Companion { *; }
-
-# 保留序列化相关的函数（如 serializer()）
--keepclasseswithmembers class ** {
-    kotlinx.serialization.KSerializer serializer(...);
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.BuiltinSkillAsset {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.SkillRegistryEntry {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.AgentAlarmToolService$AlarmSoundSettings {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.AgentAlarmToolService$ExactAlarmRecordRaw {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.AgentAlarmToolService$ExactAlarmRecord {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.WorkspaceScheduledTaskScheduler$StoredTask {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.MemoryIndexEntry {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.mcp.RemoteMcpServerConfig {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.quicklog.QuickLogRecord {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.bot.quicklog.QuickLogWidgetSettings {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.config.ModelSceneConfigCache$CacheData {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.config.ModelSceneConfigCache$Metadata {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.llm.AiRequestLogEntry {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.llm.ModelProviderConfigStore$StoredModelProviderProfile {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.llm.SceneModelBindingEntry {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.llm.SceneVoiceConfig {
+    <fields>;
+}
+-keepclassmembers,allowoptimization class cn.com.omnimind.baselib.util.RuntimeLogEntry {
+    <fields>;
 }
 
-# 保护 kotlinx.serialization 相关类 (精简版)
--keep class kotlinx.serialization.** { *; }
--dontwarn kotlinx.serialization.**
-
-# 保护数据类的构造函数和字段
--keepclassmembers @kotlinx.serialization.Serializable class * {
-    public synthetic <init>(...);
+# Some persisted enums do not yet declare @SerializedName values.
+-keepclassmembers,allowoptimization enum cn.com.omnimind.** {
+    <fields>;
 }
 
-# 保持接口类不被混淆
--keep interface cn.com.omnimind.baselib.database.** { *; }
-
-# 保持自定义View类不被混淆
--keep class cn.com.omnimind.overlay.view.** { *; }
-
-# 保持Lottie动画相关类不被混淆
--keep class com.airbnb.lottie.** { *; }
--dontwarn com.airbnb.lottie.**
-
-# 保持MMKV相关类不被混淆
--keep class com.tencent.mmkv.** { *; }
--dontwarn com.tencent.mmkv.**
-
+# Logback is an optional JVM logging backend and is not packaged on Android.
 -dontwarn ch.qos.logback.**
 
-# 保持Ktor相关类不被混淆
--keep class io.ktor.** { *; }
--dontwarn io.ktor.**
-
-# 保持协程相关类不被混淆
--keep class kotlinx.coroutines.** { *; }
--dontwarn kotlinx.coroutines.**
-
-# 保持必须的注解不被混淆
--keep class javax.annotation.** { *; }
--keep class javax.inject.** { *; }
--keep class org.repackage.** {*;}
-
--keep class com.uyumao.** { *; }
-
--keepclassmembers class * {
-   public <init> (org.json.JSONObject);
-}
-
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-}
-
--keep public class cn.com.omnimind.bot.R$* {
-    public static final int *;
-}
-
-# 广告检测数据模型 - 这些类会被 Gson 序列化为 JSON，字段名不能被混淆
--keep class cn.com.omnimind.assists.detection.detectors.popup.models.** { *; }
--keep class cn.com.omnimind.assists.detection.detectors.button.** { *; }
-
-# NanoHTTPD Web 服务器 (Debug 版本)
--keep class fi.iki.elonen.** { *; }
-
-# ==================== Detection 模块数据模型 ====================
-# 这些类涉及 Gson JSON 反序列化，字段名不能被混淆
-
-# 其他优化选项
--optimizationpasses 5
--allowaccessmodification
+# Ktor's IntelliJ debugger detector probes these JVM-only management APIs.
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean

--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@style/*authsdk*,@style/*AppCompat*,@style/*MaterialComponents*,@color/primary,*android:attr/*"
+    tools:keep="@raw/model_scenes_default,@style/*authsdk*,@style/*AppCompat*,@style/*MaterialComponents*,@color/primary,*android:attr/*"
     tools:shrinkMode="safe" />

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelSceneRegistry.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelSceneRegistry.kt
@@ -1,6 +1,7 @@
 package cn.com.omnimind.baselib.llm
 
 import android.content.Context
+import cn.com.omnimind.baselib.R
 import cn.com.omnimind.baselib.i18n.AppLanguageMode
 import cn.com.omnimind.baselib.i18n.AppLocaleManager
 import cn.com.omnimind.baselib.util.OmniLog
@@ -112,14 +113,10 @@ object ModelSceneRegistry {
                 return emptyMap()
             }
 
-            // 读取 raw 资源
-            val inputStream = context.resources.openRawResource(
-                context.resources.getIdentifier(
-                    "model_scenes_default",
-                    "raw",
-                    context.packageName
-                )
-            )
+            // Keep a compile-time resource reference so Release resource
+            // shrinking can prove that the built-in scene catalog is used.
+            val inputStream =
+                context.resources.openRawResource(R.raw.model_scenes_default)
             val json = inputStream.bufferedReader().use { it.readText() }
             
             // 解析 JSON


### PR DESCRIPTION
## 变更摘要

精简 Android Release 构建中的 R8 与资源收缩配置，移除宽泛、重复的保留规则，改为仅保护应用实际使用的反射入口和 Gson 持久化字段。内置模型场景资源改为编译期静态引用，并排除未使用的协程调试探针元数据。

## 优化前后对比

| 项目 | 优化前（`origin/main`） | 优化后（本 PR） |
| --- | --- | --- |
| R8 规则 | 广泛保留应用、Flutter、AndroidX、Kotlin、Room、Gson、协程等整个包 | 依赖自带 consumer rules，并仅保留应用实际需要的反射入口和字段 |
| Gson 模型 | 保留整个数据类或包，限制类和成员收缩 | 精确保留持久化字段名，类仍可混淆、优化，无用类型仍可删除或合并 |
| 内置模型场景 | 通过字符串和 `getIdentifier` 动态查找资源 | 使用 `R.raw.model_scenes_default` 静态引用，并通过资源保留规则明确保护 |
| 打包元数据 | 包含未使用的 `DebugProbesKt.bin` | 从 Release 包中排除 |
| Release APK | 79,200,865 字节（75.53 MiB） | 68,708,369 字节（65.53 MiB） |

在相同代码基线、相同 `productionStandardRelease` 变体和相同本地验证签名条件下，APK 减少 **10,492,496 字节**，约 **10.5 MB（10.01 MiB）**，降幅约 **13.25%**。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [ ] 测试相关
- [x] CI/CD 或构建相关

## 关联 Issue

无。

## 主要改动

1. 移除 Android、Flutter、AndroidX、Kotlin、Room、Gson、协程等依赖已有 consumer rules 覆盖的宽泛 R8 规则。
2. 使用精确的字段保留规则保护 Gson 持久化模型，同时继续允许类混淆、优化及无用类型删除。
3. 将内置模型场景改为静态资源引用并明确保留，排除 `DebugProbesKt.bin` 打包元数据。

## 测试说明

- [x] 已本地编译通过（Release）
- [x] 已执行相关测试
- [x] 已手动验证关键路径

测试细节：

```text
- origin/main 与本 PR 均完成 :app:assembleProductionStandardRelease
- 两个对比 APK 的 versionName 均为 0.5.6.12
- :app:testDevelopStandardDebugUnitTest：BUILD SUCCESSFUL
- 相关 baselib Release 单元测试：BUILD SUCCESSFUL
- Flutter 模型提供商、模型选择器及输入区域相关测试：45 项通过
- R8 mapping：20 条精确规则、138 个持久化字段，字段改名数为 0
- APK 内容：5 个内置模型场景、28 个模型提供商图标均存在
- APK V3 签名验证通过，missing_rules 为空
```

## UI 变更（如有）

无。

## 风险与回滚

主要风险是精简 R8 规则后，反射访问或动态资源引用可能受代码、资源收缩影响。已通过优化前后完整 Release 构建、R8 mapping、APK 资源内容和相关测试覆盖关键路径；如需回滚，可直接回退本 PR 的单个提交。

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [x] 已更新必要注释；无需额外文档变更
- [x] 已确认不会影响无关模块