### PR TITLE
fix(build): 兼容旧版 R8 持久化数据

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,10 +14,10 @@
     public static final java.lang.String BASE_URL;
 }
 
-# Gson persists these unannotated Kotlin models. Keep only their instance field
-# names; classes, constructors, methods, and service/store fields remain
-# eligible for shrinking and optimization. Prefer @SerializedName on new
-# persisted fields.
+# Gson persists these Kotlin models. Keep only their instance field names as a
+# compatibility safety net; classes, constructors, methods, and service/store
+# fields remain eligible for shrinking and optimization. Persisted baselib
+# models also declare stable @SerializedName values.
 -keepclassmembers,allowoptimization class cn.com.omnimind.bot.agent.runtime.AcpAgentProfile {
     <fields>;
 }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/AiRequestLogStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/AiRequestLogStore.kt
@@ -2,6 +2,7 @@ package cn.com.omnimind.baselib.llm
 
 import cn.com.omnimind.baselib.util.OmniLog
 import com.google.gson.GsonBuilder
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
 import java.util.UUID
@@ -9,18 +10,31 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 data class AiRequestLogEntry(
+    @field:SerializedName(value = "id", alternate = ["a"])
     val id: String = UUID.randomUUID().toString(),
+    @field:SerializedName(value = "createdAt", alternate = ["b"])
     val createdAt: Long = System.currentTimeMillis(),
+    @field:SerializedName(value = "label", alternate = ["c"])
     val label: String = "",
+    @field:SerializedName(value = "model", alternate = ["d"])
     val model: String = "",
+    @field:SerializedName(value = "protocolType", alternate = ["e"])
     val protocolType: String = "openai_compatible",
+    @field:SerializedName(value = "url", alternate = ["f"])
     val url: String = "",
+    @field:SerializedName(value = "method", alternate = ["g"])
     val method: String = "POST",
+    @field:SerializedName(value = "stream", alternate = ["h"])
     val stream: Boolean = false,
+    @field:SerializedName(value = "statusCode", alternate = ["i"])
     val statusCode: Int? = null,
+    @field:SerializedName(value = "success", alternate = ["j"])
     val success: Boolean = true,
+    @field:SerializedName(value = "requestJson", alternate = ["k"])
     val requestJson: String = "",
+    @field:SerializedName(value = "responseJson", alternate = ["l"])
     val responseJson: String = "",
+    @field:SerializedName(value = "errorMessage", alternate = ["m"])
     val errorMessage: String? = null
 ) {
     fun toMap(): Map<String, Any?> {

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderConfigStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderConfigStore.kt
@@ -3,6 +3,8 @@ package cn.com.omnimind.baselib.llm
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.baselib.util.OssIdentity
 import com.google.gson.Gson
+import com.google.gson.JsonParser
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
 
@@ -44,16 +46,27 @@ object ModelProviderConfigStore {
     private val gson = Gson()
 
     private data class StoredModelProviderProfile(
+        @field:SerializedName(value = "id", alternate = ["a"])
         val id: String? = null,
+        @field:SerializedName(value = "name", alternate = ["b"])
         val name: String? = null,
+        @field:SerializedName(value = "baseUrl", alternate = ["c"])
         val baseUrl: String? = null,
+        @field:SerializedName(value = "apiKey", alternate = ["d"])
         val apiKey: String? = null,
+        @field:SerializedName(value = "customHeaders", alternate = ["e"])
         val customHeaders: Map<String, String>? = null,
+        @field:SerializedName(value = "sourceType", alternate = ["f"])
         val sourceType: String? = null,
+        @field:SerializedName(value = "readOnly", alternate = ["g"])
         val readOnly: Boolean? = null,
+        @field:SerializedName(value = "ready", alternate = ["h"])
         val ready: Boolean? = null,
+        @field:SerializedName("statusText")
         val statusText: String? = null,
+        @field:SerializedName(value = "protocolType", alternate = ["i"])
         val protocolType: String? = null,
+        @field:SerializedName(value = "wireApi", alternate = ["j"])
         val wireApi: String? = null
     )
 
@@ -61,7 +74,17 @@ object ModelProviderConfigStore {
         ModelProviderMigration.ensureMigrated()
         val mmkv = MMKV.defaultMMKV()
         val deletedOfficialProfileIds = readDeletedOfficialProfileIds(mmkv)
-        val storedProfiles = readActiveProfiles(mmkv, deletedOfficialProfileIds)
+        val storedProfilesRaw = mmkv.decodeString(KEY_PROVIDER_PROFILES)
+        val decodedProfiles = decodeProfilesJson(storedProfilesRaw)
+        if (shouldPreserveStoredProfiles(storedProfilesRaw, decodedProfiles)) {
+            OmniLog.w(TAG, "provider profiles payload is not empty but could not be decoded")
+            return defaultProfiles(deletedOfficialProfileIds)
+        }
+        val storedProfiles = readActiveProfiles(
+            mmkv = mmkv,
+            deletedOfficialProfileIds = deletedOfficialProfileIds,
+            profiles = decodedProfiles
+        )
         val current = ensureBuiltinOfficialProfilesSeeded(
             mmkv,
             storedProfiles,
@@ -112,6 +135,7 @@ object ModelProviderConfigStore {
         ModelProviderMigration.ensureMigrated()
         val mmkv = MMKV.defaultMMKV()
         val deletedOfficialProfileIds = readDeletedOfficialProfileIds(mmkv)
+        readProfilesForUpdate(mmkv)
 
         val sanitized = buildList<ModelProviderProfile> {
             profiles
@@ -182,7 +206,11 @@ object ModelProviderConfigStore {
         val mmkv = MMKV.defaultMMKV()
 
         val deletedOfficialProfileIds = readDeletedOfficialProfileIds(mmkv)
-        val current = readActiveProfiles(mmkv, deletedOfficialProfileIds).toMutableList().ifEmpty {
+        val current = readActiveProfiles(
+            mmkv = mmkv,
+            deletedOfficialProfileIds = deletedOfficialProfileIds,
+            profiles = readProfilesForUpdate(mmkv)
+        ).toMutableList().ifEmpty {
             defaultProfiles(deletedOfficialProfileIds).toMutableList()
         }
         val normalizedId = id?.trim()?.takeIf { it.isNotEmpty() } ?: generateProfileId(current)
@@ -226,7 +254,11 @@ object ModelProviderConfigStore {
         val mmkv = MMKV.defaultMMKV()
         val normalizedId = profileId.trim()
         val deletedOfficialProfileIds = readDeletedOfficialProfileIds(mmkv)
-        val current = readActiveProfiles(mmkv, deletedOfficialProfileIds).toMutableList().ifEmpty {
+        val current = readActiveProfiles(
+            mmkv = mmkv,
+            deletedOfficialProfileIds = deletedOfficialProfileIds,
+            profiles = readProfilesForUpdate(mmkv)
+        ).toMutableList().ifEmpty {
             defaultProfiles(deletedOfficialProfileIds).toMutableList()
         }
         require(current.size > 1) { "at least one provider profile must remain" }
@@ -638,15 +670,52 @@ object ModelProviderConfigStore {
         return gson.toJson(normalized)
     }
 
-    private fun readProfiles(mmkv: MMKV): List<ModelProviderProfile> {
-        return decodeProfilesJson(mmkv.decodeString(KEY_PROVIDER_PROFILES))
+    internal fun shouldPreserveStoredProfiles(
+        raw: String?,
+        decodedProfiles: List<ModelProviderProfile>
+    ): Boolean {
+        val normalizedRaw = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return false
+        return try {
+            val root = JsonParser.parseString(normalizedRaw)
+            when {
+                root.isJsonNull -> false
+                !root.isJsonArray -> true
+                root.asJsonArray.isEmpty -> false
+                decodedProfiles.isEmpty() -> true
+                else -> root.asJsonArray.any { element ->
+                    if (!element.isJsonObject) {
+                        true
+                    } else {
+                        val profile = element.asJsonObject
+                        listOf("id", "a").none { fieldName ->
+                            val id = profile.get(fieldName)
+                            id != null &&
+                                id.isJsonPrimitive &&
+                                id.asJsonPrimitive.isString &&
+                                id.asString.isNotBlank()
+                        }
+                    }
+                }
+            }
+        } catch (_: Throwable) {
+            true
+        }
+    }
+
+    private fun readProfilesForUpdate(mmkv: MMKV): List<ModelProviderProfile> {
+        val raw = mmkv.decodeString(KEY_PROVIDER_PROFILES)
+        val profiles = decodeProfilesJson(raw)
+        check(!shouldPreserveStoredProfiles(raw, profiles)) {
+            "provider profiles payload cannot be updated safely"
+        }
+        return profiles
     }
 
     private fun readActiveProfiles(
         mmkv: MMKV,
-        deletedOfficialProfileIds: Set<String>
+        deletedOfficialProfileIds: Set<String>,
+        profiles: List<ModelProviderProfile>
     ): List<ModelProviderProfile> {
-        val profiles = readProfiles(mmkv)
         val activeProfiles = filterDeletedOfficialProfiles(profiles, deletedOfficialProfileIds)
         if (activeProfiles.size != profiles.size) {
             writeProfiles(mmkv, activeProfiles)
@@ -726,7 +795,12 @@ object ModelProviderConfigStore {
             }
 
             try {
-                val existingProfiles = readProfiles(mmkv)
+                val storedProfilesRaw = mmkv.decodeString(KEY_PROVIDER_PROFILES)
+                val existingProfiles = decodeProfilesJson(storedProfilesRaw)
+                if (shouldPreserveStoredProfiles(storedProfilesRaw, existingProfiles)) {
+                    OmniLog.w(TAG, "skip provider migration to preserve undecodable profiles")
+                    return
+                }
                 if (existingProfiles.isNotEmpty()) {
                     ensureEditingProfile(mmkv, existingProfiles)
                     syncLegacyFlatConfig(mmkv, existingProfiles.first())

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderModels.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderModels.kt
@@ -1,5 +1,7 @@
 package cn.com.omnimind.baselib.llm
 
+import com.google.gson.annotations.SerializedName
+
 data class ModelProviderConfig(
     val id: String = "",
     val name: String = "",
@@ -77,16 +79,25 @@ data class SceneModelOverrideEntry(
 )
 
 data class SceneModelBindingEntry(
+    @field:SerializedName(value = "sceneId", alternate = ["a"])
     val sceneId: String,
+    @field:SerializedName(value = "providerProfileId", alternate = ["b"])
     val providerProfileId: String,
+    @field:SerializedName(value = "modelId", alternate = ["c"])
     val modelId: String
 )
 
 data class SceneVoiceConfig(
+    @field:SerializedName(value = "autoPlay", alternate = ["a"])
     val autoPlay: Boolean = false,
+    @field:SerializedName(value = "voiceId", alternate = ["b"])
     val voiceId: String = "default_zh",
+    @field:SerializedName(value = "stylePreset", alternate = ["c"])
     val stylePreset: String = "默认",
+    @field:SerializedName(value = "customStyle", alternate = ["d"])
     val customStyle: String = "",
+    @field:SerializedName(value = "ttsMode", alternate = ["e"])
     val ttsMode: String = "builtin",
+    @field:SerializedName(value = "customCurlCommand", alternate = ["f"])
     val customCurlCommand: String = ""
 )

--- a/baselib/src/main/java/cn/com/omnimind/baselib/util/RuntimeLogStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/util/RuntimeLogStore.kt
@@ -1,17 +1,25 @@
 package cn.com.omnimind.baselib.util
 
 import com.google.gson.GsonBuilder
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
 import java.util.UUID
 
 data class RuntimeLogEntry(
+    @field:SerializedName(value = "id", alternate = ["a"])
     val id: String = UUID.randomUUID().toString(),
+    @field:SerializedName(value = "createdAt", alternate = ["b"])
     val createdAt: Long = System.currentTimeMillis(),
+    @field:SerializedName(value = "level", alternate = ["c"])
     val level: String = "INFO",
+    @field:SerializedName(value = "tag", alternate = ["d"])
     val tag: String = "",
+    @field:SerializedName(value = "message", alternate = ["e"])
     val message: String = "",
+    @field:SerializedName(value = "stackTrace", alternate = ["f"])
     val stackTrace: String? = null,
+    @field:SerializedName(value = "isCrash", alternate = ["g"])
     val isCrash: Boolean = false,
 ) {
     fun toMap(): Map<String, Any?> {

--- a/baselib/src/test/java/cn/com/omnimind/baselib/llm/PersistedJsonCompatibilityTest.kt
+++ b/baselib/src/test/java/cn/com/omnimind/baselib/llm/PersistedJsonCompatibilityTest.kt
@@ -1,0 +1,232 @@
+package cn.com.omnimind.baselib.llm
+
+import cn.com.omnimind.baselib.util.RuntimeLogEntry
+import com.google.gson.Gson
+import com.google.gson.JsonParser
+import com.google.gson.reflect.TypeToken
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PersistedJsonCompatibilityTest {
+    private val gson = Gson()
+
+    @Test
+    fun providerProfiles_preserveNonEmptyPayloadWhenDecodingProducesNoProfiles() {
+        val raw = """[{"unexpected":"value"}]"""
+        val decoded = ModelProviderConfigStore.decodeProfilesJson(raw)
+
+        assertTrue(decoded.isEmpty())
+        assertTrue(ModelProviderConfigStore.shouldPreserveStoredProfiles(raw, decoded))
+        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles(null, emptyList()))
+        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("   ", emptyList()))
+        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("[]", emptyList()))
+        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("[ ]", emptyList()))
+        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("null", emptyList()))
+        assertTrue(ModelProviderConfigStore.shouldPreserveStoredProfiles("{", emptyList()))
+        assertTrue(
+            ModelProviderConfigStore.shouldPreserveStoredProfiles(
+                """{"id":"custom-provider"}""",
+                emptyList()
+            )
+        )
+    }
+
+    @Test
+    fun providerProfiles_readReleaseObfuscatedFieldsAndWriteCanonicalFields() {
+        val releaseRaw =
+            """
+                [
+                  {
+                    "a": "custom-provider",
+                    "b": "Custom Provider",
+                    "c": "https://api.example.com/v1",
+                    "d": "sk-test",
+                    "e": {
+                      "HTTP-Referer": "https://example.com",
+                      "X-Title": "OpenOmniBot"
+                    },
+                    "f": "custom",
+                    "g": false,
+                    "h": true,
+                    "i": "openai_compatible",
+                    "j": "responses"
+                  }
+                ]
+            """.trimIndent()
+        val profiles = ModelProviderConfigStore.decodeProfilesJson(releaseRaw)
+
+        assertEquals(1, profiles.size)
+        val profile = profiles.single()
+        assertEquals("custom-provider", profile.id)
+        assertEquals("Custom Provider", profile.name)
+        assertEquals("https://api.example.com/v1", profile.baseUrl)
+        assertEquals("sk-test", profile.apiKey)
+        assertEquals(
+            linkedMapOf(
+                "HTTP-Referer" to "https://example.com",
+                "X-Title" to "OpenOmniBot"
+            ),
+            profile.customHeaders
+        )
+        assertEquals("custom", profile.sourceType)
+        assertFalse(profile.readOnly)
+        assertTrue(profile.ready)
+        assertNull(profile.statusText)
+        assertEquals("openai_compatible", profile.protocolType)
+        assertEquals("responses", profile.wireApi)
+        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles(releaseRaw, profiles))
+        assertTrue(
+            ModelProviderConfigStore.shouldPreserveStoredProfiles(
+                """
+                    [
+                      {"a":"custom-provider"},
+                      {"futureId":"future-provider"}
+                    ]
+                """.trimIndent(),
+                profiles
+            )
+        )
+
+        val encoded = ModelProviderConfigStore.encodeProfilesJson(profiles)
+        val encodedProfile = JsonParser.parseString(encoded)
+            .asJsonArray
+            .single()
+            .asJsonObject
+        assertTrue(encodedProfile.has("id"))
+        assertTrue(encodedProfile.has("customHeaders"))
+        assertTrue(encodedProfile.has("protocolType"))
+        assertFalse(encodedProfile.has("a"))
+        assertFalse(encodedProfile.has("e"))
+        assertFalse(encodedProfile.has("i"))
+    }
+
+    @Test
+    fun sceneBindings_readReleaseObfuscatedFieldsAndWriteCanonicalFields() {
+        val type = object : TypeToken<Map<String, SceneModelBindingEntry>>() {}.type
+        val bindings: Map<String, SceneModelBindingEntry> = gson.fromJson(
+            """
+                {
+                  "scene.dispatch.model": {
+                    "a": "scene.dispatch.model",
+                    "b": "custom-provider",
+                    "c": "gpt-test"
+                  }
+                }
+            """.trimIndent(),
+            type
+        )
+
+        val binding = bindings.getValue("scene.dispatch.model")
+        assertEquals("scene.dispatch.model", binding.sceneId)
+        assertEquals("custom-provider", binding.providerProfileId)
+        assertEquals("gpt-test", binding.modelId)
+
+        val encoded = JsonParser.parseString(gson.toJson(binding)).asJsonObject
+        assertTrue(encoded.has("sceneId"))
+        assertTrue(encoded.has("providerProfileId"))
+        assertTrue(encoded.has("modelId"))
+        assertFalse(encoded.has("a"))
+    }
+
+    @Test
+    fun voiceConfig_readsReleaseObfuscatedFields() {
+        val config = SceneVoiceConfigStore.parse(
+            """
+                {
+                  "a": true,
+                  "b": "default_en",
+                  "c": "专业播报",
+                  "d": "  节奏慢一点  ",
+                  "e": "custom_curl",
+                  "f": "  curl https://tts.example.com -d '{{text}}'  "
+                }
+            """.trimIndent()
+        )
+
+        requireNotNull(config)
+        assertTrue(config.autoPlay)
+        assertEquals(SceneVoiceConfigStore.VOICE_DEFAULT_EN, config.voiceId)
+        assertEquals(SceneVoiceConfigStore.STYLE_PROFESSIONAL_BROADCAST, config.stylePreset)
+        assertEquals("节奏慢一点", config.customStyle)
+        assertEquals(SceneVoiceConfigStore.TTS_MODE_CUSTOM_CURL, config.ttsMode)
+        assertEquals(
+            "curl https://tts.example.com -d '{{text}}'",
+            config.customCurlCommand
+        )
+    }
+
+    @Test
+    fun aiRequestLogs_readReleaseObfuscatedFields() {
+        val type = object : TypeToken<List<AiRequestLogEntry>>() {}.type
+        val entries: List<AiRequestLogEntry> = gson.fromJson(
+            """
+                [
+                  {
+                    "a": "request-1",
+                    "b": 1234,
+                    "c": "Chat",
+                    "d": "gpt-test",
+                    "e": "openai_compatible",
+                    "f": "https://api.example.com/v1/chat/completions",
+                    "g": "POST",
+                    "h": true,
+                    "i": 200,
+                    "j": true,
+                    "k": "{\"input\":\"hello\"}",
+                    "l": "{\"output\":\"world\"}",
+                    "m": null
+                  }
+                ]
+            """.trimIndent(),
+            type
+        )
+
+        val entry = entries.single()
+        assertEquals("request-1", entry.id)
+        assertEquals(1234L, entry.createdAt)
+        assertEquals("Chat", entry.label)
+        assertEquals("gpt-test", entry.model)
+        assertEquals("openai_compatible", entry.protocolType)
+        assertEquals("https://api.example.com/v1/chat/completions", entry.url)
+        assertEquals("POST", entry.method)
+        assertTrue(entry.stream)
+        assertEquals(200, entry.statusCode)
+        assertTrue(entry.success)
+        assertEquals("""{"input":"hello"}""", entry.requestJson)
+        assertEquals("""{"output":"world"}""", entry.responseJson)
+        assertNull(entry.errorMessage)
+    }
+
+    @Test
+    fun runtimeLogs_readReleaseObfuscatedFields() {
+        val type = object : TypeToken<List<RuntimeLogEntry>>() {}.type
+        val entries: List<RuntimeLogEntry> = gson.fromJson(
+            """
+                [
+                  {
+                    "a": "log-1",
+                    "b": 5678,
+                    "c": "ERROR",
+                    "d": "Test",
+                    "e": "failed",
+                    "f": "stack",
+                    "g": true
+                  }
+                ]
+            """.trimIndent(),
+            type
+        )
+
+        val entry = entries.single()
+        assertEquals("log-1", entry.id)
+        assertEquals(5678L, entry.createdAt)
+        assertEquals("ERROR", entry.level)
+        assertEquals("Test", entry.tag)
+        assertEquals("failed", entry.message)
+        assertEquals("stack", entry.stackTrace)
+        assertTrue(entry.isCrash)
+    }
+}


### PR DESCRIPTION
## 背景

`0.5.6.12` 的 Release 测试 APK 启用 R8 后，Gson 持久化模型的字段名被混淆为 `a/b/c...`。`0.5.6.13` 虽然固定了后续写入使用的字段名，但没有兼容读取测试包已经写入的旧字段，升级读取时可能把提供商配置判为空并写回默认值。

这是正式发版前的 Release 测试包升级兼容问题，不是 `models.dev` 刷新或服务端主动删除配置。

## 修改内容

- 为提供商配置、场景模型绑定、语音配置、AI 请求日志和运行日志声明稳定 JSON 字段名，并添加旧版 R8 字段别名。
- 在提供商配置的自动迁移、保存、删除和整体替换入口增加保护：原始数据无法完整识别时只使用内存默认值，不覆盖 MMKV 中的原数据。
- 保留现有窄范围 R8 规则，继续进行类名、方法名和无用代码收缩，不回退发布包优化。
- 添加旧版 JSON 读取、新版规范字段写入及未知数据防覆盖的回归测试。

## 修复前后

- 修复前：旧测试包写入的 `a/b/c...` 字段无法按新字段名读取，profile 可能被过滤并被默认配置覆盖。
- 修复后：尚未被覆盖的旧数据可直接恢复读取；新数据统一写入稳定字段名；无法确认格式的数据会保留原文并停止写回。
- 已经被旧逻辑覆盖的数据无法凭空还原，仍需依赖原测试包数据或备份恢复。

## 包体积

使用相同 `origin/main` 基线、JDK/Gradle 工具链和本地调试签名对比：

- 修复前约 `68.71 MB`
- 修复后约 `68.72 MB`
- 增量约 `9 KB`（小于 `0.02%`），可视为基本不变

该数字用于同条件相对比较，正式签名后的绝对值可能有轻微差异。

## 验证

- `:baselib:testReleaseUnitTest`：29 个测试通过。
- `:app:testDevelopStandardDebugUnitTest`：336 个测试通过。
- Flutter 提供商、场景、models.dev 与语音相关定向测试：41 个测试通过。
- `flutter analyze --no-fatal-warnings --no-fatal-infos`：退出码 0；仅有项目现存提示。
- `:app:assembleProductionStandardRelease`：R8、资源收缩与 APK 打包成功。
- 产物确认继续混淆类名和方法名，并保留运行时 `@SerializedName` 兼容信息；APK v3 签名验证通过（本地调试签名，仅用于构建验证）。
