### PR TITLE
fix(llm): 恢复 Provider 配置增删操作

### DIFF
--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderConfigStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/ModelProviderConfigStore.kt
@@ -3,7 +3,6 @@ package cn.com.omnimind.baselib.llm
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.baselib.util.OssIdentity
 import com.google.gson.Gson
-import com.google.gson.JsonParser
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
@@ -76,10 +75,6 @@ object ModelProviderConfigStore {
         val deletedOfficialProfileIds = readDeletedOfficialProfileIds(mmkv)
         val storedProfilesRaw = mmkv.decodeString(KEY_PROVIDER_PROFILES)
         val decodedProfiles = decodeProfilesJson(storedProfilesRaw)
-        if (shouldPreserveStoredProfiles(storedProfilesRaw, decodedProfiles)) {
-            OmniLog.w(TAG, "provider profiles payload is not empty but could not be decoded")
-            return defaultProfiles(deletedOfficialProfileIds)
-        }
         val storedProfiles = readActiveProfiles(
             mmkv = mmkv,
             deletedOfficialProfileIds = deletedOfficialProfileIds,
@@ -670,45 +665,8 @@ object ModelProviderConfigStore {
         return gson.toJson(normalized)
     }
 
-    internal fun shouldPreserveStoredProfiles(
-        raw: String?,
-        decodedProfiles: List<ModelProviderProfile>
-    ): Boolean {
-        val normalizedRaw = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return false
-        return try {
-            val root = JsonParser.parseString(normalizedRaw)
-            when {
-                root.isJsonNull -> false
-                !root.isJsonArray -> true
-                root.asJsonArray.isEmpty -> false
-                decodedProfiles.isEmpty() -> true
-                else -> root.asJsonArray.any { element ->
-                    if (!element.isJsonObject) {
-                        true
-                    } else {
-                        val profile = element.asJsonObject
-                        listOf("id", "a").none { fieldName ->
-                            val id = profile.get(fieldName)
-                            id != null &&
-                                id.isJsonPrimitive &&
-                                id.asJsonPrimitive.isString &&
-                                id.asString.isNotBlank()
-                        }
-                    }
-                }
-            }
-        } catch (_: Throwable) {
-            true
-        }
-    }
-
     private fun readProfilesForUpdate(mmkv: MMKV): List<ModelProviderProfile> {
-        val raw = mmkv.decodeString(KEY_PROVIDER_PROFILES)
-        val profiles = decodeProfilesJson(raw)
-        check(!shouldPreserveStoredProfiles(raw, profiles)) {
-            "provider profiles payload cannot be updated safely"
-        }
-        return profiles
+        return decodeProfilesJson(mmkv.decodeString(KEY_PROVIDER_PROFILES))
     }
 
     private fun readActiveProfiles(
@@ -797,10 +755,6 @@ object ModelProviderConfigStore {
             try {
                 val storedProfilesRaw = mmkv.decodeString(KEY_PROVIDER_PROFILES)
                 val existingProfiles = decodeProfilesJson(storedProfilesRaw)
-                if (shouldPreserveStoredProfiles(storedProfilesRaw, existingProfiles)) {
-                    OmniLog.w(TAG, "skip provider migration to preserve undecodable profiles")
-                    return
-                }
                 if (existingProfiles.isNotEmpty()) {
                     ensureEditingProfile(mmkv, existingProfiles)
                     syncLegacyFlatConfig(mmkv, existingProfiles.first())

--- a/baselib/src/test/java/cn/com/omnimind/baselib/llm/PersistedJsonCompatibilityTest.kt
+++ b/baselib/src/test/java/cn/com/omnimind/baselib/llm/PersistedJsonCompatibilityTest.kt
@@ -14,24 +14,27 @@ class PersistedJsonCompatibilityTest {
     private val gson = Gson()
 
     @Test
-    fun providerProfiles_preserveNonEmptyPayloadWhenDecodingProducesNoProfiles() {
-        val raw = """[{"unexpected":"value"}]"""
+    fun providerProfiles_ignoreUnknownEntriesAndKeepRecognizedProfiles() {
+        val raw =
+            """
+                [
+                  {"unexpected":"value"},
+                  {
+                    "a":"custom-provider",
+                    "b":"Custom Provider",
+                    "c":"https://api.example.com/v1",
+                    "d":"sk-test"
+                  }
+                ]
+            """.trimIndent()
+
         val decoded = ModelProviderConfigStore.decodeProfilesJson(raw)
 
-        assertTrue(decoded.isEmpty())
-        assertTrue(ModelProviderConfigStore.shouldPreserveStoredProfiles(raw, decoded))
-        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles(null, emptyList()))
-        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("   ", emptyList()))
-        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("[]", emptyList()))
-        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("[ ]", emptyList()))
-        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles("null", emptyList()))
-        assertTrue(ModelProviderConfigStore.shouldPreserveStoredProfiles("{", emptyList()))
-        assertTrue(
-            ModelProviderConfigStore.shouldPreserveStoredProfiles(
-                """{"id":"custom-provider"}""",
-                emptyList()
-            )
-        )
+        assertEquals(1, decoded.size)
+        assertEquals("custom-provider", decoded.single().id)
+        assertEquals("Custom Provider", decoded.single().name)
+        assertEquals("https://api.example.com/v1", decoded.single().baseUrl)
+        assertEquals("sk-test", decoded.single().apiKey)
     }
 
     @Test
@@ -77,19 +80,6 @@ class PersistedJsonCompatibilityTest {
         assertNull(profile.statusText)
         assertEquals("openai_compatible", profile.protocolType)
         assertEquals("responses", profile.wireApi)
-        assertFalse(ModelProviderConfigStore.shouldPreserveStoredProfiles(releaseRaw, profiles))
-        assertTrue(
-            ModelProviderConfigStore.shouldPreserveStoredProfiles(
-                """
-                    [
-                      {"a":"custom-provider"},
-                      {"futureId":"future-provider"}
-                    ]
-                """.trimIndent(),
-                profiles
-            )
-        )
-
         val encoded = ModelProviderConfigStore.encodeProfilesJson(profiles)
         val encodedProfile = JsonParser.parseString(encoded)
             .asJsonArray


### PR DESCRIPTION
## 问题

PR #457 为避免无法识别的旧 Provider 数据被覆盖，增加了写入保护。但当本地数据包含未知旧格式时，新增、编辑和删除都会抛出 `provider profiles payload cannot be updated safely`，导致整个 Provider 配置页面无法继续操作。

## 修改内容

- 移除未知旧数据对 Provider 新增、编辑、删除和迁移流程的全局阻断。
- 继续保留能够识别的旧 R8 字段兼容，已识别的 Provider 配置不会丢失。
- 无法识别的旧条目直接忽略，并在后续正常写入时清理。
- 不修改或撤销现有 R8 收缩配置。
- 调整持久化兼容测试，覆盖“忽略未知条目并保留可识别条目”的行为。

## 用户影响

- Provider 的新增、编辑和删除恢复正常。
- 可识别的旧配置继续迁移并使用。
- 完全无法识别的旧条目不再阻断用户操作，但不会保留。

## 验证

- `:baselib:testReleaseUnitTest`：29 个测试通过。
- `:app:testDevelopStandardDebugUnitTest`：336 个测试通过。
- WebChat TypeScript 与 Vite 构建随应用测试任务通过。
- `git diff --check` 通过。
