### PR TITLE
fix(chat): 修复模式切换后 Agent 按钮未恢复可点击状态

### DIFF
--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -597,6 +597,33 @@ class _ChatAppBarModeShortcutButton extends StatefulWidget {
 class _ChatAppBarModeShortcutButtonState
     extends State<_ChatAppBarModeShortcutButton> {
   bool _isOpen = false;
+  late final ValueNotifier<bool> _isAgentLoadingNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _isAgentLoadingNotifier = ValueNotifier<bool>(widget.isAgentLoading);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ChatAppBarModeShortcutButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.isAgentLoading == widget.isAgentLoading) {
+      return;
+    }
+    final isAgentLoading = widget.isAgentLoading;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _isAgentLoadingNotifier.value = isAgentLoading;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _isAgentLoadingNotifier.dispose();
+    super.dispose();
+  }
 
   Future<void> _openMenu() async {
     if (_isOpen) {
@@ -631,46 +658,52 @@ class _ChatAppBarModeShortcutButtonState
       transitionDuration: _kChatAppBarModeMenuOpenDuration,
       reverseTransitionDuration: _kChatAppBarModeMenuCloseDuration,
       unfoldAlignment: Alignment.topCenter,
-      child: _ChatAppBarModeShortcutMenuContent(
-        width: _kChatAppBarAccessoryButtonSize,
-        closeTooltip: isEnglish ? 'Close mode menu' : '收起模式菜单',
-        headerIcon: _buildOpenIcon(selectedColor),
-        items: [
-          _ChatAppBarModeShortcutMenuItemData(
-            action: _ChatAppBarModeShortcutAction.omniAi,
-            iconAsset: _kChatAppBarAgentIconAsset,
-            tooltip: isEnglish ? 'OmniAi' : '小万',
-            selected: widget.isOmniAiSelected,
-            enabled: widget.onOmniAiTap != null,
-            iconSize: _kChatAppBarModeMenuOmniAiIconSize,
-            iconOffset: _kChatAppBarModeMenuOmniAiIconOffset,
-          ),
-          for (final agent in acpAgentModes)
-            _ChatAppBarModeShortcutMenuItemData(
-              action: _ChatAppBarModeShortcutAction.acpAgent(agent.id),
-              agentId: agent.id,
-              tooltip: agent.name,
-              selected:
-                  widget.isAgentSelected && agent.id == widget.activeAcpAgentId,
-              enabled:
-                  !widget.isAgentLoading &&
-                  (widget.onAcpAgentTap != null || widget.onAgentTap != null),
-              iconSize: _chatAppBarModeMenuAgentIconSize(agent.id),
+      child: ValueListenableBuilder<bool>(
+        valueListenable: _isAgentLoadingNotifier,
+        builder: (context, isAgentLoading, _) =>
+            _ChatAppBarModeShortcutMenuContent(
+              width: _kChatAppBarAccessoryButtonSize,
+              closeTooltip: isEnglish ? 'Close mode menu' : '收起模式菜单',
+              headerIcon: _buildOpenIcon(selectedColor),
+              items: [
+                _ChatAppBarModeShortcutMenuItemData(
+                  action: _ChatAppBarModeShortcutAction.omniAi,
+                  iconAsset: _kChatAppBarAgentIconAsset,
+                  tooltip: isEnglish ? 'OmniAi' : '小万',
+                  selected: widget.isOmniAiSelected,
+                  enabled: widget.onOmniAiTap != null,
+                  iconSize: _kChatAppBarModeMenuOmniAiIconSize,
+                  iconOffset: _kChatAppBarModeMenuOmniAiIconOffset,
+                ),
+                for (final agent in acpAgentModes)
+                  _ChatAppBarModeShortcutMenuItemData(
+                    action: _ChatAppBarModeShortcutAction.acpAgent(agent.id),
+                    agentId: agent.id,
+                    tooltip: agent.name,
+                    selected:
+                        widget.isAgentSelected &&
+                        agent.id == widget.activeAcpAgentId,
+                    enabled:
+                        !isAgentLoading &&
+                        (widget.onAcpAgentTap != null ||
+                            widget.onAgentTap != null),
+                    iconSize: _chatAppBarModeMenuAgentIconSize(agent.id),
+                  ),
+                _ChatAppBarModeShortcutMenuItemData(
+                  action: _ChatAppBarModeShortcutAction.pureChat,
+                  iconAsset: _kChatAppBarPureChatIconAsset,
+                  tooltip: isEnglish ? 'Pure chat' : '纯聊天模式',
+                  selected: widget.isPureChatSelected,
+                  enabled: canSelectPureChat,
+                  iconSize: _kChatAppBarModeMenuPureChatIconSize,
+                ),
+              ],
+              selectedColor: selectedColor,
+              // popup 有自己的不透明 surface，不能复用为聊天壁纸适配的 AppBar
+              // iconTint；后者在浅色主题 + 深色壁纸时可能接近白色。
+              iconTint: palette.textSecondary,
+              disabledTint: palette.textTertiary,
             ),
-          _ChatAppBarModeShortcutMenuItemData(
-            action: _ChatAppBarModeShortcutAction.pureChat,
-            iconAsset: _kChatAppBarPureChatIconAsset,
-            tooltip: isEnglish ? 'Pure chat' : '纯聊天模式',
-            selected: widget.isPureChatSelected,
-            enabled: canSelectPureChat,
-            iconSize: _kChatAppBarModeMenuPureChatIconSize,
-          ),
-        ],
-        selectedColor: selectedColor,
-        // popup 有自己的不透明 surface，不能复用为聊天壁纸适配的 AppBar
-        // iconTint；后者在浅色主题 + 深色壁纸时可能接近白色。
-        iconTint: palette.textSecondary,
-        disabledTint: palette.textTertiary,
       ),
     );
     if (mounted) {

--- a/ui/test/features/home/pages/chat/widgets/chat_app_bar_test.dart
+++ b/ui/test/features/home/pages/chat/widgets/chat_app_bar_test.dart
@@ -730,6 +730,71 @@ void main() {
     expect(find.text('toggles:1'), findsOneWidget);
   });
 
+  testWidgets(
+    'updates ACP Agent availability while the mode menu remains open',
+    (tester) async {
+      final isAgentLoading = ValueNotifier<bool>(true);
+      addTearDown(isAgentLoading.dispose);
+      String? selectedAgentId;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: DefaultAssetBundle(
+            bundle: _SvgTestAssetBundle(),
+            child: ValueListenableBuilder<bool>(
+              valueListenable: isAgentLoading,
+              builder: (context, loading, _) => Scaffold(
+                body: ChatAppBar(
+                  onMenuTap: () {},
+                  onOmniAiTap: () {},
+                  onPureChatToggleTap: () {},
+                  onAcpAgentTap: (agentId) {
+                    selectedAgentId = agentId;
+                  },
+                  acpAgentModes: const <ChatAcpAgentModeOption>[
+                    ChatAcpAgentModeOption(id: 'codex-acp', name: 'Codex'),
+                  ],
+                  isAgentLoading: loading,
+                  activeMode: ChatSurfaceMode.normal,
+                  onModeChanged: (_) {},
+                  onDisplayLayerChanged: (_) {},
+                  onTerminalEnvironmentTap: (_) {},
+                  onTerminalTap: () {},
+                  onBrowserTap: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('chat-app-bar-pure-chat-button')),
+      );
+      await tester.pumpAndSettle();
+
+      final agentRow = find.byKey(
+        const ValueKey('chat-app-bar-mode-menu-acp-codex-acp'),
+      );
+      InkWell agentInkWell() => tester.widget<InkWell>(
+        find.descendant(of: agentRow, matching: find.byType(InkWell)),
+      );
+
+      expect(agentInkWell().onTap, isNull);
+
+      isAgentLoading.value = false;
+      await tester.pumpAndSettle();
+
+      expect(agentRow, findsOneWidget);
+      expect(agentInkWell().onTap, isNotNull);
+
+      await tester.tap(agentRow);
+      await tester.pumpAndSettle();
+
+      expect(selectedAgentId, 'codex-acp');
+    },
+  );
+
   testWidgets('shows every ACP Agent with its brand icon and selects it', (
     tester,
   ) async {


### PR DESCRIPTION
## 变更摘要

修复模式菜单保持打开时，ACP Agent 切换完成后按钮仍显示为灰色、无法继续点击的问题。确保加载状态结束后，菜单中的 Agent 按钮能够及时恢复可点击状态。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档更新
- [x] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

无。

## 主要改动

1. 将 Agent 加载状态同步到独立显示的模式菜单弹层。
2. Agent 切换完成后，无需关闭并重新打开菜单即可恢复按钮状态。
3. 增加菜单保持打开期间状态变化的回归测试。

## 测试说明

- [ ] 已本地编译通过
- [x] 已执行相关测试
- [ ] 已手动验证关键路径

测试结果：

- `dart format`：通过，0 个文件需要调整
- `flutter analyze`：通过，No issues found
- 针对性 Flutter 测试：通过
- 测试场景：`updates ACP Agent availability while the mode menu remains open`

## UI 变更（如有）

无视觉样式改动，仅修复模式菜单中 Agent 按钮的可用状态同步。

## 风险与回滚

风险较低，修改范围仅限模式菜单的加载状态同步。若出现异常，可回滚本次提交。

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [x] 本次修改不需要更新文档
- [x] 已确认不会影响无关模块