### PR TITLE
fix(chat): 优化流式响应并防止思考内容丢失

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -411,6 +411,19 @@ class AgentConversationHistoryRepository(
             conversationMode = conversationMode,
             entryId = entryId
         )
+        val resolvedPayload = if (
+            entryType == ENTRY_TYPE_UI_CARD &&
+            existing?.entryType == ENTRY_TYPE_UI_CARD
+        ) {
+            AgentConversationHistorySupport.preserveDeepThinkingContent(
+                existingPayload = AgentConversationHistorySupport.readMap(
+                    existing.payloadJson
+                ),
+                incomingPayload = payload
+            )
+        } else {
+            payload
+        }
         upsertEntry(
             AgentConversationEntry(
                 id = existing?.id ?: 0,
@@ -420,7 +433,7 @@ class AgentConversationHistoryRepository(
                 entryType = entryType,
                 status = status,
                 summary = summary.trim(),
-                payloadJson = gson.toJson(payload),
+                payloadJson = gson.toJson(resolvedPayload),
                 createdAt = existing?.createdAt ?: createdAt,
                 updatedAt = System.currentTimeMillis()
             )

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistorySupport.kt
@@ -204,6 +204,52 @@ internal object AgentConversationHistorySupport {
         ).filterValues { it != null }
     }
 
+    fun preserveDeepThinkingContent(
+        existingPayload: Map<String, Any?>,
+        incomingPayload: Map<String, Any?>
+    ): Map<String, Any?> {
+        val existingContent = toStringAnyMap(existingPayload["content"])
+        val existingCardData = toStringAnyMap(existingContent["cardData"])
+        val incomingContent = toStringAnyMap(incomingPayload["content"])
+        val incomingCardData = toStringAnyMap(incomingContent["cardData"])
+        if (
+            existingCardData["type"]?.toString() != "deep_thinking" ||
+            incomingCardData["type"]?.toString() != "deep_thinking"
+        ) {
+            return incomingPayload
+        }
+
+        val existingThinking = AgentTextSanitizer.sanitizeUtf16(
+            existingCardData["thinkingContent"]?.toString().orEmpty()
+        )
+        val incomingThinking = AgentTextSanitizer.sanitizeUtf16(
+            incomingCardData["thinkingContent"]?.toString().orEmpty()
+        )
+        if (existingThinking.isBlank() || incomingThinking.isNotBlank()) {
+            return incomingPayload
+        }
+
+        val mergedCardData = linkedMapOf<String, Any?>().apply {
+            putAll(incomingCardData)
+            put("thinkingContent", existingThinking)
+            listOf(
+                "thinkingContentTruncated",
+                "thinkingOriginalLength",
+                "thinkingTruncateMode"
+            ).forEach { key ->
+                existingCardData[key]?.let { put(key, it) }
+            }
+        }
+        val mergedContent = linkedMapOf<String, Any?>().apply {
+            putAll(incomingContent)
+            put("cardData", mergedCardData)
+        }
+        return linkedMapOf<String, Any?>().apply {
+            putAll(incomingPayload)
+            put("content", mergedContent)
+        }
+    }
+
     private fun readReasoningContent(payload: Map<String, Any?>): String? {
         return AgentTextSanitizer.sanitizeUtf16(
             payload["reasoning_content"]?.toString()

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -273,14 +273,13 @@ class HttpAgentLlmClient(
         var eventSource: EventSource? = null
         var streamIdleWatchdog: Job? = null
         val emissionQueue = Channel<suspend () -> Unit>(Channel.UNLIMITED)
+        val emissionLock = Any()
         val emissionJob = scope.launch {
             for (block in emissionQueue) {
                 runCatching { block.invoke() }
                     .onFailure { OmniLog.w(tag, "stream emission failed: ${it.message}") }
             }
         }
-        var hasPublishedReasoningForTurn = false
-
         fun enqueueEmission(block: suspend () -> Unit) {
             if (emissionQueue.isClosedForSend) {
                 return
@@ -313,7 +312,6 @@ class HttpAgentLlmClient(
 
         fun dispatchReasoningSnapshot(reasoning: String) {
             lastReasoning = reasoning
-            hasPublishedReasoningForTurn = true
             if (onReasoningUpdate != null) {
                 enqueueEmission {
                     onReasoningUpdate.invoke(reasoning)
@@ -335,9 +333,42 @@ class HttpAgentLlmClient(
         fun scheduleReasoningSnapshotLocked(delayMs: Long) {
             reasoningEmitJob = scope.launch {
                 delay(delayMs)
-                val snapshot = synchronized(reasoningLock) {
-                    reasoningEmitJob = null
-                    collectReasoningSnapshotLocked()
+                synchronized(emissionLock) {
+                    val snapshot = synchronized(reasoningLock) {
+                        reasoningEmitJob = null
+                        collectReasoningSnapshotLocked()
+                    }
+                    if (snapshot != null) {
+                        dispatchReasoningSnapshot(snapshot)
+                    }
+                }
+            }
+        }
+
+        fun emitReasoning(force: Boolean = false) {
+            var snapshot: String? = null
+            synchronized(emissionLock) {
+                synchronized(reasoningLock) {
+                    val length = accumulator.currentReasoningLength()
+                    if (length <= 0 || length == lastReasoningEmitLength) return
+                    if (force) {
+                        reasoningEmitJob?.cancel()
+                        reasoningEmitJob = null
+                        snapshot = collectReasoningSnapshotLocked()
+                        return@synchronized
+                    }
+                    if (reasoningEmitJob?.isActive == true) return
+                    val delayMs = ReasoningStreamUpdatePolicy.nextDelayMs(
+                        hasEmittedBefore = lastReasoningEmitLength > 0,
+                        lastEmitAtMs = lastReasoningEmitAt,
+                        nowMs = System.currentTimeMillis(),
+                        intervalMs = REASONING_UPDATE_INTERVAL_MS
+                    )
+                    if (delayMs <= 0L) {
+                        snapshot = collectReasoningSnapshotLocked()
+                    } else {
+                        scheduleReasoningSnapshotLocked(delayMs)
+                    }
                 }
                 if (snapshot != null) {
                     dispatchReasoningSnapshot(snapshot)
@@ -345,45 +376,26 @@ class HttpAgentLlmClient(
             }
         }
 
-        fun emitReasoning(force: Boolean = false) {
-            var snapshot: String? = null
-            synchronized(reasoningLock) {
-                val length = accumulator.currentReasoningLength()
-                if (length <= 0 || length == lastReasoningEmitLength) return
-                if (force) {
-                    reasoningEmitJob?.cancel()
-                    reasoningEmitJob = null
-                    snapshot = collectReasoningSnapshotLocked()
-                    return@synchronized
-                }
-                if (reasoningEmitJob?.isActive == true) return
-                val delayMs = ReasoningStreamUpdatePolicy.nextDelayMs(
-                    hasEmittedBefore = lastReasoningEmitLength > 0,
-                    lastEmitAtMs = lastReasoningEmitAt,
-                    nowMs = System.currentTimeMillis(),
-                    intervalMs = REASONING_UPDATE_INTERVAL_MS
-                )
-                if (delayMs <= 0L) {
-                    snapshot = collectReasoningSnapshotLocked()
-                } else {
-                    scheduleReasoningSnapshotLocked(delayMs)
-                }
-            }
-            if (snapshot != null) {
-                dispatchReasoningSnapshot(snapshot)
-            }
-        }
-
         fun emitContent() {
             val content = accumulator.currentContent()
             if (content.isEmpty() || content == lastContent) return
-            if (!hasPublishedReasoningForTurn && accumulator.currentReasoningLength() > 0) {
-                emitReasoning(force = true)
-            }
-            lastContent = content
-            if (onContentUpdate != null) {
-                enqueueEmission {
-                    onContentUpdate.invoke(content)
+            synchronized(emissionLock) {
+                var reasoningSnapshot: String? = null
+                synchronized(reasoningLock) {
+                    if (accumulator.currentReasoningLength() > 0) {
+                        reasoningEmitJob?.cancel()
+                        reasoningEmitJob = null
+                        reasoningSnapshot = collectReasoningSnapshotLocked()
+                    }
+                }
+                if (reasoningSnapshot != null) {
+                    dispatchReasoningSnapshot(reasoningSnapshot)
+                }
+                lastContent = content
+                if (onContentUpdate != null) {
+                    enqueueEmission {
+                        onContentUpdate.invoke(content)
+                    }
                 }
             }
         }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/AgentConversationHistorySupportTest.kt
@@ -530,6 +530,54 @@ class AgentConversationHistorySupportTest {
     }
 
     @Test
+    fun `preserveDeepThinkingContent keeps prior text when final snapshot is empty`() {
+        val existing = AgentConversationHistorySupport.buildCardMessagePayload(
+            messageId = "task-thinking",
+            cardData = mapOf(
+                "type" to "deep_thinking",
+                "thinkingContent" to "已经收到的思考内容",
+                "thinkingOriginalLength" to 10,
+                "thinkingContentTruncated" to false,
+                "thinkingTruncateMode" to "none",
+                "stage" to 1,
+                "isLoading" to true
+            ),
+            isError = false,
+            streamMeta = null,
+            createdAt = 1000
+        )
+        val incoming = AgentConversationHistorySupport.buildCardMessagePayload(
+            messageId = "task-thinking",
+            cardData = mapOf(
+                "type" to "deep_thinking",
+                "thinkingContent" to "",
+                "thinkingOriginalLength" to 0,
+                "thinkingContentTruncated" to false,
+                "thinkingTruncateMode" to "none",
+                "stage" to 4,
+                "isLoading" to false,
+                "endTime" to 2000
+            ),
+            isError = false,
+            streamMeta = null,
+            createdAt = 1000
+        )
+
+        val merged = AgentConversationHistorySupport.preserveDeepThinkingContent(
+            existingPayload = existing,
+            incomingPayload = incoming
+        )
+        val content = merged["content"] as Map<*, *>
+        val cardData = content["cardData"] as Map<*, *>
+
+        assertEquals("已经收到的思考内容", cardData["thinkingContent"])
+        assertEquals(10, cardData["thinkingOriginalLength"])
+        assertEquals(4, cardData["stage"])
+        assertEquals(false, cardData["isLoading"])
+        assertEquals(2000, cardData["endTime"])
+    }
+
+    @Test
     fun `normalizeInterruptedEntries converts running tools to interrupted`() {
         val runningEntry = AgentConversationEntry(
             id = 1,

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpAgentLlmClientTest.kt
@@ -209,9 +209,10 @@ class HttpAgentLlmClientTest {
     }
 
     @Test
-    fun `qwen route streams content before done after separate reasoning channel`() = runBlocking {
+    fun `qwen route emits pending reasoning before content`() = runBlocking {
         val scope = CoroutineScope(Job() + Dispatchers.Default)
         val firstContentUpdate = CompletableDeferred<String>()
+        val emissions = mutableListOf<String>()
         try {
             val client = HttpAgentLlmClient(
                 scope = scope,
@@ -237,6 +238,12 @@ class HttpAgentLlmClientTest {
                         source,
                         null,
                         "message",
+                        """{"choices":[{"delta":{"content":"","reasoning_content":"更多"}}]}"""
+                    )
+                    listener.onEvent(
+                        source,
+                        null,
+                        "message",
                         """{"choices":[{"delta":{"content":"最终"}}]}"""
                     )
                     withTimeout(1_000L) {
@@ -257,7 +264,11 @@ class HttpAgentLlmClientTest {
 
             val turn = client.streamTurn(
                 request = simpleRequest(),
+                onReasoningUpdate = { reasoning ->
+                    emissions += "reasoning:$reasoning"
+                },
                 onContentUpdate = { content ->
+                    emissions += "content:$content"
                     if (!firstContentUpdate.isCompleted) {
                         firstContentUpdate.complete(content)
                     }
@@ -265,8 +276,17 @@ class HttpAgentLlmClientTest {
             )
 
             assertEquals("最终", firstContentUpdate.await())
-            assertEquals("先分析", turn.reasoning)
+            assertEquals("先分析更多", turn.reasoning)
             assertEquals("最终回答", turn.message.contentText())
+            val lastReasoningIndex = emissions.indexOfLast {
+                it.startsWith("reasoning:")
+            }
+            val firstContentIndex = emissions.indexOfFirst {
+                it.startsWith("content:")
+            }
+            assertTrue(lastReasoningIndex >= 0)
+            assertTrue(firstContentIndex >= 0)
+            assertTrue(lastReasoningIndex < firstContentIndex)
         } finally {
             scope.cancel()
         }

--- a/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_widgets.dart
@@ -1727,6 +1727,44 @@ class ChatMessageList extends StatefulWidget {
   State<ChatMessageList> createState() => _ChatMessageListState();
 }
 
+class _ChatLatestEdgeScrollPhysics extends ClampingScrollPhysics {
+  const _ChatLatestEdgeScrollPhysics({
+    required this.shouldStickToLatest,
+    super.parent,
+  });
+
+  final ValueGetter<bool> shouldStickToLatest;
+
+  @override
+  _ChatLatestEdgeScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _ChatLatestEdgeScrollPhysics(
+      shouldStickToLatest: shouldStickToLatest,
+      parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  double adjustPositionForNewDimensions({
+    required ScrollMetrics oldPosition,
+    required ScrollMetrics newPosition,
+    required bool isScrolling,
+    required double velocity,
+  }) {
+    if (!shouldStickToLatest() || isScrolling || velocity != 0.0) {
+      return super.adjustPositionForNewDimensions(
+        oldPosition: oldPosition,
+        newPosition: newPosition,
+        isScrolling: isScrolling,
+        velocity: velocity,
+      );
+    }
+    return switch (newPosition.axisDirection) {
+      AxisDirection.down || AxisDirection.right => newPosition.maxScrollExtent,
+      AxisDirection.up || AxisDirection.left => newPosition.minScrollExtent,
+    };
+  }
+}
+
 class _ChatMessageListState extends State<ChatMessageList> {
   static const Duration _kAgentRunToggleAutoStickSuppression = Duration(
     milliseconds: 420,
@@ -1787,10 +1825,10 @@ class _ChatMessageListState extends State<ChatMessageList> {
       _autoStickToLatest = true;
       _outerScrollWasUserDriven = false;
       _autoStickSuppressedUntil = null;
+      _scheduleStickToLatest();
+      return;
     }
     if (_autoStickToLatest) {
-      _autoStickToLatest = true;
-      _scheduleStickToLatest();
       return;
     }
     if (_isAutoStickTemporarilySuppressed) {
@@ -1798,7 +1836,6 @@ class _ChatMessageListState extends State<ChatMessageList> {
     }
     if (_isNearLatest(null, _manualLatestAttachTolerance)) {
       _autoStickToLatest = true;
-      _scheduleStickToLatest();
     }
   }
 
@@ -1858,16 +1895,11 @@ class _ChatMessageListState extends State<ChatMessageList> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _stickToBottomScheduled = false;
       if (!mounted) {
-        if (mounted) {
-          _scheduleStickToBottom();
-        }
         return;
       }
       final positions = _attachedPositions();
       if (positions.isEmpty) {
-        if (mounted) {
-          _scheduleStickToBottom();
-        }
+        _scheduleStickToLatest();
         return;
       }
       if (!_autoStickToLatest) {
@@ -1881,12 +1913,6 @@ class _ChatMessageListState extends State<ChatMessageList> {
         position.jumpTo(target);
       }
     });
-  }
-
-  void _handleStreamingTextLayoutChanged() {
-    if (_autoStickToLatest && !_isAutoStickTemporarilySuppressed) {
-      _scheduleStickToLatest();
-    }
   }
 
   void _bindObservableMessages(List<ChatMessageModel> messages) {
@@ -1906,9 +1932,6 @@ class _ChatMessageListState extends State<ChatMessageList> {
       return;
     }
     _collapseCancelledAgentRuns();
-    if (_autoStickToLatest && !_isAutoStickTemporarilySuppressed) {
-      _scheduleStickToLatest();
-    }
     // 流式追加文本这类 content 级变更由每行的 ValueListenableBuilder 精确
     // 刷新，这里不再整表 setState（否则每个 chunk 都会重跑时间线分组和
     // 全部可见行的 itemBuilder）。结构变化仍走完整重建。
@@ -2351,7 +2374,7 @@ class _ChatMessageListState extends State<ChatMessageList> {
         onParentScrollHandoff: _handleParentScrollHandoff,
         onRequestAuthorize: widget.onRequestAuthorize,
         onUserMessageLongPressStart: widget.onUserMessageLongPressStart,
-        onStreamingTextLayoutChanged: _handleStreamingTextLayoutChanged,
+        onStreamingTextLayoutChanged: null,
         onToggleAgentRunGroup: _toggleAgentRunGroup,
         expandedAgentRunTaskIds: _expandedAgentRunTaskIds,
         useAcpPresentation: widget.useAcpPresentation,
@@ -2466,7 +2489,10 @@ class _ChatMessageListState extends State<ChatMessageList> {
     Widget listView = ListView.builder(
       controller: widget.scrollController,
       reverse: false,
-      physics: const ClampingScrollPhysics(),
+      physics: _ChatLatestEdgeScrollPhysics(
+        shouldStickToLatest: () =>
+            _autoStickToLatest && !_isAutoStickTemporarilySuppressed,
+      ),
       clipBehavior: Clip.hardEdge,
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
       itemCount: timelineEntries.length,

--- a/ui/lib/features/home/pages/command_overlay/widgets/cards/deep_thinking_card.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/cards/deep_thinking_card.dart
@@ -288,6 +288,7 @@ class _DeepThinkingCardState extends State<DeepThinkingCard>
 
   void _toggleCollapsed() {
     if (!widget.isCollapsible || widget.stage != 4) return;
+    widget.onParentScrollHandoff?.call();
     _setCollapsed(
       !_isCollapsed,
       markCompletionHandled: _shouldAutoCollapse(widget),
@@ -787,8 +788,8 @@ class _DeepThinkingCardState extends State<DeepThinkingCard>
       return false;
     }
 
-    parentPosition.jumpTo(next);
     widget.onParentScrollHandoff?.call();
+    parentPosition.jumpTo(next);
     return true;
   }
 

--- a/ui/lib/features/home/pages/command_overlay/widgets/cards/deep_thinking_card.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/cards/deep_thinking_card.dart
@@ -455,6 +455,11 @@ class _DeepThinkingCardState extends State<DeepThinkingCard>
 
   @override
   Widget build(BuildContext context) {
+    final hasContent = widget.thinkingText.trim().isNotEmpty;
+    if (!hasContent && !_isActivelyThinking(widget)) {
+      return const SizedBox.shrink();
+    }
+
     final palette = context.omniPalette;
     final parentScrollPosition = _resolveParentScrollPosition(context);
     final resolvedTextColor = context.isDarkTheme
@@ -463,7 +468,6 @@ class _DeepThinkingCardState extends State<DeepThinkingCard>
     final secondaryTextColor = context.isDarkTheme
         ? palette.textSecondary
         : resolvedTextColor.withValues(alpha: 0.68);
-    final bool hasContent = widget.thinkingText.isNotEmpty;
     final bool canCollapse = widget.isCollapsible && widget.stage == 4;
 
     // 根据阶段显示不同的文案

--- a/ui/test/features/home/pages/chat/widgets/chat_message_list_test.dart
+++ b/ui/test/features/home/pages/chat/widgets/chat_message_list_test.dart
@@ -509,6 +509,104 @@ void main() {
     },
   );
 
+  testWidgets('streaming body growth stays pinned during every layout frame', (
+    tester,
+  ) async {
+    final controller = ScrollController();
+    final messages = ObservableChatMessageList()
+      ..replaceAllMessages(<ChatMessageModel>[
+        ChatMessageModel(
+          id: 'body-task-text',
+          type: 1,
+          user: 2,
+          content: const <String, dynamic>{
+            'text': '正文开始',
+            'id': 'body-task-text',
+            'renderMarkdown': true,
+          },
+          streamMeta: const <String, dynamic>{
+            'parentTaskId': 'body-task',
+            'kind': 'text_snapshot',
+            'seq': 1,
+            'isFinal': false,
+          },
+        ),
+        ...List.generate(18, (index) {
+          return ChatMessageModel.assistantMessage(
+            List.generate(
+              4,
+              (line) => '较早正文 ${index + 1} - 第 ${line + 1} 行',
+            ).join('\n'),
+            id: 'body-older-$index',
+          );
+        }),
+      ]);
+
+    await tester.pumpWidget(
+      _buildLocalizedApp(
+        child: SizedBox(
+          width: 400,
+          height: 520,
+          child: ChatMessageList(
+            messages: messages,
+            scrollController: controller,
+            activeAgentTaskIds: const <String>{'body-task'},
+            onBeforeTaskExecute: () async {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(
+      controller.offset,
+      closeTo(controller.position.maxScrollExtent, 0.5),
+    );
+
+    final existing = messages[0];
+    final content = Map<String, dynamic>.from(existing.content ?? const {});
+    content['text'] = List.generate(
+      48,
+      (index) => '正文第 ${index + 1} 行持续流式增长，用于验证布局期间保持最新位置。',
+    ).join('\n');
+    messages[0] = existing.copyWith(
+      content: content,
+      streamMeta: const <String, dynamic>{
+        'parentTaskId': 'body-task',
+        'kind': 'text_snapshot',
+        'seq': 2,
+        'isFinal': false,
+      },
+    );
+
+    for (var frame = 0; frame < 30; frame += 1) {
+      await tester.pump(const Duration(milliseconds: 16));
+      expect(
+        controller.offset,
+        closeTo(controller.position.maxScrollExtent, 0.5),
+        reason: 'frame $frame should remain pinned while body layout grows',
+      );
+    }
+
+    messages[0] = messages[0].copyWith(
+      streamMeta: const <String, dynamic>{
+        'parentTaskId': 'body-task',
+        'kind': 'text_snapshot',
+        'seq': 3,
+        'isFinal': true,
+      },
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 16));
+
+    expect(
+      controller.offset,
+      closeTo(controller.position.maxScrollExtent, 0.5),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'expanding an older thinking card does not snap the list back to latest',
     (tester) async {

--- a/ui/test/features/home/pages/command_overlay/widgets/deep_thinking_card_test.dart
+++ b/ui/test/features/home/pages/command_overlay/widgets/deep_thinking_card_test.dart
@@ -36,6 +36,29 @@ void main() {
     },
   );
 
+  testWidgets('completed empty thinking card does not imply content exists', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: DeepThinkingCard(
+            thinkingText: '',
+            stage: 4,
+            isLoading: false,
+            isCollapsible: true,
+            startTime: 1000,
+            endTime: 13000,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(DeepThinkingCard), findsOneWidget);
+    expect(find.text('思考完成'), findsNothing);
+    expect(find.byIcon(Icons.keyboard_arrow_down_rounded), findsNothing);
+  });
+
   testWidgets('thinking expansion stays anchored to the top edge', (
     tester,
   ) async {


### PR DESCRIPTION
## 主要改动

- 调整消息列表的贴底策略，在流式正文持续增长时同步修正滚动位置，减少分段跳动和结束时的二次抖动
- 串行派发思考与正文快照，避免已收到的思考尚未展示时正文提前出现
- 防止完成阶段的空快照覆盖已经持久化的思考内容
- 模型未返回可展示的思考文本时，不再显示无效的“思考完成”详情
- 补充流式滚动、响应顺序、思考持久化和空内容渲染测试

## 问题原因

原有实现通过帧结束后的滚动跳转追赶正文高度变化，连续输出时容易产生逐段上移。思考卡在模型调用开始时会提前创建，部分轮次未返回思考文本或结束时产生空快照，导致空卡片或已有内容丢失。

## 验证

- Kotlin 与 Flutter 针对性测试通过
- 流式增长、思考折叠和响应顺序测试通过
- Flutter Analyze 通过
- Production Standard Release 构建成功
- 已在真我 GT8 Pro 真机覆盖安装验证