### PR TITLE
feat: Ubuntu Rootfs 按需下载，优化安装包体积

### DIFF
--- a/ReTerminal/core/main/build.gradle.kts
+++ b/ReTerminal/core/main/build.gradle.kts
@@ -314,6 +314,7 @@ dependencies {
     api(libs.accompanist.systemuicontroller)
     testImplementation(libs.junit)
     testImplementation("org.json:json:20250517")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
 //    api(libs.termux.shared)
 
     api(project(":core:resources"))

--- a/ReTerminal/core/main/build.gradle.kts
+++ b/ReTerminal/core/main/build.gradle.kts
@@ -29,9 +29,12 @@ val libtallocDebChecksum = "ac81ad623d74c209718b9f3acb2dd702cc8a88c431e820d21222
 val alpineMiniRootfsUrl =
     "https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/aarch64/alpine-minirootfs-3.21.0-aarch64.tar.gz"
 val alpineMiniRootfsChecksum = "f31202c4070c4ef7de9e157e1bd01cb4da3a2150035d74ea5372c5e86f1efac1"
-val ubuntuBaseRootfsUrl =
-    "https://cdimage.ubuntu.com/ubuntu-base/releases/24.04.4/release/ubuntu-base-24.04.4-base-arm64.tar.gz"
-val ubuntuBaseRootfsChecksum = "04207713ece899c3740823d33690441ad3a7f0ded1101aca744e2b0f37ac7ff2"
+val terminalRuntimeManifestUrl = providers.gradleProperty("OMNIBOT_TERMINAL_RUNTIME_MANIFEST_URL")
+    .orElse(providers.environmentVariable("OMNIBOT_TERMINAL_RUNTIME_MANIFEST_URL"))
+    .getOrElse("")
+    .trim()
+
+fun buildConfigString(value: String): String = "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
 
 android {
     namespace = "com.rk.terminal"
@@ -42,6 +45,11 @@ android {
         minSdk = 24
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+        buildConfigField(
+            "String",
+            "TERMINAL_RUNTIME_MANIFEST_URL",
+            buildConfigString(terminalRuntimeManifestUrl)
+        )
     }
 
     sourceSets {
@@ -212,13 +220,13 @@ val prepareEmbeddedTerminalRuntime by tasks.registering {
     inputs.property("libtallocDebChecksum", libtallocDebChecksum)
     inputs.property("alpineMiniRootfsUrl", alpineMiniRootfsUrl)
     inputs.property("alpineMiniRootfsChecksum", alpineMiniRootfsChecksum)
-    inputs.property("ubuntuBaseRootfsUrl", ubuntuBaseRootfsUrl)
-    inputs.property("ubuntuBaseRootfsChecksum", ubuntuBaseRootfsChecksum)
     outputs.dir(outputDir)
     outputs.dir(jniOutputDir)
     doLast {
         val root = outputDir.get().asFile
         val jniRoot = jniOutputDir.get().asFile
+        root.deleteRecursively()
+        jniRoot.deleteRecursively()
         root.mkdirs()
         jniRoot.mkdirs()
         val workDir = temporaryDir.apply {
@@ -270,11 +278,6 @@ val prepareEmbeddedTerminalRuntime by tasks.registering {
             remoteUrl = alpineMiniRootfsUrl,
             expectedChecksum = alpineMiniRootfsChecksum
         )
-        downloadRuntimeFile(
-            localPath = root.resolve("ubuntu.tar.gz").absolutePath,
-            remoteUrl = ubuntuBaseRootfsUrl,
-            expectedChecksum = ubuntuBaseRootfsChecksum
-        )
     }
 }
 
@@ -309,6 +312,8 @@ dependencies {
     api(libs.androidx.material.icons.core)
     api(libs.androidx.palette)
     api(libs.accompanist.systemuicontroller)
+    testImplementation(libs.junit)
+    testImplementation("org.json:json:20250517")
 //    api(libs.termux.shared)
 
     api(project(":core:resources"))

--- a/ReTerminal/core/main/src/main/java/com/rk/terminal/runtime/EmbeddedRuntimeInstaller.kt
+++ b/ReTerminal/core/main/src/main/java/com/rk/terminal/runtime/EmbeddedRuntimeInstaller.kt
@@ -1,25 +1,57 @@
 package com.rk.terminal.runtime
 
 import android.content.Context
+import android.os.StatFs
+import androidx.annotation.VisibleForTesting
 import com.rk.libcommons.localBinDir
 import com.rk.libcommons.localDir
 import com.rk.libcommons.localLibDir
+import com.rk.terminal.BuildConfig
 import com.rk.terminal.ui.screens.terminal.stat
 import com.rk.terminal.ui.screens.terminal.vmstat
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONObject
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.math.BigInteger
 import java.security.MessageDigest
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.TimeUnit
 
 object EmbeddedRuntimeInstaller {
-    private data class RuntimeAssetSpec(
-        val outputName: String,
-        val assetCandidates: List<String>,
-        val executable: Boolean = false
+    data class RuntimeInstallProgress(
+        val phase: String,
+        val distribution: String,
+        val message: String,
+        val downloadedBytes: Long = 0L,
+        val totalBytes: Long = 0L,
+        val progress: Double? = null,
+        val error: String? = null
+    )
+
+    data class RuntimeManifestEntry(
+        val id: String,
+        val version: String,
+        val abi: String,
+        val fileName: String,
+        val compressedSize: Long,
+        val expandedSize: Long,
+        val sha256: String,
+        val downloadUrl: HttpUrl
     )
 
     data class InstallStatus(
@@ -28,223 +60,439 @@ object EmbeddedRuntimeInstaller {
         val message: String
     )
 
-    private const val ASSET_ROOT = "embedded-terminal-runtime"
-    private val installMutex = Mutex()
-    private val runtimeAssets = listOf(
-        RuntimeAssetSpec(
-            outputName = "proot",
-            assetCandidates = listOf("proot"),
-            executable = true
-        ),
-        RuntimeAssetSpec(
-            outputName = "libtalloc.so.2",
-            assetCandidates = listOf("libtalloc.so.2")
-        ),
-        RuntimeAssetSpec(
-            outputName = "alpine.tar.gz",
-            assetCandidates = listOf("alpine.tar.gz", "alpine.tar")
-        ),
-        RuntimeAssetSpec(
-            outputName = "ubuntu.tar.gz",
-            assetCandidates = listOf("ubuntu.tar.gz", "ubuntu.tar")
-        )
+    private data class RuntimeAssetSpec(
+        val outputName: String,
+        val assetCandidates: List<String>,
+        val executable: Boolean = false
     )
+
+    private const val ASSET_ROOT = "embedded-terminal-runtime"
+    private const val PREFS_NAME = "embedded_terminal_runtime_downloads"
+    private const val MAX_MANIFEST_BYTES = 1024 * 1024L
+    private const val MIN_RUNTIME_BYTES = 1024 * 1024L
+    private const val MAX_RUNTIME_BYTES = 512 * 1024 * 1024L
+    private const val DISK_SAFETY_BYTES = 16 * 1024 * 1024L
+    private const val LEGACY_EXPANDED_MIN_BYTES = 64 * 1024 * 1024L
+    private const val MAX_REDIRECTS = 5
+    private const val LEGACY_UBUNTU_SHA256 =
+        "04207713ece899c3740823d33690441ad3a7f0ded1101aca744e2b0f37ac7ff2"
+    private const val OFFICIAL_UBUNTU_VERSION = "24.04.4"
+    private const val OFFICIAL_UBUNTU_FILE_NAME = "ubuntu-base-24.04.4-base-arm64.tar.gz"
+    private const val OFFICIAL_UBUNTU_COMPRESSED_SIZE = 29_870_567L
+    private const val OFFICIAL_UBUNTU_EXPANDED_SIZE = 106_649_600L
+    private const val OFFICIAL_UBUNTU_URL =
+        "https://cdimage.ubuntu.com/ubuntu-base/releases/24.04.4/release/ubuntu-base-24.04.4-base-arm64.tar.gz"
+
+    private val installMutex = Mutex()
+    private val commonAssets = listOf(
+        RuntimeAssetSpec("proot", listOf("proot"), executable = true),
+        RuntimeAssetSpec("libtalloc.so.2", listOf("libtalloc.so.2"))
+    )
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .build()
 
     suspend fun ensureRuntimeInstalled(
         context: Context,
-        onProgress: suspend (String) -> Unit = {}
+        onProgress: suspend (RuntimeInstallProgress) -> Unit = {}
     ): InstallStatus = withContext(Dispatchers.IO) {
         installMutex.withLock {
+            val distribution = TerminalDistribution.selected()
             try {
-                onProgress("正在校验终端环境运行资源")
-                val resolvedAssets = runtimeAssets.associateWith { spec ->
-                    spec.assetCandidates.firstOrNull { assetName ->
-                        runCatching {
-                            context.assets.open("$ASSET_ROOT/$assetName").close()
-                        }.isSuccess
-                    }
-                }
-                val missingAssets = resolvedAssets.filterValues { it == null }.keys
-                if (missingAssets.isNotEmpty()) {
-                    return@withLock InstallStatus(
-                        success = false,
-                        installed = false,
-                        message = "缺少内置终端环境运行资源，请重新安装包含终端资源的构建。"
-                    )
-                }
-
-                onProgress("正在安装终端环境运行资源")
-                var refreshedFiles = 0
-                val installedFiles = mutableMapOf<String, File>()
-                runtimeAssets.forEach { spec ->
-                    val assetName = resolvedAssets.getValue(spec)
-                        ?: error("Missing runtime asset mapping for ${spec.outputName}")
-                    val target = File(context.filesDir, spec.outputName)
-                    if (copyAssetIfChanged(
-                            context = context,
-                            assetPath = "$ASSET_ROOT/$assetName",
-                            target = target,
-                            executable = spec.executable
-                        )
-                    ) {
-                        refreshedFiles++
-                    }
-                    installedFiles[spec.outputName] = target
-                }
-
-                // ReTerminal init-host.sh expects these runtime helpers to exist under $PREFIX/local.
-                localDir().mkdirs()
-                localBinDir().mkdirs()
-                localLibDir().mkdirs()
-                installedFiles["proot"]?.let { source ->
-                    if (copyFileIfChanged(source, File(localBinDir(), "proot"), executable = true)) {
-                        refreshedFiles++
-                    }
-                }
-                installedFiles["libtalloc.so.2"]?.let { source ->
-                    if (copyFileIfChanged(source, File(localLibDir(), "libtalloc.so.2"), executable = false)) {
-                        refreshedFiles++
-                    }
-                }
-                if (writeTextIfChanged(File(localDir(), "stat"), stat)) {
-                    refreshedFiles++
-                }
-                if (writeTextIfChanged(File(localDir(), "vmstat"), vmstat)) {
-                    refreshedFiles++
-                }
-
-                InstallStatus(
-                    success = true,
-                    installed = true,
-                    message = if (refreshedFiles > 0) {
-                        "终端环境运行资源已刷新。"
-                    } else {
-                        "终端环境运行资源已就绪。"
-                    }
-                )
+                emit(onProgress, "checking", distribution, "正在校验终端环境运行资源")
+                val installedFiles = installCommonAssets(context)
+                installDistribution(context, distribution, onProgress)
+                installCommonHelpers(installedFiles)
+                emit(onProgress, "ready", distribution, "终端环境运行资源已就绪。", progress = 1.0)
+                InstallStatus(true, true, "终端环境运行资源已就绪。")
+            } catch (error: CancellationException) {
+                throw error
             } catch (error: Exception) {
-                InstallStatus(
-                    success = false,
-                    installed = false,
-                    message = error.message ?: "安装终端环境运行资源失败。"
-                )
+                val message = error.message ?: "安装终端环境运行资源失败。"
+                emit(onProgress, "error", distribution, message, error = message)
+                InstallStatus(false, false, message)
             }
         }
+    }
+
+    fun isCurrentDistributionReady(context: Context): Boolean {
+        val distribution = TerminalDistribution.selected()
+        val commonReady = commonAssets.all { File(context.filesDir, it.outputName).isFile }
+        return commonReady && (
+            isRootfsInstalled(context, distribution) ||
+                File(context.filesDir, distribution.rootfsArchiveName).isFile
+            )
+    }
+
+    private suspend fun installDistribution(
+        context: Context,
+        distribution: TerminalDistribution.Spec,
+        onProgress: suspend (RuntimeInstallProgress) -> Unit
+    ) {
+        if (isRootfsInstalled(context, distribution)) {
+            emit(onProgress, "ready", distribution, "${distribution.displayName} 系统已安装。")
+            return
+        }
+
+        val archive = File(context.filesDir, distribution.rootfsArchiveName)
+        if (distribution.id == TerminalDistribution.alpine.id) {
+            emit(onProgress, "installing", distribution, "正在安装 Alpine 离线运行资源")
+            copyAssetIfChanged(
+                context,
+                listOf("alpine.tar.gz", "alpine.tar"),
+                archive,
+                executable = false
+            )
+            return
+        }
+
+        if (isTrustedExistingUbuntuArchive(context, archive)) {
+            val savedExpandedSize = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getLong("ubuntu_expanded_size", 0L)
+            val estimatedExpandedSize = savedExpandedSize.takeIf { it > 0L }
+                ?: maxOf(LEGACY_EXPANDED_MIN_BYTES, archive.length() * 4L)
+            ensureAvailableSpace(context, estimatedExpandedSize + DISK_SAFETY_BYTES)
+            emit(onProgress, "ready", distribution, "已找到可用的 Ubuntu 运行资源。")
+            return
+        }
+
+        val manifestOverride = BuildConfig.TERMINAL_RUNTIME_MANIFEST_URL.trim()
+        val entry = if (manifestOverride.isBlank()) {
+            emit(onProgress, "manifest", distribution, "正在准备 Ubuntu 官方下载")
+            officialUbuntuRuntime()
+        } else {
+            emit(onProgress, "manifest", distribution, "正在获取 Ubuntu 下载信息")
+            fetchManifestEntry(
+                requireHttpsUrl(manifestOverride, "终端运行时清单"),
+                distribution.id
+            )
+        }
+        ensureDiskSpace(context, entry, File(context.filesDir, "${archive.name}.part"))
+        downloadVerifiedArchive(context, distribution, entry, archive, onProgress)
+    }
+
+    @VisibleForTesting
+    internal fun officialUbuntuRuntime(): RuntimeManifestEntry = RuntimeManifestEntry(
+        id = TerminalDistribution.ubuntu.id,
+        version = OFFICIAL_UBUNTU_VERSION,
+        abi = "arm64-v8a",
+        fileName = OFFICIAL_UBUNTU_FILE_NAME,
+        compressedSize = OFFICIAL_UBUNTU_COMPRESSED_SIZE,
+        expandedSize = OFFICIAL_UBUNTU_EXPANDED_SIZE,
+        sha256 = LEGACY_UBUNTU_SHA256,
+        downloadUrl = requireHttpsUrl(OFFICIAL_UBUNTU_URL, "Ubuntu 官方下载地址")
+    )
+
+    private fun installCommonAssets(context: Context): MutableMap<String, File> {
+        val installed = mutableMapOf<String, File>()
+        commonAssets.forEach { spec ->
+            val target = File(context.filesDir, spec.outputName)
+            copyAssetIfChanged(context, spec.assetCandidates, target, spec.executable)
+            installed[spec.outputName] = target
+        }
+        return installed
+    }
+
+    private fun installCommonHelpers(installedFiles: Map<String, File>) {
+        localDir().mkdirs()
+        localBinDir().mkdirs()
+        localLibDir().mkdirs()
+        installedFiles["proot"]?.let {
+            copyFileIfChanged(it, File(localBinDir(), "proot"), executable = true)
+        }
+        installedFiles["libtalloc.so.2"]?.let {
+            copyFileIfChanged(it, File(localLibDir(), "libtalloc.so.2"), executable = false)
+        }
+        writeTextIfChanged(File(localDir(), "stat"), stat)
+        writeTextIfChanged(File(localDir(), "vmstat"), vmstat)
+    }
+
+    private fun isRootfsInstalled(context: Context, distribution: TerminalDistribution.Spec): Boolean {
+        val parent = context.filesDir.parentFile ?: return false
+        val rootfs = File(File(parent, "local"), distribution.rootfsDirectoryName)
+        return rootfs.isDirectory && rootfs.listFiles().orEmpty().any { it.name != "root" && it.name != "tmp" }
+    }
+
+    private fun isTrustedExistingUbuntuArchive(context: Context, archive: File): Boolean {
+        if (!archive.isFile || archive.length() <= 0L) return false
+        val digest = sha256OrNull(archive) ?: return false
+        val savedDigest = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString("ubuntu_sha256", null)
+        return digest.equals(savedDigest, ignoreCase = true) ||
+            digest.equals(LEGACY_UBUNTU_SHA256, ignoreCase = true)
+    }
+
+    private fun fetchManifestEntry(manifestUrl: HttpUrl, distributionId: String): RuntimeManifestEntry {
+        val request = Request.Builder()
+            .url(manifestUrl)
+            .header("Accept", "application/json")
+            .header("User-Agent", "OpenOmniBot-TerminalRuntime")
+            .get()
+            .build()
+        executeHttps(request).use { response ->
+            if (!response.isSuccessful) throw IOException("获取终端运行时清单失败（HTTP ${response.code}）。")
+            val body = response.body ?: throw IOException("终端运行时清单为空。")
+            val declaredSize = body.contentLength()
+            if (declaredSize > MAX_MANIFEST_BYTES) throw IOException("终端运行时清单过大。")
+            val bytes = body.bytes()
+            if (bytes.size > MAX_MANIFEST_BYTES) throw IOException("终端运行时清单过大。")
+            return parseManifest(String(bytes, Charsets.UTF_8), distributionId)
+        }
+    }
+
+    @VisibleForTesting
+    internal fun parseManifest(rawJson: String, distributionId: String): RuntimeManifestEntry {
+        val payload = JSONObject(rawJson)
+        if (payload.optInt("schemaVersion", -1) != 1) throw IOException("不支持的终端运行时清单版本。")
+        val runtimes = payload.optJSONArray("runtimes") ?: throw IOException("终端运行时清单缺少 runtimes。")
+        var match: JSONObject? = null
+        for (index in 0 until runtimes.length()) {
+            val item = runtimes.optJSONObject(index) ?: continue
+            if (item.optString("id") == distributionId && item.optString("abi") == "arm64-v8a") {
+                match = item
+                break
+            }
+        }
+        val item = match ?: throw IOException("清单中没有适用于 arm64-v8a 的 $distributionId 运行时。")
+        val id = item.optString("id").trim()
+        val version = item.optString("version").trim()
+        val abi = item.optString("abi").trim()
+        val fileName = item.optString("fileName").trim()
+        val compressedSize = item.optLong("compressedSize", -1L)
+        val expandedSize = item.optLong("expandedSize", -1L)
+        val digest = item.optString("sha256").trim().lowercase()
+        val downloadUrl = requireHttpsUrl(item.optString("downloadUrl"), "终端运行时下载地址")
+        if (id != TerminalDistribution.ubuntu.id || abi != "arm64-v8a") throw IOException("终端运行时标识无效。")
+        if (version.isBlank() || !fileName.matches(Regex("^[A-Za-z0-9._-]+\\.tar\\.gz$"))) {
+            throw IOException("终端运行时文件信息无效。")
+        }
+        if (compressedSize !in MIN_RUNTIME_BYTES..MAX_RUNTIME_BYTES || expandedSize < compressedSize) {
+            throw IOException("终端运行时大小信息无效。")
+        }
+        if (!digest.matches(Regex("^[a-f0-9]{64}$"))) throw IOException("终端运行时 SHA-256 无效。")
+        return RuntimeManifestEntry(id, version, abi, fileName, compressedSize, expandedSize, digest, downloadUrl)
+    }
+
+    private suspend fun downloadVerifiedArchive(
+        context: Context,
+        distribution: TerminalDistribution.Spec,
+        entry: RuntimeManifestEntry,
+        archive: File,
+        onProgress: suspend (RuntimeInstallProgress) -> Unit
+    ) {
+        val partial = File(context.filesDir, "${archive.name}.part")
+        if (partial.length() > entry.compressedSize) partial.delete()
+        repeat(2) { attempt ->
+            downloadAttempt(distribution, entry, partial, onProgress)
+            if (partial.length() == entry.compressedSize && sha256OrNull(partial) == entry.sha256) {
+                replaceWithFile(archive, partial)
+                context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit()
+                    .putString("${distribution.id}_version", entry.version)
+                    .putString("${distribution.id}_sha256", entry.sha256)
+                    .putLong("${distribution.id}_expanded_size", entry.expandedSize)
+                    .apply()
+                return
+            }
+            partial.delete()
+            if (attempt == 0) {
+                emit(onProgress, "verifying", distribution, "Ubuntu 校验失败，正在重新完整下载")
+            }
+        }
+        throw IOException("Ubuntu 运行资源校验失败，请检查网络后重试。")
+    }
+
+    private suspend fun downloadAttempt(
+        distribution: TerminalDistribution.Spec,
+        entry: RuntimeManifestEntry,
+        partial: File,
+        onProgress: suspend (RuntimeInstallProgress) -> Unit
+    ) {
+        partial.parentFile?.mkdirs()
+        var existing = partial.takeIf { it.isFile }?.length() ?: 0L
+        val builder = Request.Builder()
+            .url(entry.downloadUrl)
+            .header("Accept", "application/octet-stream")
+            .header("User-Agent", "OpenOmniBot-TerminalRuntime")
+            .get()
+        if (existing > 0L) builder.header("Range", "bytes=$existing-")
+        executeHttps(builder.build()).use { response ->
+            if (response.code == 416 && existing > 0L) {
+                partial.delete()
+                return downloadAttempt(distribution, entry, partial, onProgress)
+            }
+            if (!response.isSuccessful) throw IOException("下载 Ubuntu 运行资源失败（HTTP ${response.code}）。")
+            val append = existing > 0L && response.code == 206 &&
+                response.header("Content-Range")?.startsWith("bytes $existing-") == true
+            if (existing > 0L && !append) {
+                existing = 0L
+                partial.delete()
+            }
+            val body = response.body ?: throw IOException("Ubuntu 下载响应为空。")
+            var downloaded = existing
+            emitDownload(onProgress, distribution, downloaded, entry.compressedSize)
+            java.io.FileOutputStream(partial, append).use { output ->
+                body.byteStream().use { input ->
+                    val buffer = ByteArray(64 * 1024)
+                    while (true) {
+                        coroutineContext.ensureActive()
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        downloaded += read
+                        if (downloaded > entry.compressedSize) throw IOException("Ubuntu 下载内容超过清单声明大小。")
+                        output.write(buffer, 0, read)
+                        emitDownload(onProgress, distribution, downloaded, entry.compressedSize)
+                    }
+                    output.fd.sync()
+                }
+            }
+        }
+    }
+
+    private fun ensureDiskSpace(context: Context, entry: RuntimeManifestEntry, partial: File) {
+        val remainingDownload = (entry.compressedSize - partial.length()).coerceAtLeast(0L)
+        val required = remainingDownload + entry.expandedSize + DISK_SAFETY_BYTES
+        ensureAvailableSpace(context, required)
+    }
+
+    private fun ensureAvailableSpace(context: Context, required: Long) {
+        val available = StatFs(context.filesDir.absolutePath).availableBytes
+        if (available < required) {
+            throw IOException("存储空间不足：Ubuntu 初始化至少还需要 ${formatMiB(required)}，当前可用 ${formatMiB(available)}。")
+        }
+    }
+
+    private fun executeHttps(initialRequest: Request): Response {
+        var request = initialRequest
+        repeat(MAX_REDIRECTS + 1) { redirectCount ->
+            if (request.url.scheme != "https") throw IOException("终端运行时仅允许通过 HTTPS 下载。")
+            val response = client.newCall(request).execute()
+            if (response.code !in 300..399) return response
+            val location = response.header("Location")
+            response.close()
+            if (redirectCount >= MAX_REDIRECTS || location.isNullOrBlank()) throw IOException("终端运行时下载重定向无效。")
+            val next = request.url.resolve(location) ?: throw IOException("终端运行时下载重定向无效。")
+            if (next.scheme != "https") throw IOException("终端运行时下载拒绝非 HTTPS 重定向。")
+            request = request.newBuilder().url(next).build()
+        }
+        throw IOException("终端运行时下载重定向过多。")
+    }
+
+    private fun requireHttpsUrl(raw: String, label: String): HttpUrl {
+        val url = raw.trim().toHttpUrlOrNull() ?: throw IOException("$label 未配置或格式无效。")
+        if (url.scheme != "https" || url.host.isBlank()) throw IOException("$label 必须使用 HTTPS。")
+        return url
     }
 
     private fun copyAssetIfChanged(
         context: Context,
-        assetPath: String,
+        candidates: List<String>,
         target: File,
         executable: Boolean
     ): Boolean {
-        val assetDigest = context.assets.open(assetPath).use { input ->
-            sha256(input)
-        }
-        val targetDigest = sha256OrNull(target)
-        val changed = targetDigest != assetDigest
-        if (changed) {
-            replaceFile(target, executable) { temp ->
-                context.assets.open(assetPath).use { input ->
-                    temp.outputStream().use { output ->
-                        input.copyTo(output)
-                    }
-                }
-            }
+        val assetName = candidates.firstOrNull { name ->
+            runCatching { context.assets.open("$ASSET_ROOT/$name").close() }.isSuccess
+        } ?: error("缺少内置终端运行资源：${candidates.first()}。")
+        val assetPath = "$ASSET_ROOT/$assetName"
+        val assetDigest = context.assets.open(assetPath).use(::sha256)
+        val changed = sha256OrNull(target) != assetDigest
+        if (changed) replaceFile(target, executable) { temp ->
+            context.assets.open(assetPath).use { input -> temp.outputStream().use(input::copyTo) }
         }
         applyPermissions(target, executable)
         return changed
     }
 
-    private fun copyFileIfChanged(
-        source: File,
-        target: File,
-        executable: Boolean
-    ): Boolean {
-        val sourceDigest = sha256OrNull(source)
-            ?: error("Missing embedded terminal runtime file: ${source.absolutePath}")
-        val targetDigest = sha256OrNull(target)
-        val changed = targetDigest != sourceDigest
-        if (changed) {
-            replaceFile(target, executable) { temp ->
-                source.inputStream().use { input ->
-                    temp.outputStream().use { output ->
-                        input.copyTo(output)
-                    }
-                }
-            }
-        }
+    private fun copyFileIfChanged(source: File, target: File, executable: Boolean): Boolean {
+        val digest = sha256OrNull(source) ?: error("Missing runtime file: ${source.absolutePath}")
+        val changed = sha256OrNull(target) != digest
+        if (changed) replaceFile(target, executable) { temp -> source.copyTo(temp, overwrite = true) }
         applyPermissions(target, executable)
         return changed
     }
 
-    private fun writeTextIfChanged(target: File, content: String): Boolean {
-        target.parentFile?.mkdirs()
-        val changed = !target.exists() || target.readText() != content
-        if (changed) {
-            replaceFile(target, executable = false) { temp ->
-                temp.writeText(content)
-            }
+    private fun writeTextIfChanged(target: File, content: String) {
+        if (!target.exists() || target.readText() != content) {
+            replaceFile(target, executable = false) { it.writeText(content) }
         }
-        applyPermissions(target, executable = false)
-        return changed
     }
 
-    private fun replaceFile(
-        target: File,
-        executable: Boolean,
-        writer: (File) -> Unit
-    ) {
+    private fun replaceFile(target: File, executable: Boolean, writer: (File) -> Unit) {
         target.parentFile?.mkdirs()
-        val parent = target.parentFile ?: error("Missing parent directory for ${target.absolutePath}")
-        val temp = File.createTempFile("${target.name}.", ".tmp", parent)
+        val temp = File.createTempFile("${target.name}.", ".tmp", target.parentFile)
         try {
             writer(temp)
             applyPermissions(temp, executable)
-            if (target.exists() && !target.delete()) {
-                error("Failed to replace ${target.absolutePath}")
-            }
-            if (!temp.renameTo(target)) {
-                error("Failed to move refreshed runtime file to ${target.absolutePath}")
-            }
+            if (target.exists() && !target.delete()) error("Failed to replace ${target.absolutePath}")
+            if (!temp.renameTo(target)) error("Failed to move ${target.absolutePath}")
         } finally {
-            if (temp.exists()) {
-                temp.delete()
-            }
+            if (temp.exists()) temp.delete()
         }
-        applyPermissions(target, executable)
+    }
+
+    private fun replaceWithFile(target: File, source: File) {
+        try {
+            Files.move(
+                source.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
     }
 
     private fun applyPermissions(file: File, executable: Boolean) {
-        if (!file.exists()) {
-            return
-        }
+        if (!file.exists()) return
         file.setReadable(true, false)
         file.setWritable(true, true)
-        if (executable) {
-            file.setExecutable(true, false)
-        }
+        if (executable) file.setExecutable(true, false)
     }
 
+    private suspend fun emit(
+        callback: suspend (RuntimeInstallProgress) -> Unit,
+        phase: String,
+        distribution: TerminalDistribution.Spec,
+        message: String,
+        progress: Double? = null,
+        error: String? = null
+    ) = callback(RuntimeInstallProgress(phase, distribution.id, message, progress = progress, error = error))
+
+    private suspend fun emitDownload(
+        callback: suspend (RuntimeInstallProgress) -> Unit,
+        distribution: TerminalDistribution.Spec,
+        downloaded: Long,
+        total: Long
+    ) = callback(
+        RuntimeInstallProgress(
+            phase = "downloading",
+            distribution = distribution.id,
+            message = "正在下载 Ubuntu 运行资源 ${formatMiB(downloaded)} / ${formatMiB(total)}",
+            downloadedBytes = downloaded,
+            totalBytes = total,
+            progress = if (total > 0L) downloaded.toDouble() / total else null
+        )
+    )
+
     private fun sha256OrNull(file: File): String? {
-        if (!file.exists() || file.length() == 0L || !file.isFile) {
-            return null
-        }
-        return file.inputStream().use { input ->
-            sha256(input)
-        }
+        if (!file.isFile || file.length() <= 0L) return null
+        return file.inputStream().use(::sha256)
     }
 
     private fun sha256(input: InputStream): String {
         val digest = MessageDigest.getInstance("SHA-256")
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         while (true) {
-            val readBytes = input.read(buffer)
-            if (readBytes < 0) {
-                break
-            }
-            digest.update(buffer, 0, readBytes)
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
         }
         return BigInteger(1, digest.digest()).toString(16).padStart(64, '0')
     }
+
+    private fun formatMiB(bytes: Long): String = "%.1f MB".format(bytes / 1024.0 / 1024.0)
 }

--- a/ReTerminal/core/main/src/main/java/com/rk/terminal/runtime/EmbeddedRuntimeInstaller.kt
+++ b/ReTerminal/core/main/src/main/java/com/rk/terminal/runtime/EmbeddedRuntimeInstaller.kt
@@ -2,6 +2,8 @@ package com.rk.terminal.runtime
 
 import android.content.Context
 import android.os.StatFs
+import android.system.ErrnoException
+import android.system.Os
 import androidx.annotation.VisibleForTesting
 import com.rk.libcommons.localBinDir
 import com.rk.libcommons.localDir
@@ -11,26 +13,29 @@ import com.rk.terminal.ui.screens.terminal.stat
 import com.rk.terminal.ui.screens.terminal.vmstat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.coroutineContext
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONObject
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.math.BigInteger
 import java.security.MessageDigest
-import java.nio.file.AtomicMoveNotSupportedException
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.coroutineContext
 
 object EmbeddedRuntimeInstaller {
     data class RuntimeInstallProgress(
@@ -98,10 +103,10 @@ object EmbeddedRuntimeInstaller {
 
     suspend fun ensureRuntimeInstalled(
         context: Context,
+        distribution: TerminalDistribution.Spec = TerminalDistribution.selected(),
         onProgress: suspend (RuntimeInstallProgress) -> Unit = {}
     ): InstallStatus = withContext(Dispatchers.IO) {
         installMutex.withLock {
-            val distribution = TerminalDistribution.selected()
             try {
                 emit(onProgress, "checking", distribution, "正在校验终端环境运行资源")
                 val installedFiles = installCommonAssets(context)
@@ -226,22 +231,46 @@ object EmbeddedRuntimeInstaller {
             digest.equals(LEGACY_UBUNTU_SHA256, ignoreCase = true)
     }
 
-    private fun fetchManifestEntry(manifestUrl: HttpUrl, distributionId: String): RuntimeManifestEntry {
+    private suspend fun fetchManifestEntry(
+        manifestUrl: HttpUrl,
+        distributionId: String
+    ): RuntimeManifestEntry {
         val request = Request.Builder()
             .url(manifestUrl)
             .header("Accept", "application/json")
             .header("User-Agent", "OpenOmniBot-TerminalRuntime")
             .get()
             .build()
-        executeHttps(request).use { response ->
+        return executeHttps(request) { response ->
             if (!response.isSuccessful) throw IOException("获取终端运行时清单失败（HTTP ${response.code}）。")
             val body = response.body ?: throw IOException("终端运行时清单为空。")
-            val declaredSize = body.contentLength()
-            if (declaredSize > MAX_MANIFEST_BYTES) throw IOException("终端运行时清单过大。")
-            val bytes = body.bytes()
-            if (bytes.size > MAX_MANIFEST_BYTES) throw IOException("终端运行时清单过大。")
-            return parseManifest(String(bytes, Charsets.UTF_8), distributionId)
+            val bytes = readBoundedManifest(body.byteStream(), body.contentLength())
+            parseManifest(String(bytes, Charsets.UTF_8), distributionId)
         }
+    }
+
+    @VisibleForTesting
+    internal suspend fun readBoundedManifest(
+        input: InputStream,
+        declaredSize: Long = -1L
+    ): ByteArray {
+        if (declaredSize > MAX_MANIFEST_BYTES) throw IOException("终端运行时清单过大。")
+        val initialCapacity = declaredSize
+            .takeIf { it in 1..MAX_MANIFEST_BYTES }
+            ?.toInt()
+            ?: DEFAULT_BUFFER_SIZE
+        val output = ByteArrayOutputStream(initialCapacity)
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            coroutineContext.ensureActive()
+            val read = input.read(buffer)
+            if (read < 0) break
+            total += read
+            if (total > MAX_MANIFEST_BYTES) throw IOException("终端运行时清单过大。")
+            output.write(buffer, 0, read)
+        }
+        return output.toByteArray()
     }
 
     @VisibleForTesting
@@ -319,10 +348,10 @@ object EmbeddedRuntimeInstaller {
             .header("User-Agent", "OpenOmniBot-TerminalRuntime")
             .get()
         if (existing > 0L) builder.header("Range", "bytes=$existing-")
-        executeHttps(builder.build()).use { response ->
+        executeHttps(builder.build()) { response ->
             if (response.code == 416 && existing > 0L) {
                 partial.delete()
-                return downloadAttempt(distribution, entry, partial, onProgress)
+                return@executeHttps downloadAttempt(distribution, entry, partial, onProgress)
             }
             if (!response.isSuccessful) throw IOException("下载 Ubuntu 运行资源失败（HTTP ${response.code}）。")
             val append = existing > 0L && response.code == 206 &&
@@ -365,20 +394,73 @@ object EmbeddedRuntimeInstaller {
         }
     }
 
-    private fun executeHttps(initialRequest: Request): Response {
+    private sealed interface HttpsCallResult<out T> {
+        data class Complete<T>(val value: T) : HttpsCallResult<T>
+        data class Redirect(val request: Request) : HttpsCallResult<Nothing>
+    }
+
+    private suspend fun <T> executeHttps(
+        initialRequest: Request,
+        consume: suspend (Response) -> T
+    ): T {
         var request = initialRequest
         repeat(MAX_REDIRECTS + 1) { redirectCount ->
             if (request.url.scheme != "https") throw IOException("终端运行时仅允许通过 HTTPS 下载。")
-            val response = client.newCall(request).execute()
-            if (response.code !in 300..399) return response
-            val location = response.header("Location")
-            response.close()
-            if (redirectCount >= MAX_REDIRECTS || location.isNullOrBlank()) throw IOException("终端运行时下载重定向无效。")
-            val next = request.url.resolve(location) ?: throw IOException("终端运行时下载重定向无效。")
-            if (next.scheme != "https") throw IOException("终端运行时下载拒绝非 HTTPS 重定向。")
-            request = request.newBuilder().url(next).build()
+            when (
+                val result = executeCancellableCall(client.newCall(request)) { response ->
+                    if (response.code !in 300..399) {
+                        HttpsCallResult.Complete(consume(response))
+                    } else {
+                        val location = response.header("Location")
+                        if (redirectCount >= MAX_REDIRECTS || location.isNullOrBlank()) {
+                            throw IOException("终端运行时下载重定向无效。")
+                        }
+                        val next = request.url.resolve(location)
+                            ?: throw IOException("终端运行时下载重定向无效。")
+                        if (next.scheme != "https") {
+                            throw IOException("终端运行时下载拒绝非 HTTPS 重定向。")
+                        }
+                        HttpsCallResult.Redirect(request.newBuilder().url(next).build())
+                    }
+                }
+            ) {
+                is HttpsCallResult.Complete -> return result.value
+                is HttpsCallResult.Redirect -> request = result.request
+            }
         }
         throw IOException("终端运行时下载重定向过多。")
+    }
+
+    @VisibleForTesting
+    internal suspend fun <T> executeCancellableCall(
+        call: Call,
+        consume: suspend (Response) -> T
+    ): T = coroutineScope {
+        val cancellationWatcher = launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                awaitCancellation()
+            } finally {
+                call.cancel()
+            }
+        }
+        try {
+            val response = try {
+                call.execute()
+            } catch (error: IOException) {
+                coroutineContext.ensureActive()
+                throw error
+            }
+            try {
+                consume(response)
+            } catch (error: IOException) {
+                coroutineContext.ensureActive()
+                throw error
+            } finally {
+                response.close()
+            }
+        } finally {
+            cancellationWatcher.cancel()
+        }
     }
 
     private fun requireHttpsUrl(raw: String, label: String): HttpUrl {
@@ -435,14 +517,9 @@ object EmbeddedRuntimeInstaller {
 
     private fun replaceWithFile(target: File, source: File) {
         try {
-            Files.move(
-                source.toPath(),
-                target.toPath(),
-                StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING
-            )
-        } catch (_: AtomicMoveNotSupportedException) {
-            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            Os.rename(source.absolutePath, target.absolutePath)
+        } catch (error: ErrnoException) {
+            throw IOException("无法替换已校验的终端运行资源。", error)
         }
     }
 

--- a/ReTerminal/core/main/src/main/java/com/rk/terminal/ui/screens/downloader/Downloader.kt
+++ b/ReTerminal/core/main/src/main/java/com/rk/terminal/ui/screens/downloader/Downloader.kt
@@ -41,7 +41,8 @@ fun Downloader(
         try {
             needsDownload = !Rootfs.isFilesDownloaded()
             val status = EmbeddedRuntimeInstaller.ensureRuntimeInstalled(context) { step ->
-                progressText = step
+                progressText = step.message
+                progress = step.progress?.toFloat()?.coerceIn(0f, 1f) ?: progress
             }
             if (!status.success) {
                 toast(setupFailedStr.format(status.message))

--- a/ReTerminal/core/main/src/main/java/com/rk/terminal/ui/screens/terminal/Rootfs.kt
+++ b/ReTerminal/core/main/src/main/java/com/rk/terminal/ui/screens/terminal/Rootfs.kt
@@ -1,11 +1,8 @@
 package com.rk.terminal.ui.screens.terminal
 
-import android.os.Environment
 import androidx.compose.runtime.mutableStateOf
 import com.rk.libcommons.application
-import com.rk.libcommons.child
-import com.rk.terminal.App
-import java.io.File
+import com.rk.terminal.runtime.EmbeddedRuntimeInstaller
 
 object Rootfs {
     val reTerminal = application!!.filesDir
@@ -18,10 +15,6 @@ object Rootfs {
 
     var isDownloaded = mutableStateOf(isFilesDownloaded())
     fun isFilesDownloaded(): Boolean{
-        return reTerminal.exists() &&
-            reTerminal.child("proot").exists() &&
-            reTerminal.child("libtalloc.so.2").exists() &&
-            reTerminal.child("alpine.tar.gz").exists() &&
-            reTerminal.child("ubuntu.tar.gz").exists()
+        return application?.let(EmbeddedRuntimeInstaller::isCurrentDistributionReady) == true
     }
 }

--- a/ReTerminal/core/main/src/test/java/com/rk/terminal/runtime/EmbeddedRuntimeInstallerTest.kt
+++ b/ReTerminal/core/main/src/test/java/com/rk/terminal/runtime/EmbeddedRuntimeInstallerTest.kt
@@ -1,9 +1,22 @@
 package com.rk.terminal.runtime
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertThrows
 import org.junit.Test
+import java.io.ByteArrayInputStream
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 class EmbeddedRuntimeInstallerTest {
     @Test
@@ -86,6 +99,61 @@ class EmbeddedRuntimeInstallerTest {
         }
         assertThrows(IOException::class.java) {
             EmbeddedRuntimeInstaller.parseManifest(manifest(sha256 = "not-a-sha"), "ubuntu")
+        }
+    }
+
+    @Test
+    fun readsManifestWithinOneMiBLimit() = runBlocking {
+        val payload = "{\"schemaVersion\":1,\"runtimes\":[]}".toByteArray()
+
+        val actual = EmbeddedRuntimeInstaller.readBoundedManifest(
+            input = ByteArrayInputStream(payload),
+            declaredSize = -1L
+        )
+
+        assertTrue(payload.contentEquals(actual))
+    }
+
+    @Test
+    fun rejectsChunkedManifestAsSoonAsItExceedsOneMiB() {
+        val oversized = ByteArray(1024 * 1024 + 1)
+
+        assertThrows(IOException::class.java) {
+            runBlocking {
+                EmbeddedRuntimeInstaller.readBoundedManifest(
+                    input = ByteArrayInputStream(oversized),
+                    declaredSize = -1L
+                )
+            }
+        }
+    }
+
+    @Test
+    fun cancellationInterruptsStalledHttpCall() = runBlocking {
+        val server = MockWebServer()
+        server.enqueue(
+            MockResponse()
+                .setSocketPolicy(SocketPolicy.NO_RESPONSE)
+        )
+        server.start()
+        try {
+            val call = OkHttpClient.Builder()
+                .readTimeout(60, TimeUnit.SECONDS)
+                .build()
+                .newCall(Request.Builder().url(server.url("/ubuntu.tar.gz")).build())
+            val download = async(Dispatchers.IO) {
+                EmbeddedRuntimeInstaller.executeCancellableCall(call) { response ->
+                    response.body!!.byteStream().read()
+                }
+            }
+
+            assertTrue(server.takeRequest(2, TimeUnit.SECONDS) != null)
+            download.cancel()
+            withTimeout(2_000L) { download.cancelAndJoin() }
+
+            assertTrue(call.isCanceled())
+        } finally {
+            server.shutdown()
         }
     }
 }

--- a/ReTerminal/core/main/src/test/java/com/rk/terminal/runtime/EmbeddedRuntimeInstallerTest.kt
+++ b/ReTerminal/core/main/src/test/java/com/rk/terminal/runtime/EmbeddedRuntimeInstallerTest.kt
@@ -1,0 +1,91 @@
+package com.rk.terminal.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.io.IOException
+
+class EmbeddedRuntimeInstallerTest {
+    @Test
+    fun usesPinnedOfficialUbuntuRuntimeByDefault() {
+        val entry = EmbeddedRuntimeInstaller.officialUbuntuRuntime()
+
+        assertEquals("ubuntu", entry.id)
+        assertEquals("24.04.4", entry.version)
+        assertEquals(29_870_567L, entry.compressedSize)
+        assertEquals(106_649_600L, entry.expandedSize)
+        assertEquals(
+            "04207713ece899c3740823d33690441ad3a7f0ded1101aca744e2b0f37ac7ff2",
+            entry.sha256
+        )
+        assertEquals("cdimage.ubuntu.com", entry.downloadUrl.host)
+        assertEquals("https", entry.downloadUrl.scheme)
+    }
+
+    private fun manifest(
+        id: String = "ubuntu",
+        abi: String = "arm64-v8a",
+        url: String = "https://updates.example/terminal-runtimes/downloads/ubuntu/24.04.4/ubuntu.tar.gz",
+        compressedSize: Long = 2_000_000,
+        expandedSize: Long = 8_000_000,
+        sha256: String = "a".repeat(64)
+    ): String = """
+        {
+          "schemaVersion": 1,
+          "runtimes": [{
+            "id": "$id",
+            "version": "24.04.4",
+            "abi": "$abi",
+            "fileName": "ubuntu-base-24.04.4-base-arm64.tar.gz",
+            "compressedSize": $compressedSize,
+            "expandedSize": $expandedSize,
+            "sha256": "$sha256",
+            "downloadUrl": "$url"
+          }]
+        }
+    """.trimIndent()
+
+    @Test
+    fun parsesPinnedArm64HttpsRuntime() {
+        val entry = EmbeddedRuntimeInstaller.parseManifest(manifest(), "ubuntu")
+
+        assertEquals("ubuntu", entry.id)
+        assertEquals("24.04.4", entry.version)
+        assertEquals("arm64-v8a", entry.abi)
+        assertEquals(2_000_000, entry.compressedSize)
+        assertEquals("https", entry.downloadUrl.scheme)
+    }
+
+    @Test
+    fun rejectsNonHttpsDownload() {
+        assertThrows(IOException::class.java) {
+            EmbeddedRuntimeInstaller.parseManifest(
+                manifest(url = "http://updates.example/ubuntu.tar.gz"),
+                "ubuntu"
+            )
+        }
+    }
+
+    @Test
+    fun rejectsUnknownAbiAndDistribution() {
+        assertThrows(IOException::class.java) {
+            EmbeddedRuntimeInstaller.parseManifest(manifest(abi = "armeabi-v7a"), "ubuntu")
+        }
+        assertThrows(IOException::class.java) {
+            EmbeddedRuntimeInstaller.parseManifest(manifest(id = "debian"), "debian")
+        }
+    }
+
+    @Test
+    fun rejectsInvalidSizesAndDigest() {
+        assertThrows(IOException::class.java) {
+            EmbeddedRuntimeInstaller.parseManifest(
+                manifest(compressedSize = 8_000_000, expandedSize = 2_000_000),
+                "ubuntu"
+            )
+        }
+        assertThrows(IOException::class.java) {
+            EmbeddedRuntimeInstaller.parseManifest(manifest(sha256 = "not-a-sha"), "ubuntu")
+        }
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
@@ -530,6 +530,50 @@ class SpecialPermissionManager(private val context: Context) {
         }
     }
 
+    fun switchEmbeddedTerminalDistribution(call: MethodCall, result: MethodChannel.Result) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val rawId = call.argument<String>("distribution")?.trim()?.lowercase()
+                val distribution = TerminalDistribution.supported.firstOrNull { it.id == rawId }
+                    ?: throw IllegalArgumentException("Unsupported terminal distribution: $rawId")
+                val current = TerminalDistribution.selected()
+                if (current.id == distribution.id) {
+                    withContext(Dispatchers.Main) { result.success(distribution.id) }
+                    return@launch
+                }
+
+                val preparation = EmbeddedTerminalInitCoordinator.prepareDistribution(
+                    context = context,
+                    distribution = distribution
+                )
+                if (!preparation.success) {
+                    withContext(Dispatchers.Main) {
+                        result.error(
+                            "SWITCH_TERMINAL_DISTRIBUTION_FAILED",
+                            preparation.message,
+                            null
+                        )
+                    }
+                    return@launch
+                }
+
+                TerminalManager.getInstance(context).closeAllSessions()
+                com.rk.settings.Settings.terminal_distribution = distribution.workingMode
+                com.rk.settings.Settings.working_Mode = distribution.workingMode
+                withContext(Dispatchers.Main) { result.success(distribution.id) }
+            } catch (e: Exception) {
+                OmniLog.e(TAG, "Error switching terminal distribution", e)
+                withContext(Dispatchers.Main) {
+                    result.error(
+                        "SWITCH_TERMINAL_DISTRIBUTION_FAILED",
+                        e.message ?: "Failed to switch terminal distribution.",
+                        e.message
+                    )
+                }
+            }
+        }
+    }
+
     fun installEmbeddedTerminalPackages(call: MethodCall, result: MethodChannel.Result) {
         CoroutineScope(Dispatchers.IO).launch {
             try {

--- a/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/SpecialPermissionManager.kt
@@ -810,6 +810,10 @@ class SpecialPermissionManager(private val context: Context) {
         }
     }
 
+    fun cancelEmbeddedTerminalInit(result: MethodChannel.Result) {
+        result.success(EmbeddedTerminalInitCoordinator.cancelCurrent())
+    }
+
     fun isUnknownAppInstallAllowed(result: MethodChannel.Result) {
         try {
             result.success(ExternalApkInstaller.canInstallPackages(context))

--- a/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalInitCoordinator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalInitCoordinator.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.termux.TermuxCommandRunner
 import cn.com.omnimind.bot.termux.TermuxLiveEnvironmentResult
+import com.ai.assistance.operit.terminal.TerminalManager
+import com.rk.terminal.runtime.TerminalDistribution
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -147,6 +149,32 @@ object EmbeddedTerminalInitCoordinator {
         }
     }
 
+    suspend fun prepareDistribution(
+        context: Context,
+        distribution: TerminalDistribution.Spec
+    ): TermuxLiveEnvironmentResult {
+        val appContext = context.applicationContext
+        val deferred = synchronized(stateLock) {
+            if (activeRun?.isCompleted == false) {
+                return TermuxLiveEnvironmentResult(
+                    success = false,
+                    wrapperReady = false,
+                    sharedStorageReady = false,
+                    message = "另一个终端环境准备任务正在运行，请稍后再试。"
+                )
+            }
+            CompletableDeferred<TermuxLiveEnvironmentResult>().also {
+                activeRun = it
+                resetEmbeddedTerminalInitStateLocked()
+            }
+        }
+        val job = workerScope.launch {
+            runDistributionPreparation(appContext, distribution, deferred)
+        }
+        synchronized(stateLock) { activeJob = job }
+        return deferred.await()
+    }
+
     fun cancelCurrent(): Boolean {
         val job = synchronized(stateLock) { activeJob?.takeIf { it.isActive } }
         job?.cancel(CancellationException("用户取消终端环境准备"))
@@ -227,6 +255,133 @@ object EmbeddedTerminalInitCoordinator {
                 finalMessage = failureMessage
             )
             deferred.completeExceptionally(error)
+        } finally {
+            synchronized(stateLock) {
+                if (activeRun === deferred) {
+                    activeRun = null
+                    activeJob = null
+                }
+            }
+        }
+    }
+
+    private suspend fun runDistributionPreparation(
+        context: Context,
+        distribution: TerminalDistribution.Spec,
+        deferred: CompletableDeferred<TermuxLiveEnvironmentResult>
+    ) {
+        try {
+            emitEmbeddedTerminalInitProgress(
+                kind = "status",
+                message = "正在准备 ${distribution.displayName} 终端环境",
+                phase = "checking",
+                distribution = distribution.id
+            )
+            var runtimeFailureMessage: String? = null
+            val manager = TerminalManager.getInstance(context)
+            val initialized = manager.initializeEnvironment(distribution = distribution) { progress ->
+                progress.error?.takeIf { it.isNotBlank() }?.let { runtimeFailureMessage = it }
+                emitEmbeddedTerminalInitProgress(
+                    kind = if (progress.error == null) "status" else "error",
+                    message = progress.message,
+                    phase = progress.phase,
+                    distribution = progress.distribution,
+                    downloadedBytes = progress.downloadedBytes,
+                    totalBytes = progress.totalBytes,
+                    explicitProgress = progress.progress,
+                    error = progress.error
+                )
+            }
+            val status = if (!initialized) {
+                TermuxLiveEnvironmentResult(
+                    success = false,
+                    wrapperReady = false,
+                    sharedStorageReady = false,
+                    message = runtimeFailureMessage ?: "${distribution.displayName} 终端环境准备失败。"
+                )
+            } else {
+                emitEmbeddedTerminalInitProgress(
+                    kind = "status",
+                    message = "正在验证 ${distribution.displayName} 终端环境",
+                    phase = "verifying",
+                    distribution = distribution.id,
+                    explicitProgress = 0.98
+                )
+                val probe = manager.executeHiddenCommand(
+                    command = "true",
+                    executorKey = "distribution-switch-${distribution.id}",
+                    timeoutMs = 60_000L,
+                    distribution = distribution
+                )
+                if (probe.isOk && probe.exitCode == 0) {
+                    TermuxLiveEnvironmentResult(
+                        success = true,
+                        wrapperReady = true,
+                        sharedStorageReady = true,
+                        message = "${distribution.displayName} 终端环境已就绪。"
+                    )
+                } else {
+                    val details = probe.error.ifBlank {
+                        probe.output.trim().takeLast(800).ifBlank { "运行时验证未通过。" }
+                    }
+                    TermuxLiveEnvironmentResult(
+                        success = false,
+                        wrapperReady = false,
+                        sharedStorageReady = false,
+                        message = "${distribution.displayName} 终端环境验证失败：$details"
+                    )
+                }
+            }
+            emitEmbeddedTerminalInitProgress(
+                kind = if (status.success) "status" else "error",
+                message = status.message,
+                phase = if (status.success) "ready" else "error",
+                distribution = distribution.id,
+                explicitProgress = if (status.success) 1.0 else null,
+                error = status.message.takeUnless { status.success }
+            )
+            markEmbeddedTerminalInitCompleted(
+                success = status.success,
+                finalMessage = status.message
+            )
+            deferred.complete(status)
+        } catch (error: CancellationException) {
+            val message = "终端环境准备已取消，已保留下载进度。"
+            emitEmbeddedTerminalInitProgress(
+                kind = "error",
+                message = message,
+                phase = "cancelled",
+                distribution = distribution.id,
+                error = message
+            )
+            markEmbeddedTerminalInitCompleted(success = false, finalMessage = message)
+            deferred.complete(
+                TermuxLiveEnvironmentResult(
+                    success = false,
+                    wrapperReady = false,
+                    sharedStorageReady = false,
+                    message = message
+                )
+            )
+        } catch (error: Exception) {
+            OmniLog.e(TAG, "Failed to prepare ${distribution.id} terminal runtime", error)
+            val message = error.message ?: "${distribution.displayName} 终端环境准备失败。"
+            emitEmbeddedTerminalInitProgress(
+                kind = "error",
+                message = message,
+                phase = "error",
+                distribution = distribution.id,
+                error = message
+            )
+            markEmbeddedTerminalInitCompleted(success = false, finalMessage = message)
+            deferred.complete(
+                TermuxLiveEnvironmentResult(
+                    success = false,
+                    wrapperReady = false,
+                    sharedStorageReady = false,
+                    message = message
+                )
+            )
         } finally {
             synchronized(stateLock) {
                 if (activeRun === deferred) {

--- a/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalInitCoordinator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalInitCoordinator.kt
@@ -5,9 +5,11 @@ import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.termux.TermuxCommandRunner
 import cn.com.omnimind.bot.termux.TermuxLiveEnvironmentResult
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 object EmbeddedTerminalInitCoordinator {
@@ -41,7 +43,12 @@ object EmbeddedTerminalInitCoordinator {
         val startedAt: Long = 0L,
         val updatedAt: Long = 0L,
         val completedAt: Long? = null,
-        val seenBasePackages: Set<String> = emptySet()
+        val seenBasePackages: Set<String> = emptySet(),
+        val phase: String? = null,
+        val distribution: String? = null,
+        val downloadedBytes: Long = 0L,
+        val totalBytes: Long = 0L,
+        val error: String? = null
     )
 
     private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -52,6 +59,7 @@ object EmbeddedTerminalInitCoordinator {
 
     private var embeddedTerminalInitState = EmbeddedTerminalInitState()
     private var activeRun: CompletableDeferred<TermuxLiveEnvironmentResult>? = null
+    private var activeJob: Job? = null
 
     fun addListener(listener: (Map<String, Any?>) -> Unit) {
         synchronized(listenerLock) {
@@ -78,7 +86,12 @@ object EmbeddedTerminalInitCoordinator {
             "logLines" to snapshot.logLines,
             "startedAt" to snapshot.startedAt.takeIf { it > 0L },
             "updatedAt" to snapshot.updatedAt.takeIf { it > 0L },
-            "completedAt" to snapshot.completedAt
+            "completedAt" to snapshot.completedAt,
+            "phase" to snapshot.phase,
+            "distribution" to snapshot.distribution,
+            "downloadedBytes" to snapshot.downloadedBytes,
+            "totalBytes" to snapshot.totalBytes,
+            "error" to snapshot.error
         )
     }
 
@@ -94,9 +107,10 @@ object EmbeddedTerminalInitCoordinator {
             }
         }
         val appContext = context.applicationContext
-        workerScope.launch {
+        val job = workerScope.launch {
             runPreparation(appContext, deferred)
         }
+        synchronized(stateLock) { activeJob = job }
         return true
     }
 
@@ -120,7 +134,10 @@ object EmbeddedTerminalInitCoordinator {
             }
         }
         if (shouldStartNow) {
-            runPreparation(appContext, deferred, selectedPackageIds)
+            val job = workerScope.launch {
+                runPreparation(appContext, deferred, selectedPackageIds)
+            }
+            synchronized(stateLock) { activeJob = job }
         }
         val status = deferred.await()
         return if (!shouldStartNow && selectedPackageIds != null && status.success) {
@@ -128,6 +145,12 @@ object EmbeddedTerminalInitCoordinator {
         } else {
             status
         }
+    }
+
+    fun cancelCurrent(): Boolean {
+        val job = synchronized(stateLock) { activeJob?.takeIf { it.isActive } }
+        job?.cancel(CancellationException("用户取消终端环境准备"))
+        return job != null
     }
 
     private suspend fun runPreparation(
@@ -146,7 +169,13 @@ object EmbeddedTerminalInitCoordinator {
             ) { progress ->
                 emitEmbeddedTerminalInitProgress(
                     kind = progress.kind.name.lowercase(),
-                    message = progress.message
+                    message = progress.message,
+                    phase = progress.phase,
+                    distribution = progress.distribution,
+                    downloadedBytes = progress.downloadedBytes,
+                    totalBytes = progress.totalBytes,
+                    explicitProgress = progress.progress,
+                    error = progress.error
                 )
             }
             val status =
@@ -174,6 +203,18 @@ object EmbeddedTerminalInitCoordinator {
                 finalMessage = status.message
             )
             deferred.complete(status)
+        } catch (error: CancellationException) {
+            val message = "终端环境准备已取消，已保留下载进度。"
+            emitEmbeddedTerminalInitProgress(kind = "error", message = message, error = message)
+            markEmbeddedTerminalInitCompleted(success = false, finalMessage = message)
+            deferred.complete(
+                TermuxLiveEnvironmentResult(
+                    success = false,
+                    wrapperReady = false,
+                    sharedStorageReady = false,
+                    message = message
+                )
+            )
         } catch (error: Exception) {
             OmniLog.e(TAG, "Failed to prepare embedded terminal runtime", error)
             val failureMessage = error.message ?: "检查内嵌终端环境失败"
@@ -190,6 +231,7 @@ object EmbeddedTerminalInitCoordinator {
             synchronized(stateLock) {
                 if (activeRun === deferred) {
                     activeRun = null
+                    activeJob = null
                 }
             }
         }
@@ -197,16 +239,37 @@ object EmbeddedTerminalInitCoordinator {
 
     private fun emitEmbeddedTerminalInitProgress(
         kind: String,
-        message: String
+        message: String,
+        phase: String? = null,
+        distribution: String? = null,
+        downloadedBytes: Long = 0L,
+        totalBytes: Long = 0L,
+        explicitProgress: Double? = null,
+        error: String? = null
     ) {
         if (message.isBlank()) {
             return
         }
-        updateEmbeddedTerminalInitState(kind, message)
+        updateEmbeddedTerminalInitState(
+            kind,
+            message,
+            phase,
+            distribution,
+            downloadedBytes,
+            totalBytes,
+            explicitProgress,
+            error
+        )
         val payload = mapOf(
             "kind" to kind,
             "message" to message,
-            "timestamp" to System.currentTimeMillis()
+            "timestamp" to System.currentTimeMillis(),
+            "phase" to phase,
+            "distribution" to distribution,
+            "downloadedBytes" to downloadedBytes,
+            "totalBytes" to totalBytes,
+            "progress" to explicitProgress,
+            "error" to error
         )
         val currentListeners = synchronized(listenerLock) {
             listeners.toList()
@@ -239,7 +302,13 @@ object EmbeddedTerminalInitCoordinator {
 
     private fun updateEmbeddedTerminalInitState(
         kind: String,
-        message: String
+        message: String,
+        phase: String?,
+        distribution: String?,
+        downloadedBytes: Long,
+        totalBytes: Long,
+        explicitProgress: Double?,
+        error: String?
     ) {
         val normalizedMessage = message.trim()
         if (normalizedMessage.isBlank()) {
@@ -271,7 +340,10 @@ object EmbeddedTerminalInitCoordinator {
                     current.seenBasePackages
                 }
 
-            val derivedProgress = deriveEmbeddedTerminalInitProgress(
+            val derivedProgress = explicitProgress?.let { downloadProgress ->
+                // Runtime download occupies the preparation section before package setup.
+                0.14 + downloadProgress.coerceIn(0.0, 1.0) * 0.42
+            } ?: deriveEmbeddedTerminalInitProgress(
                 kind = kind,
                 message = normalizedMessage,
                 seenBasePackages = nextSeenBasePackages,
@@ -289,7 +361,12 @@ object EmbeddedTerminalInitCoordinator {
                     formatEmbeddedTerminalInitLogLines(kind, normalizedLines)
                 ),
                 updatedAt = now,
-                seenBasePackages = nextSeenBasePackages
+                seenBasePackages = nextSeenBasePackages,
+                phase = phase ?: current.phase,
+                distribution = distribution ?: current.distribution,
+                downloadedBytes = downloadedBytes,
+                totalBytes = totalBytes,
+                error = error ?: current.error
             )
         }
     }

--- a/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalRuntime.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/terminal/EmbeddedTerminalRuntime.kt
@@ -26,7 +26,13 @@ import java.util.concurrent.ConcurrentHashMap
 object EmbeddedTerminalRuntime {
     data class EnvironmentProgress(
         val kind: Kind,
-        val message: String
+        val message: String,
+        val phase: String? = null,
+        val distribution: String? = null,
+        val downloadedBytes: Long = 0L,
+        val totalBytes: Long = 0L,
+        val progress: Double? = null,
+        val error: String? = null
     ) {
         enum class Kind {
             STATUS,
@@ -365,29 +371,47 @@ object EmbeddedTerminalRuntime {
                 message = "正在初始化宿主终端运行时"
             )
         )
+        var runtimeFailureMessage: String? = null
         val initialized =
-            manager.initializeEnvironment { message ->
+            manager.initializeEnvironment { runtimeProgress ->
+                runtimeProgress.error?.takeIf { it.isNotBlank() }?.let { error ->
+                    runtimeFailureMessage = error
+                }
                 emitEnvironmentProgress(
                     onProgress,
                     EnvironmentProgress(
-                        kind = EnvironmentProgress.Kind.STATUS,
-                        message = message
+                        kind = if (runtimeProgress.error == null) {
+                            EnvironmentProgress.Kind.STATUS
+                        } else {
+                            EnvironmentProgress.Kind.ERROR
+                        },
+                        message = runtimeProgress.message,
+                        phase = runtimeProgress.phase,
+                        distribution = runtimeProgress.distribution,
+                        downloadedBytes = runtimeProgress.downloadedBytes,
+                        totalBytes = runtimeProgress.totalBytes,
+                        progress = runtimeProgress.progress,
+                        error = runtimeProgress.error
                     )
                 )
             }
         if (!initialized) {
+            val failureMessage = runtimeFailureMessage ?: "内嵌终端环境初始化失败。"
             emitEnvironmentProgress(
                 onProgress,
                 EnvironmentProgress(
                     kind = EnvironmentProgress.Kind.ERROR,
-                    message = "内嵌终端环境初始化失败。"
+                    message = failureMessage,
+                    phase = "error",
+                    distribution = TerminalDistribution.selected().id,
+                    error = failureMessage
                 )
             )
             return EnvironmentStatus(
                 success = false,
                 initialized = false,
                 basePackagesReady = isBasePackagesReady(context),
-                message = "内嵌终端环境初始化失败。"
+                message = failureMessage
             )
         }
 

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/SpecialPermissionChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/SpecialPermissionChannel.kt
@@ -135,6 +135,8 @@ class SpecialPermissionChannel {
                         .getEmbeddedTerminalDistribution(result)
                     "setEmbeddedTerminalDistribution" -> specialPermissionManager!!
                         .setEmbeddedTerminalDistribution(call, result)
+                    "switchEmbeddedTerminalDistribution" -> specialPermissionManager!!
+                        .switchEmbeddedTerminalDistribution(call, result)
                     "getEmbeddedTerminalSetupSessionSnapshot" -> specialPermissionManager!!
                         .getEmbeddedTerminalSetupSessionSnapshot(result)
                     "installEmbeddedTerminalPackages" -> specialPermissionManager!!

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/SpecialPermissionChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/SpecialPermissionChannel.kt
@@ -159,6 +159,8 @@ class SpecialPermissionChannel {
                         .prepareTermuxLiveWrapper(call, result)
                     "getEmbeddedTerminalInitSnapshot" -> specialPermissionManager!!
                         .getEmbeddedTerminalInitSnapshot(result)
+                    "cancelEmbeddedTerminalInit" -> specialPermissionManager!!
+                        .cancelEmbeddedTerminalInit(result)
                     "isUnknownAppInstallAllowed" -> specialPermissionManager!!
                         .isUnknownAppInstallAllowed(result)
                     "openUnknownAppInstallSettings" -> specialPermissionManager!!

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/StorageUsageChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/StorageUsageChannel.kt
@@ -153,6 +153,7 @@ class StorageUsageChannel {
         val terminalLibFile: File,
         val terminalAlpineArchive: File,
         val terminalUbuntuArchive: File,
+        val terminalUbuntuPartialArchive: File,
         val appBinaryFiles: List<File>,
         val databaseFiles: List<File>,
     )
@@ -263,6 +264,7 @@ class StorageUsageChannel {
                 paths.terminalLibFile,
                 paths.terminalAlpineArchive,
                 paths.terminalUbuntuArchive,
+                paths.terminalUbuntuPartialArchive,
             )
         )
 
@@ -746,6 +748,7 @@ class StorageUsageChannel {
                 clearDirectoryContents(File(context.filesDir, "libtalloc.so.2")),
                 clearDirectoryContents(File(context.filesDir, "alpine.tar.gz")),
                 clearDirectoryContents(File(context.filesDir, "ubuntu.tar.gz")),
+                clearDirectoryContents(File(context.filesDir, "ubuntu.tar.gz.part")),
             )
             "terminal_runtime" -> mergeOutcomes(
                 clearCategoryInternal(context, "terminal_runtime_local", olderThanDays),
@@ -1135,6 +1138,7 @@ class StorageUsageChannel {
             terminalLibFile = File(context.filesDir, "libtalloc.so.2"),
             terminalAlpineArchive = File(context.filesDir, "alpine.tar.gz"),
             terminalUbuntuArchive = File(context.filesDir, "ubuntu.tar.gz"),
+            terminalUbuntuPartialArchive = File(context.filesDir, "ubuntu.tar.gz.part"),
             appBinaryFiles = appBinaryFiles,
             databaseFiles = databaseFiles,
         )

--- a/app/src/main/java/com/ai/assistance/operit/terminal/TerminalManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/terminal/TerminalManager.kt
@@ -19,6 +19,7 @@ import com.rk.libcommons.localLibDir
 import com.rk.settings.Settings
 import com.rk.terminal.App
 import com.rk.terminal.runtime.EmbeddedRuntimeInstaller
+import com.rk.terminal.runtime.EmbeddedRuntimeInstaller.RuntimeInstallProgress
 import com.rk.terminal.runtime.AlpineRepositoryManager
 import com.rk.terminal.runtime.TerminalDistribution
 import com.rk.terminal.runtime.UbuntuRepositoryManager
@@ -100,7 +101,7 @@ class TerminalManager private constructor(
     }
 
     suspend fun initializeEnvironment(
-        onProgress: suspend (String) -> Unit = {}
+        onProgress: suspend (RuntimeInstallProgress) -> Unit = {}
     ): Boolean {
         val status = EmbeddedRuntimeInstaller.ensureRuntimeInstalled(context, onProgress)
         if (!status.success) {

--- a/app/src/main/java/com/ai/assistance/operit/terminal/TerminalManager.kt
+++ b/app/src/main/java/com/ai/assistance/operit/terminal/TerminalManager.kt
@@ -101,9 +101,14 @@ class TerminalManager private constructor(
     }
 
     suspend fun initializeEnvironment(
+        distribution: TerminalDistribution.Spec = TerminalDistribution.selected(),
         onProgress: suspend (RuntimeInstallProgress) -> Unit = {}
     ): Boolean {
-        val status = EmbeddedRuntimeInstaller.ensureRuntimeInstalled(context, onProgress)
+        val status = EmbeddedRuntimeInstaller.ensureRuntimeInstalled(
+            context = context,
+            distribution = distribution,
+            onProgress = onProgress
+        )
         if (!status.success) {
             return false
         }
@@ -239,10 +244,11 @@ class TerminalManager private constructor(
         command: String,
         executorKey: String,
         timeoutMs: Long,
+        distribution: TerminalDistribution.Spec = TerminalDistribution.selected(),
         onProcessStarted: ((Process) -> Unit)? = null,
         onOutputChunk: suspend (String) -> Unit = {}
     ): HiddenExecResult {
-        if (!initializeEnvironment()) {
+        if (!initializeEnvironment(distribution = distribution)) {
             return HiddenExecResult(
                 output = "",
                 exitCode = -1,
@@ -253,7 +259,7 @@ class TerminalManager private constructor(
 
         return withContext(Dispatchers.IO) {
             val process = runCatching {
-                buildHiddenExecProcess(executorKey, command).start()
+                buildHiddenExecProcess(executorKey, command, distribution).start()
             }.getOrElse { error ->
                 return@withContext HiddenExecResult(
                     output = "",
@@ -352,12 +358,17 @@ class TerminalManager private constructor(
         return sessionsById[sessionId]?.terminalSession
     }
 
-    private fun buildHiddenExecProcess(executorKey: String, command: String): ProcessBuilder {
+    private fun buildHiddenExecProcess(
+        executorKey: String,
+        command: String,
+        distribution: TerminalDistribution.Spec
+    ): ProcessBuilder {
         return buildAlpineProcess(
             executorKey = executorKey,
             command = command,
             redirectErrorStream = true,
-            extraEnvironment = mapOf("OMNIBOT_HEADLESS" to "1")
+            extraEnvironment = mapOf("OMNIBOT_HEADLESS" to "1"),
+            distribution = distribution
         )
     }
 
@@ -365,7 +376,8 @@ class TerminalManager private constructor(
         executorKey: String,
         command: String,
         redirectErrorStream: Boolean,
-        extraEnvironment: Map<String, String> = emptyMap()
+        extraEnvironment: Map<String, String> = emptyMap(),
+        distribution: TerminalDistribution.Spec = TerminalDistribution.selected()
     ): ProcessBuilder {
         val initHost = ensureShellScripts()
         val processBuilder = ProcessBuilder(
@@ -377,7 +389,7 @@ class TerminalManager private constructor(
         )
         processBuilder.redirectErrorStream(redirectErrorStream)
         val env = processBuilder.environment()
-        buildEnvironmentMap(sessionId = executorKey).forEach { (key, value) ->
+        buildEnvironmentMap(sessionId = executorKey, distribution = distribution).forEach { (key, value) ->
             env[key] = value
         }
         extraEnvironment.forEach { (key, value) ->
@@ -392,8 +404,10 @@ class TerminalManager private constructor(
         return buildEnvironmentMap(sessionId).map { "${it.key}=${it.value}" }.toTypedArray()
     }
 
-    private fun buildEnvironmentMap(sessionId: String): Map<String, String> {
-        val distribution = TerminalDistribution.selected()
+    private fun buildEnvironmentMap(
+        sessionId: String,
+        distribution: TerminalDistribution.Spec = TerminalDistribution.selected()
+    ): Map<String, String> {
         val filesParent = context.filesDir.parentFile ?: context.filesDir
         val linker = if (File("/system/bin/linker64").exists()) "/system/bin/linker64" else "/system/bin/linker"
         val hostWorkspaceDir = AgentWorkspaceManager.rootDirectory(context).apply { mkdirs() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,10 @@ OMNIBOT_IMAGE_API_KEY=
 # Example: https://omnibot-updates.example.workers.dev
 OMNIBOT_UPDATE_WORKER_URL=https://omni.1775885.xyz
 
+# Optional self-hosted terminal runtime manifest override. When empty, Ubuntu
+# downloads directly from the pinned official Ubuntu Base HTTPS URL.
+OMNIBOT_TERMINAL_RUNTIME_MANIFEST_URL=
+
 #??????????
 #WB_APP_KEY=WB_APP_KEY
 #WB_REDIRECT_URL=WB_REDIRECT_URL

--- a/ui/lib/features/home/pages/termux_setting/termux_setting_page.dart
+++ b/ui/lib/features/home/pages/termux_setting/termux_setting_page.dart
@@ -131,6 +131,7 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
   bool _isDetecting = true;
   bool _isDistributionLoading = true;
   bool _isDistributionSwitching = false;
+  bool _isDistributionCancelling = false;
   bool _isAutoStartLoading = true;
   bool _isAutoStartBusy = false;
   bool _isMountsLoading = true;
@@ -147,6 +148,11 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
   Set<String> _selectedPackageIds = <String>{};
   EmbeddedTerminalDistribution _selectedDistribution =
       EmbeddedTerminalDistribution.alpine;
+  EmbeddedTerminalDistribution? _switchingDistribution;
+  StreamSubscription<EmbeddedTerminalInitProgress>?
+  _terminalInitProgressSubscription;
+  double? _distributionSwitchProgress;
+  String? _distributionSwitchStage;
 
   List<_EnvironmentViewModel> get _items {
     return _environmentDefinitions
@@ -260,6 +266,8 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _terminalInitProgressSubscription = embeddedTerminalInitProgressStream
+        .listen(_handleTerminalInitProgress);
     unawaited(_loadDistributionAndInventory(selectMissingByDefault: true));
     unawaited(_refreshAutoStartTasks());
     unawaited(_refreshWorkspaceMounts());
@@ -268,15 +276,52 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    unawaited(_terminalInitProgressSubscription?.cancel());
     super.dispose();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      unawaited(_loadDistributionAndInventory());
+      if (!_isDistributionSwitching) {
+        unawaited(_loadDistributionAndInventory());
+      }
       unawaited(_refreshAutoStartTasks());
       unawaited(_refreshWorkspaceMounts());
+    }
+  }
+
+  void _handleTerminalInitProgress(EmbeddedTerminalInitProgress progress) {
+    if (!mounted || !_isDistributionSwitching) return;
+    final switchingDistribution = _switchingDistribution;
+    if (progress.distribution != null &&
+        progress.distribution != switchingDistribution) {
+      return;
+    }
+    setState(() {
+      _distributionSwitchProgress = progress.progress;
+      if (progress.message.isNotEmpty) {
+        _distributionSwitchStage = progress.message;
+      }
+    });
+  }
+
+  Future<void> _cancelDistributionSwitch() async {
+    if (!_isDistributionSwitching || _isDistributionCancelling) return;
+    setState(() {
+      _isDistributionCancelling = true;
+      _distributionSwitchStage = _isEnglish
+          ? 'Cancelling download…'
+          : '正在取消下载…';
+    });
+    try {
+      await cancelEmbeddedTerminalInit();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDistributionCancelling = false;
+        });
+      }
     }
   }
 
@@ -317,12 +362,18 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
     setState(() {
       _selectedDistribution = distribution;
       _isDistributionSwitching = true;
+      _isDistributionCancelling = false;
+      _switchingDistribution = distribution;
+      _distributionSwitchProgress = null;
+      _distributionSwitchStage = _isEnglish
+          ? 'Preparing ${distribution == EmbeddedTerminalDistribution.ubuntu ? 'Ubuntu' : 'Alpine'}…'
+          : '正在准备 ${distribution == EmbeddedTerminalDistribution.ubuntu ? 'Ubuntu' : 'Alpine'}…';
       _hasInitializedSelection = false;
       _inventory = const <String, EmbeddedTerminalSetupInventoryItem>{};
       _selectedPackageIds = <String>{};
     });
     try {
-      final saved = await setEmbeddedTerminalDistribution(distribution);
+      final saved = await switchEmbeddedTerminalDistribution(distribution);
       if (!mounted) return;
       setState(() {
         _selectedDistribution = saved;
@@ -360,6 +411,10 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
       if (mounted) {
         setState(() {
           _isDistributionSwitching = false;
+          _isDistributionCancelling = false;
+          _switchingDistribution = null;
+          _distributionSwitchProgress = null;
+          _distributionSwitchStage = null;
         });
       }
     }
@@ -907,7 +962,40 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
           ),
           if (busy) ...[
             const SizedBox(height: 12),
-            const LinearProgressIndicator(minHeight: 2),
+            LinearProgressIndicator(
+              minHeight: 2,
+              value: _isDistributionSwitching
+                  ? _distributionSwitchProgress
+                  : null,
+            ),
+            if (_isDistributionSwitching) ...[
+              const SizedBox(height: 8),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      _distributionSwitchStage ??
+                          (_isEnglish
+                              ? 'Preparing terminal system…'
+                              : '正在准备终端系统…'),
+                      style: TextStyle(
+                        color: _secondaryTextColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton(
+                    onPressed: _isDistributionCancelling
+                        ? null
+                        : () => unawaited(_cancelDistributionSwitch()),
+                    child: Text(_isEnglish ? 'Cancel' : '取消下载'),
+                  ),
+                ],
+              ),
+            ],
           ],
         ],
       ),

--- a/ui/lib/features/welcome/pages/onboarding/onboarding_environment_controller.dart
+++ b/ui/lib/features/welcome/pages/onboarding/onboarding_environment_controller.dart
@@ -46,6 +46,11 @@ class OnboardingEnvironmentController extends ChangeNotifier {
   double get progress => _progress;
   String get stage => _stage;
 
+  Future<void> cancelSetup() async {
+    if (!_isBusy) return;
+    await cancelEmbeddedTerminalInit();
+  }
+
   EnvironmentPreset get selectedPreset =>
       environmentPresets.firstWhere((item) => item.id == _presetId);
 
@@ -291,7 +296,10 @@ class OnboardingEnvironmentController extends ChangeNotifier {
       _failed = !success;
       if (success) {
         _progress = 1;
-        _stage = t('系统与开发环境已准备完成', 'System and development environment are ready');
+        _stage = t(
+          '系统与开发环境已准备完成',
+          'System and development environment are ready',
+        );
       } else {
         _stage = (result['message'] ?? '').toString().trim().isNotEmpty
             ? (result['message'] ?? '').toString().trim()

--- a/ui/lib/features/welcome/pages/onboarding/pages/environment_progress_page.dart
+++ b/ui/lib/features/welcome/pages/onboarding/pages/environment_progress_page.dart
@@ -51,7 +51,11 @@ class OnboardingEnvironmentProgressPage extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Semantics(
-                      label: onbTr(context, '环境配置进度', 'Environment setup progress'),
+                      label: onbTr(
+                        context,
+                        '环境配置进度',
+                        'Environment setup progress',
+                      ),
                       value: progressLabel,
                       child: SizedBox(
                         width: 178,
@@ -146,6 +150,20 @@ class OnboardingEnvironmentProgressPage extends StatelessWidget {
                         icon: LucideIcons.rotateCw,
                         onPressed: onRetry,
                       ),
+                    ] else if (controller.isBusy) ...[
+                      const SizedBox(height: 28),
+                      TextButton.icon(
+                        key: const ValueKey('tutorial-environment-cancel'),
+                        onPressed: controller.cancelSetup,
+                        icon: const Icon(LucideIcons.x),
+                        label: Text(
+                          onbTr(
+                            context,
+                            '取消并保留下载进度',
+                            'Cancel and keep download progress',
+                          ),
+                        ),
+                      ),
                     ],
                     const SizedBox(height: 10),
                     _buildNavigation(context, success: success, failed: failed),
@@ -172,7 +190,11 @@ class OnboardingEnvironmentProgressPage extends StatelessWidget {
     }
     return switch (controller.phaseIndex(controller.stage)) {
       0 => onbTr(context, '正在保存配置', 'Saving your setup'),
-      1 => onbTr(context, '正在准备 $systemName 系统', 'Preparing the $systemName system'),
+      1 => onbTr(
+        context,
+        '正在准备 $systemName 系统',
+        'Preparing the $systemName system',
+      ),
       2 => onbTr(context, '正在安装开发工具', 'Installing development tools'),
       3 => onbTr(context, '正在验证安装结果', 'Verifying the installation'),
       _ => onbTr(context, '正在完成配置', 'Finishing setup'),
@@ -254,7 +276,9 @@ class _CrossFadeText extends StatelessWidget {
     final reduceMotion =
         MediaQuery.maybeOf(context)?.disableAnimations ?? false;
     return AnimatedSwitcher(
-      duration: reduceMotion ? Duration.zero : const Duration(milliseconds: 180),
+      duration: reduceMotion
+          ? Duration.zero
+          : const Duration(milliseconds: 180),
       child: Text(
         text,
         key: ValueKey<String>(text),
@@ -316,8 +340,7 @@ class _MilestoneStepper extends StatelessWidget {
               ),
               Row(
                 children: List<Widget>.generate(labels.length, (index) {
-                  final completed =
-                      index < currentPhase || controller.ready;
+                  final completed = index < currentPhase || controller.ready;
                   final active = !controller.ready && index == currentPhase;
                   final failed = controller.failed && active;
                   final color = failed
@@ -402,7 +425,9 @@ class _SetupDetails extends StatelessWidget {
     final palette = context.omniPalette;
     final extras = controller.selectedToolLabels;
     final preset = controller.selectedPreset;
-    final tools = extras.isEmpty ? preset.contents : '${preset.contents} · $extras';
+    final tools = extras.isEmpty
+        ? preset.contents
+        : '${preset.contents} · $extras';
 
     Widget detailRow({
       required IconData icon,

--- a/ui/lib/services/special_permission.dart
+++ b/ui/lib/services/special_permission.dart
@@ -34,11 +34,23 @@ class EmbeddedTerminalInitProgress {
     required this.kind,
     required this.message,
     required this.timestamp,
+    required this.phase,
+    required this.distribution,
+    required this.downloadedBytes,
+    required this.totalBytes,
+    required this.progress,
+    required this.error,
   });
 
   final String kind;
   final String message;
   final DateTime timestamp;
+  final String? phase;
+  final EmbeddedTerminalDistribution? distribution;
+  final int downloadedBytes;
+  final int totalBytes;
+  final double? progress;
+  final String? error;
 
   factory EmbeddedTerminalInitProgress.fromMap(Map<dynamic, dynamic> map) {
     final timestampValue = map['timestamp'];
@@ -49,6 +61,16 @@ class EmbeddedTerminalInitProgress {
       kind: (map['kind'] as String? ?? 'status').trim(),
       message: (map['message'] as String? ?? '').trimRight(),
       timestamp: DateTime.fromMillisecondsSinceEpoch(millis),
+      phase: (map['phase'] as String?)?.trim(),
+      distribution: (map['distribution'] as String?)?.trim().isNotEmpty == true
+          ? EmbeddedTerminalDistribution.fromId(map['distribution'] as String?)
+          : null,
+      downloadedBytes: (map['downloadedBytes'] as num?)?.toInt() ?? 0,
+      totalBytes: (map['totalBytes'] as num?)?.toInt() ?? 0,
+      progress: map['progress'] is num
+          ? (map['progress'] as num).toDouble().clamp(0.0, 1.0).toDouble()
+          : null,
+      error: (map['error'] as String?)?.trim(),
     );
   }
 }
@@ -63,6 +85,11 @@ class EmbeddedTerminalInitSnapshot {
     required this.logLines,
     required this.startedAt,
     required this.completedAt,
+    required this.phase,
+    required this.distribution,
+    required this.downloadedBytes,
+    required this.totalBytes,
+    required this.error,
   });
 
   final bool running;
@@ -73,6 +100,11 @@ class EmbeddedTerminalInitSnapshot {
   final List<String> logLines;
   final DateTime? startedAt;
   final DateTime? completedAt;
+  final String? phase;
+  final EmbeddedTerminalDistribution? distribution;
+  final int downloadedBytes;
+  final int totalBytes;
+  final String? error;
 
   factory EmbeddedTerminalInitSnapshot.fromMap(Map<dynamic, dynamic> map) {
     final rawLogLines = map['logLines'];
@@ -87,6 +119,13 @@ class EmbeddedTerminalInitSnapshot {
           : const <String>[],
       startedAt: _parseEmbeddedTerminalInitTimestamp(map['startedAt']),
       completedAt: _parseEmbeddedTerminalInitTimestamp(map['completedAt']),
+      phase: (map['phase'] as String?)?.trim(),
+      distribution: (map['distribution'] as String?)?.trim().isNotEmpty == true
+          ? EmbeddedTerminalDistribution.fromId(map['distribution'] as String?)
+          : null,
+      downloadedBytes: (map['downloadedBytes'] as num?)?.toInt() ?? 0,
+      totalBytes: (map['totalBytes'] as num?)?.toInt() ?? 0,
+      error: (map['error'] as String?)?.trim(),
     );
   }
 }
@@ -368,6 +407,11 @@ Future<EmbeddedTerminalInitSnapshot> getEmbeddedTerminalInitSnapshot() async {
     'getEmbeddedTerminalInitSnapshot',
   );
   return EmbeddedTerminalInitSnapshot.fromMap(result ?? const {});
+}
+
+Future<bool> cancelEmbeddedTerminalInit() async {
+  return await spePermission.invokeMethod<bool>('cancelEmbeddedTerminalInit') ??
+      false;
 }
 
 Future<EmbeddedTerminalRuntimeStatus> getEmbeddedTerminalRuntimeStatus() async {

--- a/ui/lib/services/special_permission.dart
+++ b/ui/lib/services/special_permission.dart
@@ -453,6 +453,16 @@ Future<EmbeddedTerminalDistribution> setEmbeddedTerminalDistribution(
   return EmbeddedTerminalDistribution.fromId(result);
 }
 
+Future<EmbeddedTerminalDistribution> switchEmbeddedTerminalDistribution(
+  EmbeddedTerminalDistribution distribution,
+) async {
+  final result = await spePermission.invokeMethod<String>(
+    'switchEmbeddedTerminalDistribution',
+    <String, dynamic>{'distribution': distribution.id},
+  );
+  return EmbeddedTerminalDistribution.fromId(result);
+}
+
 Future<EmbeddedTerminalSetupSessionSnapshot>
 getEmbeddedTerminalSetupSessionSnapshot() async {
   final result = await spePermission.invokeMethod<Map<dynamic, dynamic>>(

--- a/ui/test/features/home/pages/termux_setting/termux_setting_page_test.dart
+++ b/ui/test/features/home/pages/termux_setting/termux_setting_page_test.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/termux_setting/termux_setting_page.dart';
+import 'package:ui/l10n/generated/app_localizations.dart';
+import 'package:ui/services/omnibot_resource_service.dart';
+import 'package:ui/services/special_permission.dart';
+import 'package:ui/theme/app_theme.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const terminalChannel = MethodChannel(
+    'cn.com.omnimind.bot/SpecialPermissionEvent',
+  );
+  const terminalEventsChannel = MethodChannel(
+    'cn.com.omnimind.bot/SpecialPermissionEvents',
+  );
+  late Directory workspaceDirectory;
+  late Completer<void> switchGate;
+  late Completer<void> switchHandlerDone;
+  late bool switchShouldFail;
+  late bool cancelCalled;
+
+  setUp(() async {
+    workspaceDirectory = await Directory.systemTemp.createTemp(
+      'omnibot-termux-setting-test-',
+    );
+    OmnibotResourceService.debugSetWorkspacePaths(
+      OmnibotWorkspacePaths(
+        rootPath: workspaceDirectory.path,
+        shellRootPath: '/workspace',
+        internalRootPath: '${workspaceDirectory.path}/.omnibot',
+      ),
+    );
+    switchGate = Completer<void>();
+    switchHandlerDone = Completer<void>();
+    switchShouldFail = false;
+    cancelCalled = false;
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      terminalEventsChannel,
+      (_) async => null,
+    );
+    messenger.setMockMethodCallHandler(terminalChannel, (call) async {
+      switch (call.method) {
+        case 'getEmbeddedTerminalDistribution':
+          return 'alpine';
+        case 'getEmbeddedTerminalSetupInventory':
+          return <String, dynamic>{'packages': <String, dynamic>{}};
+        case 'getEmbeddedTerminalAutoStartTasks':
+          return <String, dynamic>{'tasks': <dynamic>[]};
+        case 'switchEmbeddedTerminalDistribution':
+          await switchGate.future;
+          if (switchShouldFail) {
+            switchHandlerDone.complete();
+            throw PlatformException(code: 'DOWNLOAD_FAILED', message: '下载失败');
+          }
+          switchHandlerDone.complete();
+          return 'ubuntu';
+        case 'cancelEmbeddedTerminalInit':
+          cancelCalled = true;
+          return true;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    if (!switchGate.isCompleted) {
+      switchGate.complete();
+    }
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(terminalChannel, null);
+    messenger.setMockMethodCallHandler(terminalEventsChannel, null);
+    OmnibotResourceService.debugResetWorkspacePaths();
+    await workspaceDirectory.delete(recursive: true);
+  });
+
+  Widget buildTestApp() {
+    return MaterialApp(
+      locale: const Locale('zh'),
+      theme: AppTheme.lightTheme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const TermuxSettingPage(),
+    );
+  }
+
+  Future<void> pumpTestPage(WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(800, 1600);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    await tester.pumpWidget(buildTestApp());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets('Ubuntu 准备期间展示取消入口', (tester) async {
+    await pumpTestPage(tester);
+
+    await tester.tap(find.text('Ubuntu'));
+    await tester.pump();
+
+    var selector = tester.widget<SegmentedButton<EmbeddedTerminalDistribution>>(
+      find.byType(SegmentedButton<EmbeddedTerminalDistribution>),
+    );
+    expect(selector.selected, <EmbeddedTerminalDistribution>{
+      EmbeddedTerminalDistribution.ubuntu,
+    });
+    expect(find.text('取消下载'), findsOneWidget);
+
+    await tester.tap(find.text('取消下载'));
+    await tester.pump();
+    expect(cancelCalled, isTrue);
+
+    switchGate.complete();
+    await tester.runAsync(() => switchHandlerDone.future);
+    await tester.pump();
+  });
+
+  testWidgets('Ubuntu 准备失败时回滚原发行版', (tester) async {
+    switchShouldFail = true;
+    switchGate.complete();
+    await pumpTestPage(tester);
+
+    await tester.tap(find.text('Ubuntu'));
+    await tester.pump();
+    await tester.runAsync(() async {
+      await switchHandlerDone.future;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    final selector = tester
+        .widget<SegmentedButton<EmbeddedTerminalDistribution>>(
+          find.byType(SegmentedButton<EmbeddedTerminalDistribution>),
+        );
+    expect(selector.selected, <EmbeddedTerminalDistribution>{
+      EmbeddedTerminalDistribution.alpine,
+    });
+  });
+}

--- a/ui/test/services/special_permission_terminal_runtime_test.dart
+++ b/ui/test/services/special_permission_terminal_runtime_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/services/special_permission.dart';
+
+void main() {
+  test('parses Ubuntu runtime download progress', () {
+    final progress = EmbeddedTerminalInitProgress.fromMap(<String, dynamic>{
+      'kind': 'status',
+      'message': 'Downloading Ubuntu',
+      'timestamp': 1234,
+      'phase': 'downloading',
+      'distribution': 'ubuntu',
+      'downloadedBytes': 25,
+      'totalBytes': 100,
+      'progress': 0.25,
+    });
+
+    expect(progress.phase, 'downloading');
+    expect(progress.distribution, EmbeddedTerminalDistribution.ubuntu);
+    expect(progress.downloadedBytes, 25);
+    expect(progress.totalBytes, 100);
+    expect(progress.progress, 0.25);
+  });
+
+  test('clamps progress and preserves structured errors', () {
+    final progress = EmbeddedTerminalInitProgress.fromMap(<String, dynamic>{
+      'kind': 'error',
+      'message': 'Download failed',
+      'timestamp': 1234,
+      'phase': 'error',
+      'distribution': 'ubuntu',
+      'progress': 2,
+      'error': 'network unavailable',
+    });
+
+    expect(progress.progress, 1);
+    expect(progress.error, 'network unavailable');
+  });
+}


### PR DESCRIPTION
## 变更说明

为优化安装包体积，将 Ubuntu Rootfs 从安装包中移除，改为用户选择 Ubuntu 时按需下载。

- Ubuntu 从官方 Ubuntu Base 源下载
- 支持下载进度、断点续传、空间检查及 SHA-256 校验
- 保留旧版已安装 Ubuntu 和归档的兼容逻辑
- Alpine 体积较小，因此继续内置并作为默认轻量环境，确保首次启动和无网络场景下仍可完成终端初始化

## 优化效果

Release APK 由约 69 MB 降至约 38 MB，减少约 31 MB，安装包体积降低约 45%。

## 验证

已通过相关测试，并在真机完成 Ubuntu 下载及初始化验证。