### PR TITLE
Fix Responses assistant content type

### DIFF
--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -2577,6 +2577,7 @@ object HttpController {
     }
 
     private fun buildResponsesMessageItem(role: String, text: String): JsonElement {
+        val contentType = if (role == "assistant") "output_text" else "input_text"
         return buildJsonObject {
             put("role", role)
             put(
@@ -2584,7 +2585,7 @@ object HttpController {
                 buildJsonArray {
                     add(
                         buildJsonObject {
-                            put("type", "input_text")
+                            put("type", contentType)
                             put("text", text)
                         }
                     )


### PR DESCRIPTION
## 变更摘要

修复 Responses API 重放历史 assistant 消息时使用错误内容类型的问题。该问题会导致请求失败：

`Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'.`

## 变更类型

- [x] Bug 修复

## 主要改动

- assistant 消息使用 `output_text`
- user 消息继续使用 `input_text`
- 仅修改 `HttpController.kt` 的 Responses 请求构造逻辑

## 测试说明

- 已核对生成的请求类型映射
- `git diff --check` 已通过
- 本地完整 Gradle 测试因 Mac 未安装 Java 未能执行
- 已在实际手机环境复现原始错误，根因与本修复一致

## UI 变更

无

## 风险与回滚

仅影响 Responses API 的历史消息格式；Chat Completions 和其他协议不受影响。如需回滚，撤销本次提交即可。