### PR TITLE
fix(omniflow): avoid apt update during runtime preparation

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowAppPlatform.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowAppPlatform.kt
@@ -9,7 +9,6 @@ import cn.com.omnimind.bot.terminal.EmbeddedTerminalRuntime
 import cn.com.omnimind.bot.plugin.runtime.RuntimeSkillBundleManager
 import com.ai.assistance.operit.terminal.TerminalManager
 import com.rk.terminal.runtime.TerminalDistribution
-import com.rk.terminal.runtime.UbuntuRepositoryManager
 import java.util.UUID
 
 internal class OmniFlowAppPlatform(
@@ -56,7 +55,6 @@ internal class OmniFlowAppPlatform(
         val command = buildOmniFlowPythonPrepareCommand(
             expectedVersion = expectedVersion,
             distributionId = distribution.id,
-            ubuntuRepositorySetup = UbuntuRepositoryManager.buildSelectedRepositorySetupCommand(),
         )
         val result = TerminalManager.getInstance(appContext).executeHiddenCommand(
             command = command,
@@ -142,7 +140,6 @@ internal class OmniFlowAppPlatform(
 internal fun buildOmniFlowPythonPrepareCommand(
     expectedVersion: String,
     distributionId: String = "alpine",
-    ubuntuRepositorySetup: String = ":",
 ): String {
     require(Regex("""\d+\.\d+""").matches(expectedVersion)) {
         "invalid_python_version"
@@ -151,24 +148,23 @@ internal fun buildOmniFlowPythonPrepareCommand(
         "unsupported_terminal_distribution"
     }
     val repairCommand = if (distributionId == "ubuntu") {
-        """
-            $ubuntuRepositorySetup
-            apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3 python3-pip python3-numpy
-        """.trimIndent()
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y --reinstall --no-install-recommends python3-numpy"
     } else {
-        "apk --wait 300 add --no-cache python3 py3-pip py3-numpy"
+        "apk --wait 300 fix --no-cache py3-numpy"
     }
     return """
         set -e
         expected='$expectedVersion'
         echo 'OMNIFLOW_PYTHON_STAGE=probe_start'
-        base_packages_ready() {
-          command -v python3 >/dev/null 2>&1 &&
-          python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' | grep -qx "${'$'}expected" &&
-          python3 -c 'import numpy' >/dev/null 2>&1
+        command -v python3 >/dev/null 2>&1 || {
+          echo 'OMNIFLOW_PYTHON_STAGE=error reason=python_missing' >&2
+          exit 12
         }
-        if ! base_packages_ready; then
+        python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' | grep -qx "${'$'}expected" || {
+          echo 'OMNIFLOW_PYTHON_STAGE=error reason=python_version_mismatch' >&2
+          exit 13
+        }
+        if ! python3 -c 'import numpy' >/dev/null 2>&1; then
           echo 'OMNIFLOW_PYTHON_STAGE=repair_start package=python-numpy'
           $repairCommand
           printf '%s\n' '$distributionId-python$expectedVersion-numpy-v1' > /etc/omnibot-python-environment
@@ -176,7 +172,7 @@ internal fun buildOmniFlowPythonPrepareCommand(
         else
           echo 'OMNIFLOW_PYTHON_STAGE=probe_ready source=environment'
         fi
-        base_packages_ready
+        python3 -c 'import numpy' >/dev/null 2>&1
         echo 'OMNIFLOW_PYTHON_STAGE=ready'
     """.trimIndent()
 }

--- a/app/src/test/java/cn/com/omnimind/bot/omniflow/OmniFlowAppPlatformTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/omniflow/OmniFlowAppPlatformTest.kt
@@ -11,17 +11,22 @@ import org.junit.Test
 
 class OmniFlowAppPlatformTest {
     @Test
-    fun `python preparation only requires system numpy`() {
+    fun `alpine python preparation reinstalls only numpy when missing`() {
         val command = buildOmniFlowPythonPrepareCommand("3.12")
 
-        assertTrue(command.contains("if ! base_packages_ready; then"))
-        assertTrue(command.contains("apk --wait 300 add --no-cache python3 py3-pip py3-numpy"))
+        assertTrue(command.contains("command -v python3"))
+        assertTrue(command.contains("reason=python_missing"))
+        assertTrue(command.contains("reason=python_version_mismatch"))
+        assertTrue(command.contains("if ! python3 -c 'import numpy'"))
+        assertTrue(command.contains("apk --wait 300 fix --no-cache py3-numpy"))
         assertTrue(command.contains("python3 -c 'import numpy'"))
         assertTrue(command.contains("OMNIFLOW_PYTHON_STAGE=repair_start package=python-numpy"))
         assertTrue(command.contains("OMNIFLOW_PYTHON_STAGE=probe_ready source=environment"))
         assertTrue(command.contains("/etc/omnibot-python-environment"))
         assertTrue(command.contains("alpine-python3.12-numpy-v1"))
         assertFalse(command.contains("apt-get"))
+        assertFalse(command.contains("apk update"))
+        assertFalse(command.contains("py3-pip"))
         assertFalse(command.contains("printf '%s\\\\n'"))
         assertFalse(command.contains("command -v uv"))
         assertFalse(command.contains("uv sync"))
@@ -30,17 +35,18 @@ class OmniFlowAppPlatformTest {
     }
 
     @Test
-    fun `ubuntu python preparation repairs system numpy with apt`() {
+    fun `ubuntu python preparation reinstalls only numpy without apt update`() {
         val command = buildOmniFlowPythonPrepareCommand(
             expectedVersion = "3.12",
             distributionId = "ubuntu",
-            ubuntuRepositorySetup = "setup-ubuntu-repository",
         )
 
-        assertTrue(command.contains("setup-ubuntu-repository"))
-        assertTrue(command.contains("apt-get update"))
-        assertTrue(command.contains("python3 python3-pip python3-numpy"))
+        assertTrue(command.contains("apt-get install -y --reinstall"))
+        assertTrue(command.contains("python3-numpy"))
         assertTrue(command.contains("ubuntu-python3.12-numpy-v1"))
+        assertFalse(command.contains("apt-get update"))
+        assertFalse(command.contains("python3-pip"))
+        assertFalse(command.contains("setup-ubuntu-repository"))
         assertFalse(command.contains("apk --wait"))
     }
 


### PR DESCRIPTION
## What changed

- stop OmniFlow runtime preparation from refreshing Ubuntu package indexes
- validate the existing Python binary and expected version before dependency repair
- reinstall only the platform NumPy package when `import numpy` fails
- avoid reinstalling Python, pip, or configuring repositories

## Why

OmniFlow duplicated onboarding environment setup during startup. On Ubuntu this triggered `apt-get update`, increasing first-run latency and making startup depend on repository availability even when Python was already installed.

## Validation

- `:app:testDevelopStandardDebugUnitTest --tests cn.com.omnimind.bot.omniflow.OmniFlowAppPlatformTest` (3 tests passed)
- `git diff --check`