### PR TITLE
Fix manual recording and reusable command workflow

### DIFF
--- a/androidgui/src/main/java/cn/com/omnimind/androidgui/AndroidGuiEnvironment.kt
+++ b/androidgui/src/main/java/cn/com/omnimind/androidgui/AndroidGuiEnvironment.kt
@@ -115,7 +115,10 @@ class AndroidGuiEnvironment internal constructor(
         )
     }
 
-    suspend fun act(action: Action): AndroidGuiActionResult {
+    suspend fun act(
+        action: Action,
+        awaitStabilization: Boolean = true,
+    ): AndroidGuiActionResult {
         if (!awaitReady()) {
             return AndroidGuiActionResult(
                 success = false,
@@ -125,6 +128,9 @@ class AndroidGuiEnvironment internal constructor(
         return try {
             val result = platform.dispatch(canonicalForDisplay(action))
             if (!result.success) return result
+            if (!awaitStabilization) {
+                return result.withStabilization("runtime_delegated")
+            }
             if (action.tool == OobActionSchema.TOOL_WAIT) {
                 return result.withStabilization("completed_by_action")
             }

--- a/androidgui/src/main/java/cn/com/omnimind/androidgui/AndroidGuiPlatform.kt
+++ b/androidgui/src/main/java/cn/com/omnimind/androidgui/AndroidGuiPlatform.kt
@@ -143,7 +143,14 @@ internal class AccessibilityAndroidGuiPlatform(
     }
 
     override suspend fun inputTarget(x: Float?, y: Float?): AndroidGuiInputTarget? =
-        withNodes { nodes -> selectInputNode(nodes, x, y)?.toInputTarget() }
+        withNodes { nodes ->
+            selectInputNode(
+                nodes = nodes,
+                x = x,
+                y = y,
+                lookup = InputNodeLookup.CLICK_TARGET,
+            )?.toInputTarget()
+        }
 
     override suspend fun installedApplications(): Map<String, String> = withContext(Dispatchers.IO) {
         val manager = context.packageManager
@@ -196,6 +203,7 @@ internal class AccessibilityAndroidGuiPlatform(
                     y = optionalNumber(action, OobActionSchema.ARG_Y),
                     resourceId = action.args[OobActionSchema.ARG_NODE_RESOURCE_ID]
                         ?.toString().orEmpty(),
+                    lookup = InputNodeLookup.INPUT_ACTION,
                 ) ?: return@withNodes AndroidGuiActionResult(false, "input_target_not_found")
                 if (node.isPassword) {
                     return@withNodes AndroidGuiActionResult(
@@ -244,7 +252,13 @@ internal class AccessibilityAndroidGuiPlatform(
         var success = false
         repeat(PRESS_KEY_ATTEMPTS) { attempt ->
             success = withNodes { nodes ->
-                val node = selectInputNode(nodes, x, y, resourceId) ?: return@withNodes false
+                val node = selectInputNode(
+                    nodes = nodes,
+                    x = x,
+                    y = y,
+                    resourceId = resourceId,
+                    lookup = InputNodeLookup.INPUT_ACTION,
+                ) ?: return@withNodes false
                 if (!node.isFocused) {
                     node.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
                 }
@@ -402,6 +416,7 @@ internal class AccessibilityAndroidGuiPlatform(
         x: Float?,
         y: Float?,
         resourceId: String = "",
+        lookup: InputNodeLookup,
     ): AccessibilityNodeInfo? {
         val editable = nodes.filter { it.isEditable && it.isEnabled && it.isVisibleToUser }
         if (resourceId.isNotBlank()) {
@@ -414,6 +429,7 @@ internal class AccessibilityAndroidGuiPlatform(
             editable.firstOrNull { node ->
                 Rect().also(node::getBoundsInScreen).contains(x.toInt(), y.toInt())
             }?.let { return it }
+            if (!lookup.allowFallbackAfterCoordinateMiss) return null
         }
         if (resourceId.isNotBlank()) {
             editable.firstOrNull { it.viewIdResourceName == resourceId && it.isFocused }
@@ -474,6 +490,13 @@ internal class AccessibilityAndroidGuiPlatform(
         const val PRESS_KEY_RETRY_DELAY_MS = 120L
         val PACKAGE = Regex("package=\\\"([^\\\"]+)\\\"")
     }
+}
+
+internal enum class InputNodeLookup(
+    val allowFallbackAfterCoordinateMiss: Boolean,
+) {
+    CLICK_TARGET(false),
+    INPUT_ACTION(true),
 }
 
 internal val OPEN_APP_INTENT_FLAGS: Int =

--- a/androidgui/src/test/java/cn/com/omnimind/androidgui/AndroidGuiEnvironmentTest.kt
+++ b/androidgui/src/test/java/cn/com/omnimind/androidgui/AndroidGuiEnvironmentTest.kt
@@ -11,6 +11,12 @@ import org.junit.Test
 
 class AndroidGuiEnvironmentTest {
     @Test
+    fun `input popup movement keeps click detection strict and input execution recoverable`() {
+        assertEquals(false, InputNodeLookup.CLICK_TARGET.allowFallbackAfterCoordinateMiss)
+        assertEquals(true, InputNodeLookup.INPUT_ACTION.allowFallbackAfterCoordinateMiss)
+    }
+
+    @Test
     fun `accessibility reconnect window tolerates slow OEM rebinding`() {
         assertEquals(15_000L, ACCESSIBILITY_READY_TIMEOUT_MS)
     }
@@ -75,6 +81,22 @@ class AndroidGuiEnvironmentTest {
         assertEquals(3, platform.observeCalls)
         assertEquals("host_completed", result.diagnostics["state_stabilization"])
         assertEquals("stable", result.diagnostics["state_stabilization_result"])
+    }
+
+    @Test
+    fun `manual action can dispatch without waiting for page stabilization`() = runBlocking {
+        val platform = ReconnectingPlatform().apply { ready = true }
+        val environment = AndroidGuiEnvironment(appContext = null, platform = platform)
+
+        val result = environment.act(
+            Action(tool = "click", args = mapOf("x" to 10, "y" to 20)),
+            awaitStabilization = false,
+        )
+
+        assertTrue(result.success)
+        assertEquals(1, platform.dispatchCalls)
+        assertEquals(0, platform.observeCalls)
+        assertEquals("runtime_delegated", result.diagnostics["state_stabilization_result"])
     }
 
     private class ReconnectingPlatform : AndroidGuiPlatform {

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/AndroidDeviceMcpServer.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/AndroidDeviceMcpServer.kt
@@ -3,6 +3,7 @@ package cn.com.omnimind.bot.mcp
 import android.content.Context
 import cn.com.omnimind.bot.agent.HttpAgentLlmClient
 import cn.com.omnimind.bot.omniflow.OmniFlow
+import cn.com.omnimind.bot.omniflow.OmniFlowFunctionRegistration
 import cn.com.omnimind.bot.omniflow.OmniFlowPluginRuntime
 import cn.com.omnimind.bot.omniflow.OmniVlmPlugin
 import cn.com.omnimind.bot.omniflow.asOmniFlowModelClient
@@ -203,18 +204,13 @@ internal object AndroidDeviceMcpServer {
         "save_function" -> {
             val runId = arguments["run_id"]?.toString().orEmpty().trim()
             require(runId.isNotEmpty()) { "omniflow_run_id_required" }
-            OmniFlow.callTool(
+            OmniFlowFunctionRegistration.saveRunLog(
                 context = context,
-                toolCall = OmniFlow.ToolCall(
-                    "save_function",
-                    mapOf(
-                        "run_id" to runId,
-                        "agent_visible" to true,
-                    ),
-                ),
+                runId = runId,
+                agentVisible = true,
                 source = "mcp",
                 modelClient = modelClient,
-            ).payload
+            )
         }
         else -> OmniFlow.callTool(
             context = context,

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/McpServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/McpServerManager.kt
@@ -45,6 +45,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
+import java.net.InetSocketAddress
+import java.net.ServerSocket
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.UUID
@@ -67,6 +69,7 @@ object McpServerManager {
     private const val PREF_TOKEN_VAULT = "mcp_server_token_v2" // 加密后的 token
     private const val PREF_PORT = "mcp_server_port"
     private const val DEFAULT_PORT = 8899
+    private const val PORT_SEARCH_ATTEMPTS = 100
     private const val WEBCHAT_SESSION_COOKIE = "omnibot_webchat_session"
     private const val WEBCHAT_SESSION_TTL_MS = 7L * 24L * 60L * 60L * 1000L
 
@@ -277,16 +280,20 @@ object McpServerManager {
                     }
                     stopServerLocked()
                 }
-                val engine = buildServer(context, port)
+                val resolvedPort = resolveAvailablePort(port)
+                val engine = buildServer(context, resolvedPort)
                 engine.start(wait = false)
 
                 server = engine
                 isRunning = true
                 activeHost = lanIp
                 mmkv.encode(PREF_ENABLE, true)
-                mmkv.encode(PREF_PORT, port)
+                mmkv.encode(PREF_PORT, resolvedPort)
                 mmkv.encode(PREF_HOST, lanIp)
-                OmniLog.i(TAG, "MCP server started at http://$lanIp:$port")
+                if (resolvedPort != port) {
+                    OmniLog.w(TAG, "MCP port $port occupied; switched to $resolvedPort")
+                }
+                OmniLog.i(TAG, "MCP server started at http://$lanIp:$resolvedPort")
                 return currentState()
             } catch (t: Throwable) {
                 server = null
@@ -296,6 +303,28 @@ object McpServerManager {
                 throw t
             }
         }
+    }
+
+    internal fun isTcpPortAvailable(port: Int): Boolean {
+        if (port !in 1..65535) return false
+        return runCatching {
+            ServerSocket().use { socket ->
+                socket.reuseAddress = false
+                socket.bind(InetSocketAddress("0.0.0.0", port))
+            }
+        }.isSuccess
+    }
+
+    internal fun resolveAvailablePort(
+        preferredPort: Int,
+        maxAttempts: Int = PORT_SEARCH_ATTEMPTS,
+        isAvailable: (Int) -> Boolean = ::isTcpPortAvailable,
+    ): Int {
+        require(preferredPort in 1..65535) { "无效的 MCP 端口: $preferredPort" }
+        require(maxAttempts > 0) { "MCP 端口搜索次数必须大于 0" }
+        val lastPort = (preferredPort.toLong() + maxAttempts - 1L).coerceAtMost(65535L).toInt()
+        return (preferredPort..lastPort).firstOrNull(isAvailable)
+            ?: error("MCP 端口 $preferredPort..$lastPort 均被占用")
     }
 
     private fun buildServer(

--- a/app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowFunctionRegistration.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowFunctionRegistration.kt
@@ -1,0 +1,31 @@
+package cn.com.omnimind.bot.omniflow
+
+import android.content.Context
+import cn.com.omnimind.baselib.runlog.InternalRunLogStore
+import cn.com.omnimind.bot.runlog.RunLogReusableFunctionCompiler
+
+object OmniFlowFunctionRegistration {
+    suspend fun saveRunLog(
+        context: Context,
+        runId: String,
+        agentVisible: Boolean = true,
+        modelClient: OmniFlowModelClient? = null,
+        source: String = "function_registration",
+    ): Map<String, Any?> {
+        val normalizedRunId = runId.trim()
+        require(normalizedRunId.isNotEmpty()) { "run_id_required" }
+        val record = requireNotNull(
+            InternalRunLogStore.getRun(context.applicationContext, normalizedRunId),
+        ) { "run_log_not_found:$normalizedRunId" }
+        val function = RunLogReusableFunctionCompiler.compile(record, agentVisible)
+        return OmniFlow.callTool(
+            context = context.applicationContext,
+            toolCall = OmniFlow.ToolCall(
+                name = "save_function",
+                arguments = mapOf("function" to function),
+            ),
+            source = source,
+            modelClient = modelClient,
+        ).payload
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowToolChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowToolChannel.kt
@@ -42,17 +42,27 @@ class OmniFlowToolChannel(context: Context) {
         val goal = payload?.get("goal")?.toString()?.trim().orEmpty()
         scope.launch {
             runCatching {
-                OmniFlow.callTool(
-                    context = appContext,
-                    toolCall = OmniFlow.ToolCall(name, arguments),
-                    goal = goal.ifBlank { name },
-                    modelClient = if (OmniFlowPluginRuntime.isEnabled()) {
+                val modelClient = if (OmniFlowPluginRuntime.isEnabled()) {
                         HttpAgentLlmClient(CoroutineScope(currentCoroutineContext()))
                             .asOmniFlowModelClient()
                     } else {
                         null
-                    },
-                ).payload
+                    }
+                if (name == TOOL_SAVE_FUNCTION && arguments["function"] == null) {
+                    OmniFlowFunctionRegistration.saveRunLog(
+                        context = appContext,
+                        runId = arguments["run_id"]?.toString().orEmpty(),
+                        agentVisible = arguments["agent_visible"] != false,
+                        modelClient = modelClient,
+                    )
+                } else {
+                    OmniFlow.callTool(
+                        context = appContext,
+                        toolCall = OmniFlow.ToolCall(name, arguments),
+                        goal = goal.ifBlank { name },
+                        modelClient = modelClient,
+                    ).payload
+                }
             }.onSuccess { response ->
                 withContext(Dispatchers.Main.immediate) { result.success(response) }
             }.onFailure { error ->
@@ -166,26 +176,17 @@ class OmniFlowToolChannel(context: Context) {
         val runLog = InternalRunLogStore.timelinePayload(appContext, result.runId)
         val conversion = if (result.success && result.actionCount > 0) {
             runCatching {
-                OmniFlow.callTool(
+                OmniFlowFunctionRegistration.saveRunLog(
                     context = appContext,
-                    toolCall = OmniFlow.ToolCall(
-                        name = TOOL_CONVERT_RUN_LOG,
-                        arguments = mapOf(
-                            "run_id" to result.runId,
-                            "register" to true,
-                            "agent_visible" to true,
-                            "enhance" to true,
-                            "name" to result.name,
-                            "description" to result.description,
-                        ),
-                    ),
+                    runId = result.runId,
+                    agentVisible = true,
                     modelClient = if (OmniFlowPluginRuntime.isEnabled()) {
                         HttpAgentLlmClient(CoroutineScope(currentCoroutineContext()))
                             .asOmniFlowModelClient()
                     } else {
                         null
                     },
-                ).payload
+                )
             }.getOrElse { error ->
                 OmniLog.e(TAG, "manual recording conversion failed: ${error.message}", error)
                 mapOf(
@@ -231,6 +232,6 @@ class OmniFlowToolChannel(context: Context) {
         const val TAG = "OmniFlowToolChannel"
         const val METHOD_CALL_TOOL = "tools/call"
         const val METHOD_START_HUMAN_TRAJECTORY_LEARNING = "startHumanTrajectoryLearning"
-        const val TOOL_CONVERT_RUN_LOG = "convert_run_log"
+        const val TOOL_SAVE_FUNCTION = "save_function"
     }
 }

--- a/app/src/main/java/cn/com/omnimind/bot/plugin/official/OmniFlowManagementToolHandler.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/plugin/official/OmniFlowManagementToolHandler.kt
@@ -15,6 +15,7 @@ import cn.com.omnimind.baselib.runlog.InternalRunLogStore
 import cn.com.omnimind.bot.omniflow.OmniFlow
 import cn.com.omnimind.bot.omniflow.OmniFlowPluginRuntime
 import cn.com.omnimind.bot.omniflow.OmniFlowPythonRuntime
+import cn.com.omnimind.bot.omniflow.OmniFlowFunctionRegistration
 import cn.com.omnimind.bot.omniflow.asOmniFlowModelClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -61,8 +62,8 @@ class OmniFlowManagementToolHandler(context: Context) : ToolHandler {
                 return developerOverrideResult(toolName, normalizedArguments)
             }
             if (
-                toolName == OmniFlowManagementTools.CONVERT_RUN_LOG &&
-                normalizedArguments["register"] == true
+                toolName == OmniFlowManagementTools.SAVE_FUNCTION &&
+                normalizedArguments["run_id"]?.toString()?.isNotBlank() == true
             ) {
                 val runId = normalizedArguments["run_id"]?.toString().orEmpty().trim()
                 val record = InternalRunLogStore.getRun(helper.context, runId)
@@ -73,19 +74,27 @@ class OmniFlowManagementToolHandler(context: Context) : ToolHandler {
                     )
                 }
             }
-            val payload = OmniFlow.callTool(
-                context = helper.context,
-                toolCall = OmniFlow.ToolCall(
-                    name = toolName,
-                    arguments = normalizedArguments,
-                ),
-                modelClient = if (OmniFlowPluginRuntime.isEnabled()) {
+            val modelClient = if (OmniFlowPluginRuntime.isEnabled()) {
                     HttpAgentLlmClient(CoroutineScope(currentCoroutineContext()))
                         .asOmniFlowModelClient()
                 } else {
                     null
-                },
-            ).payload
+                }
+            val payload = if (toolName == OmniFlowManagementTools.SAVE_FUNCTION) {
+                OmniFlowFunctionRegistration.saveRunLog(
+                    context = helper.context,
+                    runId = normalizedArguments["run_id"]?.toString().orEmpty(),
+                    agentVisible = normalizedArguments["agent_visible"] != false,
+                    modelClient = modelClient,
+                    source = "agent_function_registration",
+                )
+            } else {
+                OmniFlow.callTool(
+                    context = helper.context,
+                    toolCall = OmniFlow.ToolCall(toolName, normalizedArguments),
+                    modelClient = modelClient,
+                ).payload
+            }
             val encoded = helper.mapToJsonElement(payload).toString()
             if (payload["success"] == false) {
                 ToolExecutionResult.Error(
@@ -118,7 +127,7 @@ class OmniFlowManagementToolHandler(context: Context) : ToolHandler {
             "已读取 ${payload["count"] ?: 0} 个复用指令"
         OmniFlowManagementTools.LIST_RUN_LOGS ->
             "已读取 ${payload["count"] ?: (payload["runs"] as? List<*>)?.size ?: 0} 个 RunLog"
-        OmniFlowManagementTools.CONVERT_RUN_LOG -> "RunLog 已转换为复用指令"
+        OmniFlowManagementTools.SAVE_FUNCTION -> "RunLog 已注册为复用指令"
         else -> "OmniFlow 操作已完成"
     }
 
@@ -189,8 +198,7 @@ internal fun isRegisterableRunLog(record: CanonicalRunLogRecord?): Boolean =
 
 /**
  * A registered RunLog Function must be visible to the recall router unless the caller
- * explicitly asks for a hidden artifact. Older Agent turns commonly supplied only
- * `register=true`, which produced a successful but unusable hidden Function.
+ * explicitly asks for a hidden artifact.
  */
 internal fun normalizeOmniFlowManagementArguments(
     toolName: String,
@@ -203,8 +211,7 @@ internal fun normalizeOmniFlowManagementArguments(
         put(key, jsonElementToManagementValue(value))
     }
     if (
-        toolName == OmniFlowManagementTools.CONVERT_RUN_LOG &&
-        args["register"]?.jsonPrimitive?.booleanOrNull == true &&
+        toolName == OmniFlowManagementTools.SAVE_FUNCTION &&
         !args.containsKey("agent_visible")
     ) {
         put("agent_visible", true)

--- a/app/src/main/java/cn/com/omnimind/bot/plugin/official/OmniFlowManagementTools.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/plugin/official/OmniFlowManagementTools.kt
@@ -16,7 +16,7 @@ object OmniFlowManagementTools {
     const val LIST_RUN_LOGS = "list_run_logs"
     const val GET_RUN_LOG = "get_run_log"
     const val GET_RUN_LOG_STATE = "get_run_log_state"
-    const val CONVERT_RUN_LOG = "convert_run_log"
+    const val SAVE_FUNCTION = "save_function"
     const val GET_PYTHON_OVERRIDE = "get_omniflow_python_override"
     const val APPLY_PYTHON_OVERRIDE = "apply_omniflow_python_override"
     const val CLEAR_PYTHON_OVERRIDE = "clear_omniflow_python_override"
@@ -32,7 +32,7 @@ object OmniFlowManagementTools {
         LIST_RUN_LOGS,
         GET_RUN_LOG,
         GET_RUN_LOG_STATE,
-        CONVERT_RUN_LOG,
+        SAVE_FUNCTION,
         GET_PYTHON_OVERRIDE,
         APPLY_PYTHON_OVERRIDE,
         CLEAR_PYTHON_OVERRIDE,
@@ -65,7 +65,7 @@ object OmniFlowManagementTools {
             "Create Function",
             "Register a complete canonical Function artifact. This is a low-level operation; " +
                 "to register a completed VLM RunLog as a reusable instruction, use " +
-                "convert_run_log instead.",
+                "save_function instead.",
             required = listOf("function"),
             properties = mapOf(
                 "function" to objectProperty("Canonical OmniFlow Function artifact."),
@@ -137,22 +137,15 @@ object OmniFlowManagementTools {
             ),
         ),
         definition(
-            CONVERT_RUN_LOG,
-            "Convert RunLog",
-            "Register a successful VLM RunLog as a replayable Function. Workflow: use the " +
-                "run_id from the preceding VLM result (or list_run_logs/get_run_log), then " +
-                "call this tool with register=true and agent_visible=true. Set enhance=true " +
-                "only when semantic enhancement is requested. The returned function_id is " +
-                "the internal id used for later recall; do not invent one.",
+            SAVE_FUNCTION,
+            "Save Function",
+            "Register a successful RunLog as a replayable Function. Pass the run_id returned " +
+                "by the completed GUI task. The returned function_id is the internal id used " +
+                "for later recall; do not invent one.",
             required = listOf("run_id"),
             properties = mapOf(
                 "run_id" to stringProperty("Source RunLog id."),
-                "register" to booleanProperty("Register the converted Function."),
                 "agent_visible" to booleanProperty("Expose the Function to the Agent."),
-                "enhance" to booleanProperty("Run offline semantic enhancement."),
-                "function_id" to stringProperty("Optional Function id override."),
-                "name" to stringProperty("Optional Function name override."),
-                "description" to stringProperty("Optional Function description override."),
             ),
         ),
         definition(

--- a/app/src/main/java/cn/com/omnimind/bot/runlog/RunLogReusableFunctionCompiler.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/runlog/RunLogReusableFunctionCompiler.kt
@@ -1,0 +1,80 @@
+package cn.com.omnimind.bot.runlog
+
+import cn.com.omnimind.baselib.runlog.CanonicalRunLogRecord
+import cn.com.omnimind.baselib.runlog.InternalRunLogStore
+import cn.com.omnimind.baselib.runlog.OobActionSchema
+import com.google.gson.GsonBuilder
+import java.security.MessageDigest
+
+object RunLogReusableFunctionCompiler {
+    fun compile(
+        record: CanonicalRunLogRecord,
+        agentVisible: Boolean = true,
+    ): Map<String, Any?> {
+        require(record.success && record.status == "succeeded" && record.doneReason != "error") {
+            "run_log_not_successful"
+        }
+        val functionSteps = record.steps.mapNotNull { rawStep ->
+            val step = InternalRunLogStore.canonicalStep(rawStep)
+            val result = stringMap(step["result"])
+            val action = stringMap(step["action"])
+            val tool = action["tool"]?.toString().orEmpty()
+            if (result["success"] != true || tool !in OobActionSchema.replayableToolNames) {
+                return@mapNotNull null
+            }
+            linkedMapOf<String, Any?>(
+                "step_index" to 0,
+                "source_state_id" to step["before_state_id"],
+                "action" to linkedMapOf(
+                    "tool" to tool,
+                    "args" to stringMap(action["args"]),
+                ),
+            )
+        }.mapIndexed { index, step -> step + ("step_index" to index) }
+        require(functionSteps.isNotEmpty()) { "run_log_no_replayable_steps" }
+
+        val goal = record.goal.trim().ifEmpty {
+            record.operationDescription.trim().ifEmpty { "复用指令" }
+        }
+        val identity = compactGson.toJson(
+            linkedMapOf(
+                "goal" to goal,
+                "steps" to functionSteps.map { step ->
+                    linkedMapOf(
+                        "source_state_id" to step["source_state_id"],
+                        "action" to step["action"],
+                    )
+                },
+            ),
+        )
+        return linkedMapOf(
+            "schema_version" to "omniflow.function.v2",
+            "function_id" to "recorded_${sha256(identity).take(16)}",
+            "name" to goal.take(120),
+            "description" to goal,
+            "input_schema" to linkedMapOf(
+                "type" to "object",
+                "properties" to emptyMap<String, Any?>(),
+                "required" to emptyList<String>(),
+                "additionalProperties" to false,
+            ),
+            "bindings" to emptyList<Map<String, Any?>>(),
+            "steps" to functionSteps,
+            "checker_rules" to emptyList<Map<String, Any?>>(),
+            "agent_visible" to agentVisible,
+        )
+    }
+
+    private fun stringMap(value: Any?): Map<String, Any?> =
+        (value as? Map<*, *>)
+            ?.entries
+            ?.associate { (key, item) -> key.toString() to item }
+            .orEmpty()
+
+    private fun sha256(value: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value.toByteArray())
+            .joinToString("") { byte -> "%02x".format(byte) }
+
+    private val compactGson = GsonBuilder().disableHtmlEscaping().create()
+}

--- a/app/src/test/java/cn/com/omnimind/bot/mcp/McpServerPortAvailabilityTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/mcp/McpServerPortAvailabilityTest.kt
@@ -1,0 +1,45 @@
+package cn.com.omnimind.bot.mcp
+
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class McpServerPortAvailabilityTest {
+    @Test
+    fun occupiedPortIsRejectedBeforeStartingKtor() {
+        ServerSocket().use { socket ->
+            socket.bind(InetSocketAddress("127.0.0.1", 0))
+            assertFalse(McpServerManager.isTcpPortAvailable(socket.localPort))
+        }
+    }
+
+    @Test
+    fun releasedPortCanBeUsed() {
+        val port = ServerSocket(0).use { it.localPort }
+        assertTrue(McpServerManager.isTcpPortAvailable(port))
+    }
+
+    @Test
+    fun occupiedPreferredPortSwitchesToNextAvailablePort() {
+        assertEquals(
+            8901,
+            McpServerManager.resolveAvailablePort(
+                preferredPort = 8899,
+                maxAttempts = 3,
+                isAvailable = { it == 8901 },
+            ),
+        )
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun failsWhenSearchRangeHasNoAvailablePort() {
+        McpServerManager.resolveAvailablePort(
+            preferredPort = 8899,
+            maxAttempts = 2,
+            isAvailable = { false },
+        )
+    }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/omniflow/OmniFlowToolChannelManualRecordingTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/omniflow/OmniFlowToolChannelManualRecordingTest.kt
@@ -22,7 +22,7 @@ class OmniFlowToolChannelManualRecordingTest {
     }
 
     @Test
-    fun manualRecordingRegistersBeforeOfflineEnhancement() {
+    fun manualRecordingUsesTheCanonicalFunctionRegistrationPath() {
         val source = projectSource(
             "app/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowToolChannel.kt",
         )
@@ -30,9 +30,24 @@ class OmniFlowToolChannelManualRecordingTest {
             .substringAfter("private suspend fun finalizedPayload(")
             .substringBefore("fun clear()")
 
-        assertTrue(method.contains("\"register\" to true"))
-        assertTrue(method.contains("\"enhance\" to true"))
+        assertTrue(method.contains("OmniFlowFunctionRegistration.saveRunLog("))
+        assertTrue(method.contains("runId = result.runId"))
+        assertTrue(method.contains("agentVisible = true"))
         assertTrue(method.contains("modelClient = if (OmniFlowPluginRuntime.isEnabled())"))
+    }
+
+    @Test
+    fun manualTextInputDoesNotRequireAPreviouslyFocusedField() {
+        val source = projectSource(
+            "uikit/src/main/java/cn/com/omnimind/uikit/loader/ManualRecordingControlOverlay.kt",
+        )
+        val actionDialog = source
+            .substringAfter("private fun showManualActionDialog(")
+            .substringBefore("private fun showManualInputTextDialog(")
+
+        assertTrue(actionDialog.contains("showManualInputTextDialog(context, inputTarget)"))
+        assertTrue(!actionDialog.contains("Tap an input field first"))
+        assertTrue(!actionDialog.contains("请先点击输入框"))
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/plugin/official/OmniFlowManagementToolHandlerTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/plugin/official/OmniFlowManagementToolHandlerTest.kt
@@ -12,29 +12,28 @@ class OmniFlowManagementToolHandlerTest {
     private val json = Json { explicitNulls = false }
 
     @Test
-    fun `registering a converted runlog defaults to agent visible`() {
+    fun `saving a runlog defaults to agent visible`() {
         val args = json.parseToJsonElement(
-            """{"run_id":"gui-123","register":true,"enhance":true}""",
+            """{"run_id":"gui-123"}""",
         ).jsonObject
 
         val normalized = normalizeOmniFlowManagementArguments(
-            OmniFlowManagementTools.CONVERT_RUN_LOG,
+            OmniFlowManagementTools.SAVE_FUNCTION,
             args,
         )
 
         assertEquals("gui-123", normalized["run_id"])
-        assertEquals(true, normalized["register"])
         assertEquals(true, normalized["agent_visible"])
     }
 
     @Test
     fun `explicitly hidden converted runlog remains hidden`() {
         val args = json.parseToJsonElement(
-            """{"run_id":"gui-123","register":true,"agent_visible":false}""",
+            """{"run_id":"gui-123","agent_visible":false}""",
         ).jsonObject
 
         val normalized = normalizeOmniFlowManagementArguments(
-            OmniFlowManagementTools.CONVERT_RUN_LOG,
+            OmniFlowManagementTools.SAVE_FUNCTION,
             args,
         )
 

--- a/app/src/test/java/cn/com/omnimind/bot/runlog/RunLogReusableFunctionCompilerTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/runlog/RunLogReusableFunctionCompilerTest.kt
@@ -1,0 +1,83 @@
+package cn.com.omnimind.bot.runlog
+
+import cn.com.omnimind.baselib.runlog.CanonicalRunLogRecord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RunLogReusableFunctionCompilerTest {
+    @Test
+    fun compilesCanonicalDeviceRunLogWithoutLosingReplayActions() {
+        val record = CanonicalRunLogRecord(
+            runId = "human-test",
+            goal = "添加联系人",
+            status = "succeeded",
+            success = true,
+            steps = listOf(
+                step(0, "state-before", "click", mapOf("x" to 120.0, "y" to 240.0)),
+                step(1, "state-form", "input_text", mapOf("text" to "小万")),
+                step(2, "state-keyboard", "press_key", mapOf("key" to "BACK")),
+            ),
+            diagnostics = mapOf("done_reason" to "finished"),
+        )
+
+        val function = RunLogReusableFunctionCompiler.compile(record)
+        val steps = function["steps"] as List<*>
+
+        assertEquals("omniflow.function.v2", function["schema_version"])
+        assertEquals(
+            setOf(
+                "schema_version",
+                "function_id",
+                "name",
+                "description",
+                "input_schema",
+                "bindings",
+                "steps",
+                "checker_rules",
+                "agent_visible",
+            ),
+            function.keys,
+        )
+        assertEquals("添加联系人", function["name"])
+        assertEquals(3, steps.size)
+        assertEquals("state-before", (steps[0] as Map<*, *>)["source_state_id"])
+        assertTrue(function["agent_visible"] == true)
+    }
+
+    @Test
+    fun ignoresFailedActionsAndKeepsStableFunctionIdentity() {
+        val record = CanonicalRunLogRecord(
+            goal = "测试操作",
+            status = "succeeded",
+            success = true,
+            steps = listOf(
+                step(0, "state-1", "click", mapOf("x" to 1, "y" to 2)),
+                step(1, "state-2", "click", mapOf("x" to 3, "y" to 4), success = false),
+            ),
+            diagnostics = mapOf("done_reason" to "finished"),
+        )
+
+        val first = RunLogReusableFunctionCompiler.compile(record, agentVisible = false)
+        val second = RunLogReusableFunctionCompiler.compile(record, agentVisible = false)
+
+        assertEquals(first["function_id"], second["function_id"])
+        assertEquals(1, (first["steps"] as List<*>).size)
+        assertFalse(first["agent_visible"] as Boolean)
+    }
+
+    private fun step(
+        index: Int,
+        beforeStateId: String,
+        tool: String,
+        args: Map<String, Any?>,
+        success: Boolean = true,
+    ): Map<String, Any?> = mapOf(
+        "step_index" to index,
+        "before_state_id" to beforeStateId,
+        "action" to mapOf("tool" to tool, "args" to args),
+        "result" to mapOf("success" to success),
+        "after_state_id" to "${beforeStateId}-after",
+    )
+}

--- a/assists/src/main/java/cn/com/omnimind/assists/HumanTrajectoryLearningSession.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/HumanTrajectoryLearningSession.kt
@@ -3,6 +3,7 @@ package cn.com.omnimind.assists
 import android.content.Context
 import cn.com.omnimind.baselib.runlog.InternalRunLogStore
 import cn.com.omnimind.baselib.runlog.RunLogWriter
+import cn.com.omnimind.baselib.runlog.State
 import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.assists.task.recording.ManualRecordedAction
 import cn.com.omnimind.assists.task.recording.ManualTraceRecorder
@@ -284,6 +285,19 @@ object HumanTrajectoryLearningSession {
             }
     }
 
+    suspend fun detectManualInputTargetAfterClick(
+        x: Float,
+        y: Float,
+    ): ManualInputTarget? {
+        val session = synchronized(lock) { activeSession } ?: return null
+        if (synchronized(lock) { activePaused }) return null
+        return runCatching { session.recorder.detectInputTargetAfterClick(x, y) }
+            .getOrElse { error ->
+                OmniLog.w(TAG, "manual input target detection failed: ${error.message}")
+                null
+            }
+    }
+
     suspend fun recordManualInputText(
         text: String,
         inputTarget: ManualInputTarget? = null,
@@ -389,19 +403,16 @@ object HumanTrajectoryLearningSession {
             persistedCount
         }
         val hasActions = trace.actions.isNotEmpty()
-        val evidenceComplete = trace.actions.all(ManualRecordedAction::evidenceComplete)
         val actionsExecuted = manualOperationFailuresResolved(trace.actions)
-        val success = hasActions && evidenceComplete && actionsExecuted && persisted.isSuccess
+        val success = hasActions && actionsExecuted && persisted.isSuccess
         val doneReason = when {
             persisted.isFailure -> "runlog_persist_failed"
-            !evidenceComplete -> "state_capture_incomplete"
             !actionsExecuted -> "action_execution_failed"
             success -> "user_completed"
             else -> "empty_recording"
         }
         val errorMessage = when {
             persisted.isFailure -> "RunLog 保存失败：${persisted.exceptionOrNull()?.message.orEmpty()}"
-            !evidenceComplete -> "页面状态采集失败，本次轨迹已保存但不能安全重放"
             !actionsExecuted -> "部分手动操作执行失败，RunLog 已保留失败动作和原因"
             !hasActions -> "未记录到可复用的人类操作"
             else -> null
@@ -588,8 +599,8 @@ private fun manualRunLogFact(
     action: ManualRecordedAction,
     source: String,
 ): Map<String, Any?> {
-    val beforeState = requireNotNull(action.beforeState) { "manual_before_state_required" }
-    val afterState = requireNotNull(action.afterState) { "manual_after_state_required" }
+    val beforeState = action.beforeState ?: manualPlaceholderState(action, "before")
+    val afterState = action.afterState ?: manualPlaceholderState(action, "after")
     return linkedMapOf(
         "before_state_id" to beforeState.stateId,
         "action" to action.action.asMap(),
@@ -614,7 +625,16 @@ private fun manualRunLogFact(
     )
 }
 
-internal fun manualRunLogStates(action: ManualRecordedAction): List<Map<String, Any?>> = listOf(
-    requireNotNull(action.beforeState) { "manual_before_state_required" }.asMap(),
-    requireNotNull(action.afterState) { "manual_after_state_required" }.asMap(),
+internal fun manualRunLogStates(action: ManualRecordedAction): List<Map<String, Any?>> =
+    listOf(
+        (action.beforeState ?: manualPlaceholderState(action, "before")).asMap(),
+        (action.afterState ?: manualPlaceholderState(action, "after")).asMap(),
+    )
+
+private fun manualPlaceholderState(action: ManualRecordedAction, stage: String): State = State.create(
+    packageName = action.beforePackageName ?: action.afterPackageName.orEmpty(),
+    activityName = "manual_recording_$stage",
+    displayWidth = action.displayWidth.coerceAtLeast(1),
+    displayHeight = action.displayHeight.coerceAtLeast(1),
+    xml = "<hierarchy capture=\"unavailable\" stage=\"$stage\" />",
 )

--- a/assists/src/main/java/cn/com/omnimind/assists/recording/ManualGestureRecognizer.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/recording/ManualGestureRecognizer.kt
@@ -55,6 +55,12 @@ data class ManualRecognizedGesture(
 )
 
 object ManualGestureRecognizer {
+    fun recognizeCancelledSwipe(
+        trace: ManualPointerTrace,
+        thresholds: ManualGestureThresholds,
+    ): ManualRecognizedGesture? = recognize(trace, thresholds)
+        ?.takeIf { it.actionName == OobActionSchema.TOOL_SWIPE }
+
     fun recognize(
         trace: ManualPointerTrace,
         thresholds: ManualGestureThresholds,

--- a/assists/src/main/java/cn/com/omnimind/assists/task/recording/ManualRecordingEngine.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/task/recording/ManualRecordingEngine.kt
@@ -4,7 +4,6 @@ import cn.com.omnimind.androidgui.AndroidGuiActionResult
 import cn.com.omnimind.baselib.runlog.Action
 import cn.com.omnimind.baselib.runlog.State
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -79,16 +78,9 @@ internal class ManualRecordingEngine(
                 onDispatched(operationResult)
             } catch (error: CancellationException) {
                 throw error
-            } catch (_: Exception) {
-                Unit
-            }
+            } catch (_: Exception) {}
             executed = operationResult.success
-            val after = safeObserve(
-                stage = "${sequence}_after",
-                command = command,
-                staleXml = before.state?.xml,
-                retryUnchanged = operationResult.success && command.action.tool in STATE_CHANGING_TOOLS,
-            )
+            val after = safeObserve(stage = "${sequence}_after", command = command)
             if (operationResult.success || command.persistOnFailure) {
                 val sourceStateRequired = command.action.tool in SOURCE_STATE_REQUIRED_TOOLS
                 val evidenceComplete = !sourceStateRequired || !before.state?.xml.isNullOrBlank()
@@ -155,49 +147,29 @@ internal class ManualRecordingEngine(
     private suspend fun safeObserve(
         stage: String,
         command: ManualRecordingCommand,
-        staleXml: String? = null,
-        retryUnchanged: Boolean = false,
     ): ManualRecordingObservation {
-        var latest = ManualRecordingObservation(captureError = "xml_unavailable")
-        var latestWithXml: ManualRecordingObservation? = null
-        repeat(OBSERVATION_ATTEMPTS) { attempt ->
-            latest = try {
-                observe(stage, command).let { observation ->
-                    if (!observation.state?.xml.isNullOrBlank()) observation
-                    else observation.copy(captureError = observation.captureError ?: "xml_unavailable")
-                }
-            } catch (error: CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                ManualRecordingObservation(
-                    captureError = error.message.orEmpty().ifBlank {
-                        "${error.javaClass.simpleName}:xml_capture_failed"
-                    },
-                )
+        return try {
+            observe(stage, command).let { observation ->
+                if (!observation.state?.xml.isNullOrBlank()) observation
+                else observation.copy(captureError = observation.captureError ?: "xml_unavailable")
             }
-            val xml = latest.state?.xml
-            if (!xml.isNullOrBlank()) {
-                latestWithXml = latest
-                val unchanged = retryUnchanged && !staleXml.isNullOrBlank() && xml == staleXml
-                if (!unchanged) return latest
-            }
-            if (attempt == OBSERVATION_ATTEMPTS - 1) {
-                return latestWithXml ?: latest
-            }
-            delay(OBSERVATION_RETRY_DELAY_MS)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            ManualRecordingObservation(
+                captureError = error.message.orEmpty().ifBlank {
+                    "${error.javaClass.simpleName}:xml_capture_failed"
+                },
+            )
         }
-        return latestWithXml ?: latest
     }
 
     private companion object {
-        private const val OBSERVATION_ATTEMPTS = 5
-        private const val OBSERVATION_RETRY_DELAY_MS = 100L
         private val SOURCE_STATE_REQUIRED_TOOLS = setOf(
             "click",
             "long_press",
             "input_text",
             "swipe",
         )
-        private val STATE_CHANGING_TOOLS = SOURCE_STATE_REQUIRED_TOOLS + "press_key"
     }
 }

--- a/assists/src/main/java/cn/com/omnimind/assists/task/recording/ManualTraceRecorder.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/task/recording/ManualTraceRecorder.kt
@@ -47,14 +47,8 @@ data class ManualRecordedAction(
 }
 
 internal fun selectManualInputTargetAfterClick(
-    before: ManualInputTarget?,
-    after: ManualInputTarget?,
-    clickedFocusedTarget: ManualInputTarget?,
-): ManualInputTarget? = when {
-    clickedFocusedTarget != null -> clickedFocusedTarget
-    after != null && after != before -> after
-    else -> null
-}
+    clickedTarget: ManualInputTarget?,
+): ManualInputTarget? = clickedTarget
 
 internal fun manualInputTextActionArgs(
     text: String,
@@ -93,6 +87,16 @@ internal fun canonicalManualScreenAction(
         ),
     )
     return actionOf(tool, canonicalArgs)
+}
+
+internal fun isManualSystemBackGesture(gesture: ManualOverlayTouchGesture): Boolean {
+    if (gesture.actionName != OobActionSchema.TOOL_SWIPE || gesture.displayWidth <= 0) return false
+    val edgeWidth = gesture.displayWidth * 0.05f
+    return when (gesture.direction) {
+        "right" -> gesture.startX <= edgeWidth
+        "left" -> gesture.startX >= gesture.displayWidth - edgeWidth
+        else -> false
+    }
 }
 
 internal data class ManualTraceSnapshot(
@@ -179,7 +183,7 @@ class ManualTraceRecorder(
     private val engine = ManualRecordingEngine(
         journal = journal,
         observe = { stage, command -> captureObservation(stage, command) },
-        execute = { command -> environment.act(command.action) },
+        execute = { command -> environment.act(command.action, awaitStabilization = false) },
         onActionRecorded = { index, action -> onActionRecorded?.invoke(index, action) },
     )
 
@@ -313,32 +317,32 @@ class ManualTraceRecorder(
         if (!isRecording() || gesture.actionName !in SUPPORTED_GESTURES) {
             return ManualOverlayGestureReplayResult(executed = false, recorded = false)
         }
-        val inputTargetBefore = if (gesture.actionName == OobActionSchema.TOOL_CLICK) {
-            environment.inputTarget()?.toManualInputTarget()
-        } else {
-            null
-        }
         val command = gesture.toRecordingCommand()
         val outcome = engine.perform(command) { dispatchResult ->
             onGestureDispatched(
                 dispatchResult.success && gesture.actionName == OobActionSchema.TOOL_CLICK,
             )
         }
-        val inputTarget = if (outcome.recorded && gesture.actionName == OobActionSchema.TOOL_CLICK) {
-            awaitInputTargetAfterClick(
-                before = inputTargetBefore,
-                x = gesture.startX,
-                y = gesture.startY,
-            )
-        } else {
-            null
-        }
         return ManualOverlayGestureReplayResult(
             executed = outcome.executed,
             recorded = outcome.recorded,
             mayOpenIme = outcome.executed && gesture.actionName == OobActionSchema.TOOL_CLICK,
-            inputTarget = inputTarget,
+            inputTarget = null,
         )
+    }
+
+    suspend fun detectInputTargetAfterClick(
+        x: Float,
+        y: Float,
+    ): ManualInputTarget? = withTimeoutOrNull(INPUT_TARGET_TIMEOUT_MS) {
+        var target: ManualInputTarget? = null
+        while (target == null && isRecording()) {
+            target = selectManualInputTargetAfterClick(
+                environment.inputTarget(x, y)?.toManualInputTarget(),
+            )
+            if (target == null) delay(INPUT_TARGET_POLL_MS)
+        }
+        target
     }
 
     private suspend fun awaitInputTarget(): ManualInputTarget? = withTimeoutOrNull(INPUT_TARGET_TIMEOUT_MS) {
@@ -352,24 +356,19 @@ class ManualTraceRecorder(
         target
     }
 
-    private suspend fun awaitInputTargetAfterClick(
-        before: ManualInputTarget?,
-        x: Float,
-        y: Float,
-    ): ManualInputTarget? = withTimeoutOrNull(INPUT_TARGET_TIMEOUT_MS) {
-        var target: ManualInputTarget? = null
-        while (target == null) {
-            val after = environment.inputTarget()?.toManualInputTarget()
-            val clicked = environment.inputTarget(x, y)?.toManualInputTarget()
-            target = selectManualInputTargetAfterClick(before, after, clicked)
-            if (target == null) {
-                delay(INPUT_TARGET_POLL_MS)
-            }
-        }
-        target
-    }
-
     private fun ManualOverlayTouchGesture.toRecordingCommand(): ManualRecordingCommand {
+        if (isManualSystemBackGesture(this)) {
+            return command(
+                tool = OobActionSchema.TOOL_PRESS_KEY,
+                args = manualPressKeyActionArgs("back"),
+                title = "返回",
+                summary = "侧滑返回",
+                source = OVERLAY_TOUCH_SOURCE,
+                startedAtMs = startedAtMs,
+                displayWidth = displayWidth,
+                displayHeight = displayHeight,
+            )
+        }
         return when (actionName) {
             OobActionSchema.TOOL_CLICK -> command(
                 tool = actionName,

--- a/assists/src/test/java/cn/com/omnimind/assists/HumanTrajectoryLearningSessionTest.kt
+++ b/assists/src/test/java/cn/com/omnimind/assists/HumanTrajectoryLearningSessionTest.kt
@@ -8,9 +8,115 @@ import cn.com.omnimind.baselib.runlog.actionOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HumanTrajectoryLearningSessionTest {
+    @Test
+    fun manualRecordingKeepsEveryCoordinateActionWhenMiddleXmlIsUnavailable() = runBlocking {
+        val actions = listOf(
+            coordinateAction("打开安装页", 500, 400, state("before-0", "demo.app", "<hierarchy/>")),
+            coordinateAction("点击安装", 500, 750, null),
+            coordinateAction("点击完成", 500, 900, state("after-2", "installer", "<hierarchy/>")),
+        )
+        val records = mutableListOf<RunLogStepRecord>()
+        val writer = RunLogWriter { records += it }
+
+        actions.forEachIndexed { index, action ->
+            writer.write(
+                fact = HumanTrajectoryLearningSession.buildRunLogFact("manual-run", index, action),
+                states = manualRunLogStates(action),
+            )
+        }
+
+        assertEquals(3, records.size)
+        assertEquals(listOf(0, 1, 2), records.map { it.step["step_index"] })
+        assertEquals(
+            listOf("打开安装页", "点击安装", "点击完成"),
+            records.map { (it.step["metadata"] as Map<*, *>)["summary"] },
+        )
+        assertTrue(records[1].states.all { state ->
+            state["xml"]?.toString()?.contains("capture=\"unavailable\"") == true
+        })
+    }
+
+    @Test
+    fun manualCoordinateActionPersistsWithoutXmlStates() = runBlocking {
+        val action = ManualRecordedAction(
+            action = actionOf("click", mapOf("x" to 500, "y" to 750)),
+            title = "点击安装",
+            beforeState = null,
+            afterState = null,
+            startedAtMs = 100L,
+            finishedAtMs = 200L,
+            summary = "点击安装",
+            displayWidth = 1080,
+            displayHeight = 2400,
+            evidenceComplete = false,
+            evidenceError = "xml_unavailable",
+        )
+
+        var record: RunLogStepRecord? = null
+        val writer = RunLogWriter { record = it }
+        writer.write(
+            fact = HumanTrajectoryLearningSession.buildRunLogFact("manual-run", 0, action),
+            states = manualRunLogStates(action),
+        )
+
+        val saved = requireNotNull(record)
+        assertEquals("click", (saved.step["action"] as Map<*, *>)["tool"])
+        assertEquals(2, saved.states.size)
+        assertEquals(saved.states[0]["state_id"], saved.step["before_state_id"])
+        assertEquals(saved.states[1]["state_id"], saved.step["after_state_id"])
+        assertEquals(
+            "<hierarchy capture=\"unavailable\" stage=\"before\" />",
+            saved.states[0]["xml"],
+        )
+        assertEquals(
+            false,
+            (saved.step["metadata"] as Map<*, *>)["evidence_complete"],
+        )
+    }
+
+    @Test
+    fun cancelledEdgeBackSwipePersistsWithReplayCoordinates() = runBlocking {
+        val action = ManualRecordedAction(
+            action = actionOf(
+                "swipe",
+                linkedMapOf(
+                    "target_description" to "屏幕区域",
+                    "x1" to 1f,
+                    "y1" to 1_200f,
+                    "x2" to 320f,
+                    "y2" to 1_204f,
+                    "duration_ms" to 240L,
+                    "direction" to "right",
+                ),
+            ),
+            title = "右滑",
+            beforeState = null,
+            afterState = null,
+            startedAtMs = 100L,
+            finishedAtMs = 340L,
+            summary = "从 (1, 1200) 滑动到 (320, 1204)",
+            displayWidth = 1080,
+            displayHeight = 2400,
+            evidenceComplete = false,
+            evidenceError = "xml_unavailable",
+        )
+
+        val fact = HumanTrajectoryLearningSession.buildRunLogFact("manual-run", 0, action)
+        val savedAction = fact.getValue("action") as Map<*, *>
+        val args = requireNotNull(savedAction["args"]) as Map<*, *>
+
+        assertEquals("swipe", savedAction["tool"])
+        assertEquals(1f, args["x1"])
+        assertEquals(1_200f, args["y1"])
+        assertEquals(320f, args["x2"])
+        assertEquals(1_204f, args["y2"])
+        assertEquals("right", args["direction"])
+    }
+
     @Test
     fun failedManualInputIsRetainedAsCanonicalFailedStep() = runBlocking {
         val action = ManualRecordedAction(
@@ -128,6 +234,25 @@ class HumanTrajectoryLearningSessionTest {
         displayWidth = 1440,
         displayHeight = 3168,
         xml = xml,
+    )
+
+    private fun coordinateAction(
+        title: String,
+        x: Int,
+        y: Int,
+        observedState: State?,
+    ): ManualRecordedAction = ManualRecordedAction(
+        action = actionOf("click", mapOf("x" to x, "y" to y)),
+        title = title,
+        beforeState = observedState,
+        afterState = observedState,
+        startedAtMs = 100L,
+        finishedAtMs = 200L,
+        summary = title,
+        displayWidth = 1080,
+        displayHeight = 2400,
+        evidenceComplete = observedState != null,
+        evidenceError = if (observedState == null) "xml_unavailable" else null,
     )
 
     private fun assertStateInput(

--- a/assists/src/test/java/cn/com/omnimind/assists/recording/ManualGestureRecognizerTest.kt
+++ b/assists/src/test/java/cn/com/omnimind/assists/recording/ManualGestureRecognizerTest.kt
@@ -1,5 +1,8 @@
 package cn.com.omnimind.assists.recording
 
+import cn.com.omnimind.assists.task.recording.canonicalManualScreenAction
+import cn.com.omnimind.assists.task.recording.isManualSystemBackGesture
+import cn.com.omnimind.baselib.runlog.ActionCoordinateCodec
 import cn.com.omnimind.baselib.runlog.OobActionSchema
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -43,6 +46,84 @@ class ManualGestureRecognizerTest {
     }
 
     @Test
+    fun horizontalTracesKeepLeftAndRightDirection() {
+        val left = ManualGestureRecognizer.recognize(
+            trace(durationMs = 240L, endX = 20f, endY = 104f),
+            overlayThresholds,
+        )
+        val right = ManualGestureRecognizer.recognize(
+            trace(durationMs = 240L, endX = 260f, endY = 96f),
+            overlayThresholds,
+        )
+
+        assertEquals("left", left?.direction)
+        assertEquals("right", right?.direction)
+    }
+
+    @Test
+    fun cancelledEdgeSwipeIsKept() {
+        val gesture = ManualGestureRecognizer.recognizeCancelledSwipe(
+            ManualPointerTrace(
+                startX = 1f,
+                startY = 600f,
+                endX = 280f,
+                endY = 604f,
+                startedAtMs = 1_000L,
+                finishedAtMs = 1_240L,
+            ),
+            overlayThresholds,
+        )
+
+        assertEquals(OobActionSchema.TOOL_SWIPE, gesture?.actionName)
+        assertEquals("right", gesture?.direction)
+    }
+
+    @Test
+    fun edgeBackSwipeSurvivesCanonicalCoordinateRoundTrip() {
+        val canonical = canonicalManualScreenAction(
+            tool = OobActionSchema.TOOL_SWIPE,
+            args = linkedMapOf(
+                OobActionSchema.ARG_X1 to 1f,
+                OobActionSchema.ARG_Y1 to 1_200f,
+                OobActionSchema.ARG_X2 to 320f,
+                OobActionSchema.ARG_Y2 to 1_204f,
+                OobActionSchema.ARG_DURATION_MS to 240L,
+                OobActionSchema.ARG_DIRECTION to "right",
+            ),
+            displayWidth = 1080,
+            displayHeight = 2400,
+        )
+        val replay = ActionCoordinateCodec.toScreenPixels(
+            canonical.args,
+            ActionCoordinateCodec.DisplaySize(1080.0, 2400.0),
+        )
+
+        assertEquals(1.0, (replay[OobActionSchema.ARG_X1] as Number).toDouble(), 0.001)
+        assertEquals(1_200.0, (replay[OobActionSchema.ARG_Y1] as Number).toDouble(), 0.001)
+        assertEquals(320.0, (replay[OobActionSchema.ARG_X2] as Number).toDouble(), 0.001)
+        assertEquals(1_204.0, (replay[OobActionSchema.ARG_Y2] as Number).toDouble(), 0.001)
+        assertEquals("right", replay[OobActionSchema.ARG_DIRECTION])
+    }
+
+    @Test
+    fun onlyInwardEdgeSwipesBecomeSystemBack() {
+        assertEquals(true, isManualSystemBackGesture(overlayGesture(1f, 320f, "right")))
+        assertEquals(true, isManualSystemBackGesture(overlayGesture(1_079f, 760f, "left")))
+        assertEquals(false, isManualSystemBackGesture(overlayGesture(300f, 700f, "right")))
+        assertEquals(false, isManualSystemBackGesture(overlayGesture(1f, 0f, "left")))
+    }
+
+    @Test
+    fun cancelledShortTouchIsNotRecorded() {
+        val gesture = ManualGestureRecognizer.recognizeCancelledSwipe(
+            trace(durationMs = 120L, endX = 108f, endY = 104f),
+            overlayThresholds,
+        )
+
+        assertNull(gesture)
+    }
+
+    @Test
     fun rawThresholdGapRejectsAmbiguousMotion() {
         val gesture = ManualGestureRecognizer.recognize(
             trace(durationMs = 300L, endX = 145f, endY = 100f),
@@ -73,5 +154,24 @@ class ManualGestureRecognizerTest {
         endY = endY,
         startedAtMs = 1_000L,
         finishedAtMs = 1_000L + durationMs,
+    )
+
+    private fun overlayGesture(
+        startX: Float,
+        endX: Float,
+        direction: String,
+    ) = cn.com.omnimind.assists.ManualOverlayTouchGesture(
+        actionName = OobActionSchema.TOOL_SWIPE,
+        startX = startX,
+        startY = 1_200f,
+        endX = endX,
+        endY = 1_204f,
+        durationMs = 240L,
+        distancePx = kotlin.math.abs(endX - startX),
+        direction = direction,
+        startedAtMs = 1_000L,
+        finishedAtMs = 1_240L,
+        displayWidth = 1080,
+        displayHeight = 2400,
     )
 }

--- a/assists/src/test/java/cn/com/omnimind/assists/task/recording/ManualRecordingEngineTest.kt
+++ b/assists/src/test/java/cn/com/omnimind/assists/task/recording/ManualRecordingEngineTest.kt
@@ -15,6 +15,14 @@ import org.junit.Test
 
 class ManualRecordingEngineTest {
     @Test
+    fun `manual back is a target independent canonical key`() {
+        assertEquals(
+            mapOf("key" to "back"),
+            manualPressKeyActionArgs("back", null),
+        )
+    }
+
+    @Test
     fun `manual enter keeps the selected input target`() {
         val target = ManualInputTarget(
             description = "搜索框",
@@ -126,7 +134,7 @@ class ManualRecordingEngineTest {
     }
 
     @Test
-    fun retriesUnchangedAfterStateUntilFreshXmlArrives() = runBlocking {
+    fun capturesAfterStateOnceWithoutBlockingForPageChanges() = runBlocking {
         val journal = ManualRecordingJournal()
         var afterAttempts = 0
         val engine = ManualRecordingEngine(
@@ -136,13 +144,7 @@ class ManualRecordingEngineTest {
                     observation("<page name=\"before\"/>")
                 } else {
                     afterAttempts += 1
-                    observation(
-                        if (afterAttempts < 3) {
-                            "<page name=\"before\"/>"
-                        } else {
-                            "<page name=\"after\"/>"
-                        },
-                    )
+                    observation("<page name=\"before\"/>")
                 }
             },
             execute = { AndroidGuiActionResult(true, "ok") },
@@ -151,8 +153,8 @@ class ManualRecordingEngineTest {
         val outcome = engine.perform(action("click", 100L))
 
         assertTrue(outcome.recorded)
-        assertEquals(3, afterAttempts)
-        assertEquals("<page name=\"after\"/>", journal.lastOrNull()?.afterXml)
+        assertEquals(1, afterAttempts)
+        assertEquals("<page name=\"before\"/>", journal.lastOrNull()?.afterXml)
     }
 
     @Test
@@ -176,7 +178,7 @@ class ManualRecordingEngineTest {
     }
 
     @Test
-    fun unchangedClickStateIsStillRecordedAfterRetries() = runBlocking {
+    fun unchangedClickStateIsRecordedWithoutRetries() = runBlocking {
         val journal = ManualRecordingJournal()
         var observationCount = 0
         val engine = ManualRecordingEngine(
@@ -191,7 +193,7 @@ class ManualRecordingEngineTest {
         val outcome = engine.perform(action("click", 100L))
 
         assertTrue(outcome.recorded)
-        assertEquals(6, observationCount)
+        assertEquals(2, observationCount)
         assertEquals("<page/>", journal.lastOrNull()?.afterXml)
     }
 

--- a/assists/src/test/java/cn/com/omnimind/assists/task/recording/ManualTraceRecorderTargetTest.kt
+++ b/assists/src/test/java/cn/com/omnimind/assists/task/recording/ManualTraceRecorderTargetTest.kt
@@ -6,22 +6,15 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ManualTraceRecorderTargetTest {
-    private val before = ManualInputTarget("old", 10f, 10f)
     private val clicked = ManualInputTarget("clicked", 20f, 20f)
 
     @Test
-    fun `clicked target wins when focus snapshot is temporarily unavailable`() {
-        assertEquals(clicked, selectManualInputTargetAfterClick(before, null, clicked))
+    fun `clicked input target is offered`() {
+        assertEquals(clicked, selectManualInputTargetAfterClick(clicked))
     }
 
     @Test
-    fun `new focused target is selected after click`() {
-        val after = ManualInputTarget("new", 30f, 30f)
-        assertEquals(after, selectManualInputTargetAfterClick(before, after, null))
-    }
-
-    @Test
-    fun `unchanged focus is not recorded as input target`() {
-        assertNull(selectManualInputTargetAfterClick(before, before, null))
+    fun `click outside input does not reuse stale focus after popup is closed`() {
+        assertNull(selectManualInputTargetAfterClick(null))
     }
 }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/runlog/InternalRunLogStore.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/runlog/InternalRunLogStore.kt
@@ -521,12 +521,14 @@ object InternalRunLogStore {
         val beforeState = statePayload(context, beforeStateId)
         val payload = linkedMapOf<String, Any?>(
             "step_index" to (numberToLong(step["step_index"]) ?: 0L).toInt(),
+            "before_state_id" to beforeStateId,
             "observation" to externalStatePayload(context, beforeStateId),
             "action" to externalActionPayload(
                 action = stringMap(step["action"]),
                 display = stringMap(beforeState["display"]),
             ),
             "result" to externalResultPayload(stringMap(step["result"])),
+            "after_state_id" to afterStateId,
             "next_observation" to externalStatePayload(context, afterStateId),
         )
         stringMap(step["metadata"]).takeIf { it.isNotEmpty() }?.let {

--- a/omniflow-android/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlow.kt
+++ b/omniflow-android/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlow.kt
@@ -287,7 +287,6 @@ object OmniFlow {
         "list_run_logs",
         "get_run_log",
         "get_run_log_state",
-        "convert_run_log",
         "save_function",
     )
 }
@@ -651,7 +650,7 @@ class OmniFlowDeviceDispatcher internal constructor(
         actions.forEach { rawAction ->
             val action = rawAction.entries.associate { (key, value) -> key.toString() to value }
             val name = firstText(action["name"])
-            if (name != "convert_run_log") return@forEach
+            if (name != "save_function") return@forEach
             val arguments = mapValue(action["arguments"])
             val registration = runCatching {
                 call(

--- a/omniflow-android/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowDeveloperOverride.kt
+++ b/omniflow-android/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlowDeveloperOverride.kt
@@ -80,10 +80,12 @@ internal class OmniFlowDeveloperOverrideStore(
 
     private fun ensureBase(basePythonRoot: File, runtimeVersion: String) {
         val sourcePackage = File(basePythonRoot, "omniflow")
+        val sourceSchemas = File(basePythonRoot, "schemas")
         require(sourcePackage.isDirectory) { "omniflow_override_base_missing" }
         if (
             packageRoot.isDirectory &&
-            versionFile.takeIf(File::isFile)?.readText()?.trim() == runtimeVersion
+            versionFile.takeIf(File::isFile)?.readText()?.trim() == runtimeVersion &&
+            (!sourceSchemas.isDirectory || File(pythonRoot, "schemas").isDirectory)
         ) {
             return
         }
@@ -95,6 +97,14 @@ internal class OmniFlowDeveloperOverrideStore(
         val temporaryPackage = File(temporary, "python/omniflow")
         require(sourcePackage.copyRecursively(temporaryPackage, overwrite = true)) {
             "omniflow_override_base_copy_failed"
+        }
+        if (sourceSchemas.isDirectory) {
+            require(
+                sourceSchemas.copyRecursively(
+                    File(temporary, "python/schemas"),
+                    overwrite = true,
+                ),
+            ) { "omniflow_override_schema_copy_failed" }
         }
         preserved.forEach { (path, bytes) ->
             bytes ?: return@forEach

--- a/omniflow-android/src/test/java/cn/com/omnimind/bot/omniflow/OmniFlowDeveloperOverrideTest.kt
+++ b/omniflow-android/src/test/java/cn/com/omnimind/bot/omniflow/OmniFlowDeveloperOverrideTest.kt
@@ -32,12 +32,21 @@ class OmniFlowDeveloperOverrideTest {
             parentFile.mkdirs()
             writeText("ENGINE = 'stable'\n")
         }
+        base.resolve("schemas/oob/oob_canonical_actions.v1.json").apply {
+            parentFile.mkdirs()
+            writeText("{\"tools\":[]}")
+        }
         val store = OmniFlowDeveloperOverrideStore(temporary.resolve("override"))
 
         store.apply(base, "runtime-v1", "vlm/planner.py", "VALUE = 'edited'\n")
 
         assertEquals("VALUE = 'edited'\n", store.read("vlm/planner.py"))
         assertEquals("ENGINE = 'stable'\n", store.read("runtime/engine.py"))
+        assertEquals(
+            "{\"tools\":[]}",
+            temporary.resolve("override/python/schemas/oob/oob_canonical_actions.v1.json")
+                .readText(),
+        )
         assertEquals(listOf("omniflow/vlm/planner.py"), store.status("runtime-v1").modifiedFiles)
         assertTrue(store.clear())
         assertFalse(store.status("runtime-v1").enabled)

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -20,6 +20,7 @@ import '../../widgets/home_drawer.dart';
 import '../authorize/authorize_page_args.dart';
 import '../command_overlay/widgets/chat_input_area.dart';
 import '../command_overlay/services/manual_recording_flow_controller.dart';
+import '../command_overlay/services/manual_recording_result_card.dart';
 import '../command_overlay/services/tool_card_detail_gesture_gate.dart';
 import '../common/openclaw_connection_checker.dart';
 import '../omnibot_workspace/widgets/omnibot_workspace_browser.dart';
@@ -180,6 +181,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   SharedOpenDraftPayload? _stagedSharedOpenDraft;
   int? _stagedSharedOpenDraftExpiresAt;
   int _conversationTargetRequestId = 0;
+  final Set<String> _consumedInitialMessageRequests = <String>{};
 
   // OpenClaw 配置与开关
   bool _openClawEnabled = false;

--- a/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_conversation_flow.dart
@@ -488,7 +488,21 @@ mixin _ChatPageConversationFlowMixin on _ChatPageStateBase {
             : ((result['error_message'] ?? '').toString().trim().isEmpty
                   ? '手动录制失败'
                   : '手动录制失败：${result['error_message']}');
-        updateOrAddAiMessage(messageId, text, !succeeded);
+        final card = buildManualRecordingResultCard(
+          messageId: messageId,
+          result: result,
+          summary: text,
+        );
+        final index = _messages.indexWhere(
+          (message) => message.id == messageId,
+        );
+        setState(() {
+          if (index == -1) {
+            _messages.insert(0, card);
+          } else {
+            _messages[index] = card;
+          }
+        });
         unawaited(saveConversation());
       },
       onFinally: () async {

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -272,12 +272,28 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     }
     await _applyStagedSharedDraftIfNeeded(effectiveTarget);
     if (isStaleRequest()) return;
+    await _sendInitialMessageIfNeeded(effectiveTarget);
+    if (isStaleRequest()) return;
     await _persistVisibleThreadTargetIfNeeded();
     unawaited(_syncVisibleChatConversation());
     if (isStaleRequest()) return;
     if (syncPage) {
       _jumpToCurrentModePage(animate: false);
     }
+  }
+
+  Future<void> _sendInitialMessageIfNeeded(
+    ConversationThreadTarget target,
+  ) async {
+    final message = target.initialMessage?.trim() ?? '';
+    if (!target.isNewConversation ||
+        target.mode != ConversationMode.agent ||
+        message.isEmpty) {
+      return;
+    }
+    final requestKey = target.requestKey ?? message;
+    if (!_consumedInitialMessageRequests.add(requestKey)) return;
+    await _sendMessage(text: message);
   }
 
   void _restoreLocalAgentThreadIdFromTarget(ConversationThreadTarget target) {

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -15,6 +15,7 @@ import 'package:ui/services/agent_stream_meta.dart';
 import 'package:ui/features/home/pages/command_overlay/services/chat_service.dart';
 import 'package:ui/features/home/pages/command_overlay/constants/messages.dart';
 import 'package:ui/features/home/pages/command_overlay/services/manual_recording_flow_controller.dart';
+import 'package:ui/features/home/pages/command_overlay/services/manual_recording_result_card.dart';
 import 'package:ui/features/home/pages/command_overlay/utils/deep_thinking_parser.dart';
 import 'package:ui/features/home/pages/chat/utils/agent_run_timeline.dart';
 import 'package:ui/features/home/pages/chat/utils/stream_text_merge.dart';
@@ -1684,25 +1685,16 @@ class _ChatBotSheetState extends State<ChatBotSheet>
           (message) => message.id == messageId,
         );
         final text = _manualRecordingResultText(result);
+        final card = buildManualRecordingResultCard(
+          messageId: messageId,
+          result: result,
+          summary: text,
+        );
         setState(() {
-          final content = <String, dynamic>{'text': text, 'id': messageId};
           if (index == -1) {
-            _messages.insert(
-              0,
-              ChatMessageModel(
-                id: messageId,
-                type: 1,
-                user: 2,
-                content: content,
-                isError: result['success'] != true,
-              ),
-            );
+            _messages.insert(0, card);
           } else {
-            _messages[index] = _messages[index].copyWith(
-              content: content,
-              isLoading: false,
-              isError: result['success'] != true,
-            );
+            _messages[index] = card;
           }
         });
         unawaited(_saveConversationToDb(markComplete: true));

--- a/ui/lib/features/home/pages/command_overlay/services/manual_recording_result_card.dart
+++ b/ui/lib/features/home/pages/command_overlay/services/manual_recording_result_card.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:ui/models/chat_message_model.dart';
+import 'package:ui/services/agent_message_kinds.dart';
+
+ChatMessageModel buildManualRecordingResultCard({
+  required String messageId,
+  required Map<String, dynamic> result,
+  required String summary,
+}) {
+  final succeeded = result['success'] == true;
+  final runLog = _map(result['run_log']);
+  final runId = (runLog['run_id'] ?? '').toString().trim();
+  final function = _map(result['function']);
+  final functionId = (function['function_id'] ?? '').toString().trim();
+  final payload = <String, dynamic>{
+    'context_type': 'manual_recording_result',
+    'success': succeeded,
+    'status': succeeded ? 'succeeded' : 'failed',
+    'content': summary,
+    'run_id': runId,
+    'action_count': _list(runLog['steps']).length,
+    if (functionId.isNotEmpty) ...{
+      'auto_registered': true,
+      'registered_function_id': functionId,
+    },
+  };
+  final cardData = <String, dynamic>{
+    'type': kAgentToolSummaryCardType,
+    'uiStyle': kAgentToolUiStyle,
+    'cardId': messageId,
+    'toolName': 'vlm_task',
+    'toolTitle': '手动录制',
+    'displayName': '手动录制',
+    'toolType': 'builtin',
+    'status': succeeded ? 'success' : 'error',
+    'summary': summary,
+    'success': succeeded,
+    'resultPreviewJson': jsonEncode(payload),
+    'rawResultJson': jsonEncode(result),
+  };
+  return ChatMessageModel(
+    id: messageId,
+    type: 2,
+    user: 3,
+    content: {'cardData': cardData, 'id': messageId},
+    isError: !succeeded,
+  );
+}
+
+Map<String, dynamic> _map(Object? value) => value is Map
+    ? value.map((key, item) => MapEntry(key.toString(), item))
+    : const {};
+
+List<Map<String, dynamic>> _list(Object? value) =>
+    value is List ? value.whereType<Map>().map(_map).toList() : const [];

--- a/ui/lib/features/home/pages/command_overlay/widgets/cards/agent_tool_summary_card.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/cards/agent_tool_summary_card.dart
@@ -376,6 +376,10 @@ class _VlmTaskResultCard extends StatelessWidget {
         .toString()
         .trim();
     final autoRegistered = payload['auto_registered'] == true;
+    final registeredFunctionId = _firstNonEmptyVlmValue([
+      payload['registered_function_id'],
+      payload['function_id'],
+    ]);
     final registrationHint = (payload['registration_hint'] ?? '')
         .toString()
         .trim();
@@ -469,7 +473,12 @@ class _VlmTaskResultCard extends StatelessWidget {
                       key: const ValueKey('vlm-task-open-functions'),
                       onPressed: () => context.push(
                         autoRegistered || runId.isEmpty
-                            ? '/task/omniflow'
+                            ? Uri(
+                                path: '/task/omniflow',
+                                queryParameters: registeredFunctionId.isEmpty
+                                    ? null
+                                    : {'functionId': registeredFunctionId},
+                              ).toString()
                             : '/task/run_log/$runId',
                       ),
                       icon: const Icon(LucideIcons.workflow, size: 15),

--- a/ui/lib/features/task/pages/execution_history/omniflow_execution_center_page.dart
+++ b/ui/lib/features/task/pages/execution_history/omniflow_execution_center_page.dart
@@ -7,17 +7,32 @@ import 'package:go_router/go_router.dart';
 import 'package:ui/features/task/pages/execution_history/widgets/function_detail_sheet.dart';
 import 'package:ui/features/task/run_log/run_log_metrics.dart';
 import 'package:ui/features/task/run_log/omniflow_tool_client.dart';
+import 'package:ui/models/conversation_model.dart';
+import 'package:ui/models/conversation_thread_target.dart';
 import 'package:ui/models/omni_plugin_item.dart';
 import 'package:ui/services/omni_plugin_service.dart';
 
 class OmniFlowExecutionCenterPage extends StatefulWidget {
-  const OmniFlowExecutionCenterPage({super.key, this.initialTab});
+  const OmniFlowExecutionCenterPage({
+    super.key,
+    this.initialTab,
+    this.initialFunctionId,
+  });
 
   final String? initialTab;
+  final String? initialFunctionId;
 
   @override
   State<OmniFlowExecutionCenterPage> createState() =>
       _OmniFlowExecutionCenterPageState();
+}
+
+@visibleForTesting
+String buildFunctionEnhancementPrompt(Map<String, dynamic> function) {
+  final functionId = _string(function['function_id']);
+  return '请增强下面的 OmniFlow 复用指令。先用 get_function 读取完整内容，分析参数化、稳定性和可复用性，再通过 OmniFlow 工具保存更新；不要执行该指令。\n\n'
+      'function_id: $functionId\n'
+      '当前信息：${jsonEncode(function)}';
 }
 
 class _OmniFlowExecutionCenterPageState
@@ -42,6 +57,8 @@ class _OmniFlowExecutionCenterPageState
   bool _runLogsHasMore = false;
   int _runLogsNextOffset = 0;
   String? _runLogsError;
+  bool _initialFunctionOpened = false;
+  final Set<String> _registeringRunIds = <String>{};
 
   bool get _ready => _plugin?.installed == true && _plugin?.enabled == true;
 
@@ -109,15 +126,20 @@ class _OmniFlowExecutionCenterPageState
     if (!_ready) return;
     if (_tabController.index == 0) {
       if (!_functionsLoaded) await _loadFunctions(reset: true);
-    } else if (!_runLogsLoaded) {
-      await _loadRunLogs(reset: true);
+    } else {
+      await Future.wait([
+        if (!_runLogsLoaded) _loadRunLogs(reset: true),
+        if (!_functionsLoaded) _loadFunctions(reset: true),
+      ]);
     }
   }
 
   Future<void> _loadActive({required bool reset}) {
-    return _tabController.index == 0
-        ? _loadFunctions(reset: reset)
-        : _loadRunLogs(reset: reset);
+    if (_tabController.index == 0) return _loadFunctions(reset: reset);
+    return Future.wait([
+      _loadRunLogs(reset: reset),
+      _loadFunctions(reset: reset),
+    ]).then((_) {});
   }
 
   Future<void> _loadFunctions({required bool reset}) async {
@@ -147,6 +169,7 @@ class _OmniFlowExecutionCenterPageState
           fallback: offset + items.length,
         );
       });
+      _openInitialFunctionIfAvailable();
     } catch (error) {
       if (!mounted) return;
       setState(() {
@@ -155,6 +178,21 @@ class _OmniFlowExecutionCenterPageState
         _functionsError = error.toString();
       });
     }
+  }
+
+  void _openInitialFunctionIfAvailable() {
+    if (_initialFunctionOpened || !mounted) return;
+    final functionId = widget.initialFunctionId?.trim() ?? '';
+    if (functionId.isEmpty) return;
+    final function = _functions.cast<Map<String, dynamic>?>().firstWhere(
+      (item) => _string(item?['function_id']) == functionId,
+      orElse: () => null,
+    );
+    if (function == null) return;
+    _initialFunctionOpened = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(_showFunctionDetails(function));
+    });
   }
 
   Future<void> _loadRunLogs({required bool reset}) async {
@@ -210,7 +248,10 @@ class _OmniFlowExecutionCenterPageState
     }
   }
 
-  Future<void> _showFunctionDetails(Map<String, dynamic> function) {
+  Future<void> _showFunctionDetails(
+    Map<String, dynamic> function, {
+    bool refreshOnOpen = true,
+  }) {
     return showModalBottomSheet<void>(
       context: context,
       useRootNavigator: true,
@@ -223,6 +264,7 @@ class _OmniFlowExecutionCenterPageState
         onReplay: _replay,
         onEnhance: _enhanceFunction,
         onDelete: _deleteFunction,
+        refreshOnOpen: refreshOnOpen,
       ),
     );
   }
@@ -230,59 +272,15 @@ class _OmniFlowExecutionCenterPageState
   Future<void> _enhanceFunction(Map<String, dynamic> function) async {
     final functionId = _string(function['function_id']);
     if (functionId.isEmpty) return;
-    final instruction = await _collectEnhancementInstruction();
-    if (instruction == null || !mounted) return;
-    final sourceRunId = _string(
-      function['source_run_id'] ?? function['run_id'],
-    ).nullIfEmpty;
-    await _runAction(
-      () => OmniFlowToolClient.enhanceFunction(
-        functionId,
-        runId: sourceRunId,
-        instruction: instruction,
-      ),
-      success: _text(context, '复用指令已增强', 'Function enhanced'),
-      reload: true,
-    );
-  }
-
-  Future<String?> _collectEnhancementInstruction() {
-    var instruction = '';
-    return showDialog<String>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text(_text(context, '增强复用指令', 'Enhance Function')),
-        content: TextField(
-          key: const ValueKey('function-enhancement-instruction'),
-          autofocus: true,
-          minLines: 2,
-          maxLines: 5,
-          maxLength: 2000,
-          onChanged: (value) => instruction = value,
-          decoration: InputDecoration(
-            hintText: _text(
-              context,
-              '可选：例如“把搜索内容设为参数”或“优先使用搜索框”',
-              'Optional: for example, “make the search text a parameter”',
-            ),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext),
-            child: Text(_text(context, '取消', 'Cancel')),
-          ),
-          TextButton(
-            key: const ValueKey('function-enhancement-default'),
-            onPressed: () => Navigator.pop(dialogContext, ''),
-            child: Text(_text(context, '默认增强', 'Default')),
-          ),
-          FilledButton(
-            key: const ValueKey('function-enhancement-submit'),
-            onPressed: () => Navigator.pop(dialogContext, instruction.trim()),
-            child: Text(_text(context, '增强', 'Enhance')),
-          ),
-        ],
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    final requestKey = DateTime.now().microsecondsSinceEpoch.toString();
+    context.push(
+      '/home/chat',
+      extra: ConversationThreadTarget.newConversation(
+        mode: ConversationMode.agent,
+        requestKey: requestKey,
+        initialMessage: buildFunctionEnhancementPrompt(function),
       ),
     );
   }
@@ -417,15 +415,53 @@ class _OmniFlowExecutionCenterPageState
     );
   }
 
-  Future<void> _convertRunLog(Map<String, dynamic> runLog) async {
+  Future<void> _saveFunctionFromRunLog(Map<String, dynamic> runLog) async {
     final runId = _string(runLog['run_id']);
-    if (runId.isEmpty) return;
-    _functionsLoaded = false;
-    await _runAction(
-      () => OmniFlowToolClient.convertRunLog(runId),
-      success: _text(context, '已注册为复用指令', 'Function registered'),
-      reload: true,
-    );
+    if (runId.isEmpty || _registeringRunIds.contains(runId)) return;
+    setState(() => _registeringRunIds.add(runId));
+    try {
+      final registration = await OmniFlowToolClient.registerFunctionFromRunLog(
+        runId,
+      );
+      if (!mounted) return;
+      if (!registration.success) {
+        throw StateError(
+          registration.errorMessage ??
+              _text(context, '注册失败', 'Registration failed'),
+        );
+      }
+      final function = <String, dynamic>{
+        'name':
+            _string(runLog['goal']).nullIfEmpty ??
+            _text(context, '未命名复用指令', 'Unnamed Function'),
+        'description': _string(runLog['goal']),
+        ...registration.function!,
+      };
+      setState(() {
+        _functions = _mergeById(
+          <Map<String, dynamic>>[function],
+          _functions,
+          idKey: 'function_id',
+        );
+        _functionsLoaded = true;
+      });
+      _tabController.animateTo(0);
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+      await _showFunctionDetails(function, refreshOnOpen: false);
+      if (mounted) unawaited(_loadFunctions(reset: true));
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            error is StateError ? error.message.toString() : error.toString(),
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _registeringRunIds.remove(runId));
+    }
   }
 
   Future<void> _runAction(
@@ -542,12 +578,15 @@ class _OmniFlowExecutionCenterPageState
         ),
         _RunLogsTab(
           runLogs: _runLogs,
+          functions: _functions,
           loading: _runLogsLoading,
           error: _runLogsError,
           hasMore: _runLogsHasMore,
           onRefresh: () => _loadRunLogs(reset: true),
           onLoadMore: () => _loadRunLogs(reset: false),
-          onConvert: _convertRunLog,
+          onConvert: _saveFunctionFromRunLog,
+          onOpenFunction: _showFunctionDetails,
+          registeringRunIds: _registeringRunIds,
         ),
       ],
     );
@@ -712,21 +751,27 @@ class _FunctionListItem extends StatelessWidget {
 class _RunLogsTab extends StatelessWidget {
   const _RunLogsTab({
     required this.runLogs,
+    required this.functions,
     required this.loading,
     required this.error,
     required this.hasMore,
     required this.onRefresh,
     required this.onLoadMore,
     required this.onConvert,
+    required this.onOpenFunction,
+    required this.registeringRunIds,
   });
 
   final List<Map<String, dynamic>> runLogs;
+  final List<Map<String, dynamic>> functions;
   final bool loading;
   final String? error;
   final bool hasMore;
   final AsyncCallback onRefresh;
   final AsyncCallback onLoadMore;
   final ValueChanged<Map<String, dynamic>> onConvert;
+  final ValueChanged<Map<String, dynamic>> onOpenFunction;
+  final Set<String> registeringRunIds;
 
   @override
   Widget build(BuildContext context) {
@@ -769,11 +814,17 @@ class _RunLogsTab extends StatelessWidget {
             );
           }
           final runLog = runLogs[index];
+          final linkedFunction = _linkedFunction(runLog, functions);
           return _RunLogListItem(
             runLog: runLog,
             onOpen: () =>
                 context.push('/task/run_log/${_string(runLog['run_id'])}'),
             onConvert: () => onConvert(runLog),
+            linkedFunction: linkedFunction,
+            registering: registeringRunIds.contains(_string(runLog['run_id'])),
+            onOpenFunction: linkedFunction == null
+                ? null
+                : () => onOpenFunction(linkedFunction),
           );
         },
       ),
@@ -786,11 +837,17 @@ class _RunLogListItem extends StatelessWidget {
     required this.runLog,
     required this.onOpen,
     required this.onConvert,
+    required this.linkedFunction,
+    required this.onOpenFunction,
+    required this.registering,
   });
 
   final Map<String, dynamic> runLog;
   final VoidCallback onOpen;
   final VoidCallback onConvert;
+  final Map<String, dynamic>? linkedFunction;
+  final VoidCallback? onOpenFunction;
+  final bool registering;
 
   @override
   Widget build(BuildContext context) {
@@ -878,8 +935,33 @@ class _RunLogListItem extends StatelessWidget {
                     ),
                   ),
                   TextButton(
-                    onPressed: onConvert,
-                    child: Text(_text(context, '注册为复用指令', 'Register Function')),
+                    key: ValueKey(
+                      linkedFunction == null
+                          ? 'run-log-register-$runId'
+                          : 'run-log-function-$runId',
+                    ),
+                    onPressed: registering
+                        ? null
+                        : (onOpenFunction ?? onConvert),
+                    child: registering
+                        ? Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const SizedBox.square(
+                                dimension: 14,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              ),
+                              const SizedBox(width: 7),
+                              Text(_text(context, '注册中', 'Registering')),
+                            ],
+                          )
+                        : Text(
+                            linkedFunction == null
+                                ? _text(context, '注册为复用指令', 'Register Function')
+                                : _text(context, '查看复用指令', 'View Function'),
+                          ),
                   ),
                   Icon(
                     Icons.chevron_right_rounded,
@@ -894,6 +976,22 @@ class _RunLogListItem extends StatelessWidget {
       ),
     );
   }
+}
+
+Map<String, dynamic>? _linkedFunction(
+  Map<String, dynamic> runLog,
+  List<Map<String, dynamic>> functions,
+) {
+  final runId = _string(runLog['run_id']);
+  final executedFunctionId = _string(runLog['function_id']);
+  for (final function in functions) {
+    final functionId = _string(function['function_id']);
+    if ((executedFunctionId.isNotEmpty && functionId == executedFunctionId) ||
+        (runId.isNotEmpty && _string(function['source_run_id']) == runId)) {
+      return function;
+    }
+  }
+  return null;
 }
 
 class _LoadMoreRow extends StatelessWidget {

--- a/ui/lib/features/task/pages/execution_history/run_log_detail_page.dart
+++ b/ui/lib/features/task/pages/execution_history/run_log_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ui/features/task/pages/execution_history/widgets/run_log_timeline_components.dart';
 import 'package:ui/features/task/run_log/omniflow_tool_client.dart';
 import 'package:ui/features/task/run_log/run_log_metrics.dart';
@@ -20,6 +21,8 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
   bool _loading = true;
   bool _converting = false;
   String? _error;
+  String? _functionId;
+  String? _functionName;
 
   @override
   void initState() {
@@ -33,10 +36,18 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
       _error = null;
     });
     try {
-      final runLog = await OmniFlowToolClient.getRunLog(widget.runId);
+      final results = await Future.wait([
+        OmniFlowToolClient.getRunLog(widget.runId),
+        OmniFlowToolClient.listFunctions(),
+      ]);
+      final runLog = results[0];
+      final functions = _mapList(results[1]['functions']);
+      final linkedFunction = _linkedFunction(runLog, functions);
       if (!mounted) return;
       setState(() {
         _runLog = runLog;
+        _functionId = linkedFunction?['function_id']?.toString();
+        _functionName = linkedFunction?['name']?.toString();
         _loading = false;
       });
     } catch (error) {
@@ -52,30 +63,47 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
     if (_converting) return;
     setState(() => _converting = true);
     try {
-      final result = await OmniFlowToolClient.convertRunLog(widget.runId);
-      if (!mounted) return;
-      final success = result['success'] != false;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            success
-                ? _text(context, '已注册为复用指令', 'Function registered')
-                : (result['error_message']?.toString() ?? 'Conversion failed'),
-          ),
-        ),
+      final registration = await OmniFlowToolClient.registerFunctionFromRunLog(
+        widget.runId,
       );
+      if (!mounted) return;
+      if (!registration.success) {
+        throw StateError(registration.errorMessage ?? '注册失败');
+      }
+      final function = registration.function!;
+      final functionId = registration.functionId;
+      setState(() {
+        _functionId = functionId;
+        _functionName = function['name']?.toString();
+      });
+      _openFunction(functionId);
     } catch (error) {
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(error.toString())));
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              error is StateError ? error.message.toString() : error.toString(),
+            ),
+          ),
+        );
       }
     } finally {
       if (mounted) setState(() => _converting = false);
     }
   }
 
-  Future<void> _showState(String stateId) async {
+  void _openFunction([String? functionId]) {
+    final resolved = (functionId ?? _functionId)?.trim() ?? '';
+    if (resolved.isEmpty) return;
+    context.push(
+      Uri(
+        path: '/task/omniflow',
+        queryParameters: {'functionId': resolved},
+      ).toString(),
+    );
+  }
+
+  Future<void> _showState(String stateId, Map<String, dynamic> action) async {
     if (stateId.isEmpty) return;
     try {
       final state = await OmniFlowToolClient.getRunLogState(stateId);
@@ -83,7 +111,7 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
       await showModalBottomSheet<void>(
         context: context,
         isScrollControlled: true,
-        builder: (context) => _StateSheet(state: state),
+        builder: (context) => _StateSheet(state: state, action: action),
       );
     } catch (error) {
       if (mounted) {
@@ -130,14 +158,31 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
       floatingActionButton: _runLog == null
           ? null
           : FloatingActionButton.extended(
-              onPressed: _converting ? null : _convert,
+              key: ValueKey(
+                _functionId?.isNotEmpty == true
+                    ? 'run-log-view-function'
+                    : 'run-log-register-function',
+              ),
+              onPressed: _converting
+                  ? null
+                  : (_functionId?.isNotEmpty == true
+                        ? _openFunction
+                        : _convert),
               icon: _converting
                   ? const SizedBox.square(
                       dimension: 18,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : const Icon(Icons.add_task_rounded),
-              label: Text(_text(context, '注册为复用指令', 'Register Function')),
+                  : Icon(
+                      _functionId?.isNotEmpty == true
+                          ? Icons.account_tree_outlined
+                          : Icons.add_task_rounded,
+                    ),
+              label: Text(
+                _functionId?.isNotEmpty == true
+                    ? _text(context, '查看复用指令', 'View Function')
+                    : _text(context, '注册为复用指令', 'Register Function'),
+              ),
             ),
       body: _buildBody(),
     );
@@ -166,6 +211,23 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
           metrics: metrics,
           stepCount: steps.length,
         ),
+        if (_functionId?.isNotEmpty == true) ...[
+          const SizedBox(height: 10),
+          ListTile(
+            key: const ValueKey('run-log-linked-function'),
+            contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+            leading: const Icon(Icons.account_tree_outlined),
+            title: Text(_text(context, '对应复用指令', 'Linked Function')),
+            subtitle: Text(
+              (_functionName?.trim().isNotEmpty == true
+                      ? _functionName
+                      : _functionId) ??
+                  '',
+            ),
+            trailing: const Icon(Icons.chevron_right_rounded),
+            onTap: _openFunction,
+          ),
+        ],
         const SizedBox(height: 14),
         if (steps.isEmpty)
           Text(_text(context, '没有可显示的步骤', 'No steps to display'))
@@ -187,10 +249,28 @@ class _RunLogDetailPageState extends State<RunLogDetailPage> {
   }
 }
 
+Map<String, dynamic>? _linkedFunction(
+  Map<String, dynamic> runLog,
+  List<Map<String, dynamic>> functions,
+) {
+  final runId = runLog['run_id']?.toString().trim() ?? '';
+  final executedFunctionId = runLog['function_id']?.toString().trim() ?? '';
+  for (final function in functions) {
+    final functionId = function['function_id']?.toString().trim() ?? '';
+    final sourceRunId = function['source_run_id']?.toString().trim() ?? '';
+    if ((executedFunctionId.isNotEmpty && functionId == executedFunctionId) ||
+        (runId.isNotEmpty && sourceRunId == runId)) {
+      return function;
+    }
+  }
+  return null;
+}
+
 class _StateSheet extends StatelessWidget {
-  const _StateSheet({required this.state});
+  const _StateSheet({required this.state, required this.action});
 
   final Map<String, dynamic> state;
+  final Map<String, dynamic> action;
 
   @override
   Widget build(BuildContext context) {
@@ -214,7 +294,23 @@ class _StateSheet extends StatelessWidget {
             if (screenshotPath.isNotEmpty && screenshot.existsSync())
               ClipRRect(
                 borderRadius: BorderRadius.circular(12),
-                child: Image.file(screenshot),
+                child: LayoutBuilder(
+                  builder: (context, constraints) => Stack(
+                    children: [
+                      Image.file(screenshot),
+                      if (_actionPoint(action) case final point?)
+                        Positioned(
+                          left: point.$1 - 10,
+                          top: point.$2 - 10,
+                          child: const Icon(
+                            Icons.my_location_rounded,
+                            color: Colors.redAccent,
+                            size: 22,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
               )
             else
               Text(_text(context, '状态截图不可用', 'State screenshot unavailable')),
@@ -228,6 +324,14 @@ class _StateSheet extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  (double, double)? _actionPoint(Map<String, dynamic> action) {
+    final args = (action['args'] as Map?)?.cast<String, dynamic>() ?? {};
+    final x = double.tryParse('${args['x'] ?? ''}');
+    final y = double.tryParse('${args['y'] ?? ''}');
+    if (x == null || y == null) return null;
+    return (x, y);
   }
 }
 

--- a/ui/lib/features/task/pages/execution_history/widgets/function_detail_sheet.dart
+++ b/ui/lib/features/task/pages/execution_history/widgets/function_detail_sheet.dart
@@ -12,6 +12,7 @@ class FunctionDetailSheet extends StatefulWidget {
     required this.onReplay,
     required this.onEnhance,
     required this.onDelete,
+    this.refreshOnOpen = true,
   });
 
   final Map<String, dynamic> initialFunction;
@@ -19,6 +20,7 @@ class FunctionDetailSheet extends StatefulWidget {
   final ValueChanged<Map<String, dynamic>> onReplay;
   final ValueChanged<Map<String, dynamic>> onEnhance;
   final ValueChanged<Map<String, dynamic>> onDelete;
+  final bool refreshOnOpen;
 
   @override
   State<FunctionDetailSheet> createState() => _FunctionDetailSheetState();
@@ -33,7 +35,11 @@ class _FunctionDetailSheetState extends State<FunctionDetailSheet> {
   void initState() {
     super.initState();
     _function = Map<String, dynamic>.from(widget.initialFunction);
-    unawaited(_load());
+    if (widget.refreshOnOpen) {
+      unawaited(_load());
+    } else {
+      _loading = false;
+    }
   }
 
   Future<void> _load() async {
@@ -250,30 +256,35 @@ class _FunctionDetailSheetState extends State<FunctionDetailSheet> {
                 padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
                 child: Row(
                   children: [
-                    OutlinedButton.icon(
+                    IconButton.outlined(
+                      key: const ValueKey('function-detail-delete'),
                       onPressed: functionId.isEmpty
                           ? null
                           : () => _closeAndRun(widget.onDelete),
+                      tooltip: _text(context, '删除', 'Delete'),
                       icon: const Icon(Icons.delete_outline_rounded, size: 18),
-                      label: Text(_text(context, '删除', 'Delete')),
                     ),
                     const SizedBox(width: 8),
-                    OutlinedButton.icon(
-                      key: const ValueKey('function-detail-enhance'),
-                      onPressed: functionId.isEmpty
-                          ? null
-                          : () => _closeAndRun(widget.onEnhance),
-                      icon: const Icon(Icons.auto_fix_high_rounded, size: 18),
-                      label: Text(_text(context, '增强', 'Enhance')),
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        key: const ValueKey('function-detail-enhance'),
+                        onPressed: functionId.isEmpty
+                            ? null
+                            : () => _closeAndRun(widget.onEnhance),
+                        icon: const Icon(Icons.auto_fix_high_rounded, size: 18),
+                        label: Text(_text(context, '增强', 'Enhance')),
+                      ),
                     ),
-                    const Spacer(),
-                    FilledButton.icon(
-                      key: const ValueKey('function-detail-run'),
-                      onPressed: functionId.isEmpty
-                          ? null
-                          : () => _closeAndRun(widget.onReplay),
-                      icon: const Icon(Icons.play_arrow_rounded, size: 19),
-                      label: Text(_text(context, '执行', 'Run')),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: FilledButton.icon(
+                        key: const ValueKey('function-detail-run'),
+                        onPressed: functionId.isEmpty
+                            ? null
+                            : () => _closeAndRun(widget.onReplay),
+                        icon: const Icon(Icons.play_arrow_rounded, size: 19),
+                        label: Text(_text(context, '执行', 'Run')),
+                      ),
                     ),
                   ],
                 ),

--- a/ui/lib/features/task/pages/execution_history/widgets/run_log_timeline_components.dart
+++ b/ui/lib/features/task/pages/execution_history/widgets/run_log_timeline_components.dart
@@ -342,7 +342,8 @@ class RunLogStepDetailSheet extends StatelessWidget {
   final Map<String, dynamic> step;
   final int fallbackIndex;
   final RunLogTokenUsage? tokenUsage;
-  final Future<void> Function(String stateId) onShowState;
+  final Future<void> Function(String stateId, Map<String, dynamic> action)
+  onShowState;
 
   @override
   Widget build(BuildContext context) {
@@ -430,6 +431,37 @@ class RunLogStepDetailSheet extends StatelessWidget {
                   controller: controller,
                   padding: const EdgeInsets.fromLTRB(16, 14, 16, 24),
                   children: [
+                    if (beforeStateId.isNotEmpty ||
+                        afterStateId.isNotEmpty) ...[
+                      Text(
+                        _text(context, '动作证据', 'Action evidence'),
+                        style: TextStyle(
+                          color: palette.textSecondary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          OutlinedButton.icon(
+                            onPressed: () => onShowState(
+                              beforeStateId.isNotEmpty
+                                  ? beforeStateId
+                                  : afterStateId,
+                              action,
+                            ),
+                            icon: const Icon(Icons.image_outlined, size: 17),
+                            label: Text(
+                              _text(context, '动作截图', 'Action screenshot'),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                    ],
                     if (summary.isNotEmpty) ...[
                       Text(
                         _text(context, '决策', 'Decision'),
@@ -570,32 +602,6 @@ class RunLogStepDetailSheet extends StatelessWidget {
                         ),
                       ),
                     ),
-                    if (beforeStateId.isNotEmpty ||
-                        afterStateId.isNotEmpty) ...[
-                      const SizedBox(height: 14),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: [
-                          if (beforeStateId.isNotEmpty)
-                            OutlinedButton.icon(
-                              onPressed: () => onShowState(beforeStateId),
-                              icon: const Icon(Icons.image_outlined, size: 17),
-                              label: Text(
-                                _text(context, '前置状态', 'Before state'),
-                              ),
-                            ),
-                          if (afterStateId.isNotEmpty)
-                            OutlinedButton.icon(
-                              onPressed: () => onShowState(afterStateId),
-                              icon: const Icon(Icons.image_outlined, size: 17),
-                              label: Text(
-                                _text(context, '后置状态', 'After state'),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ],
                   ],
                 ),
               ),

--- a/ui/lib/features/task/router_config.dart
+++ b/ui/lib/features/task/router_config.dart
@@ -24,6 +24,7 @@ List<GoRoute> taskRoutes = [
     name: 'task/omniflow',
     builder: (context, state) => OmniFlowExecutionCenterPage(
       initialTab: state.uri.queryParameters['tab'],
+      initialFunctionId: state.uri.queryParameters['functionId'],
     ),
   ),
   GoRoute(

--- a/ui/lib/features/task/run_log/omniflow_tool_client.dart
+++ b/ui/lib/features/task/run_log/omniflow_tool_client.dart
@@ -1,5 +1,58 @@
 import 'package:ui/services/assists_core_service.dart';
 
+class OmniFlowFunctionRegistrationResult {
+  const OmniFlowFunctionRegistrationResult({
+    required this.function,
+    this.errorMessage,
+  });
+
+  final Map<String, dynamic>? function;
+  final String? errorMessage;
+
+  bool get success => function != null;
+  String get functionId => function?['function_id']?.toString().trim() ?? '';
+
+  factory OmniFlowFunctionRegistrationResult.fromPayload(
+    Map<String, dynamic> payload, {
+    required String runId,
+  }) {
+    if (payload['success'] == false) {
+      return OmniFlowFunctionRegistrationResult(
+        function: null,
+        errorMessage:
+            payload['error_message']?.toString().trim().nullIfEmpty ??
+            payload['error_code']?.toString().trim().nullIfEmpty ??
+            '注册失败',
+      );
+    }
+    final nested = payload['function'];
+    final function = nested is Map
+        ? nested.map((key, value) => MapEntry(key.toString(), value))
+        : <String, dynamic>{};
+    final functionId =
+        (function['function_id'] ??
+                payload['function_id'] ??
+                payload['registered_function_id'])
+            ?.toString()
+            .trim() ??
+        '';
+    if (functionId.isEmpty) {
+      return const OmniFlowFunctionRegistrationResult(
+        function: null,
+        errorMessage: '注册响应缺少 function_id',
+      );
+    }
+    return OmniFlowFunctionRegistrationResult(
+      function: <String, dynamic>{
+        ...function,
+        'function_id': functionId,
+        if ((function['source_run_id']?.toString().trim() ?? '').isEmpty)
+          'source_run_id': runId,
+      },
+    );
+  }
+}
+
 class OmniFlowToolClient {
   const OmniFlowToolClient._();
 
@@ -29,13 +82,18 @@ class OmniFlowToolClient {
     return _call('get_run_log_state', {'state_id': stateId});
   }
 
-  static Future<Map<String, dynamic>> convertRunLog(String runId) {
-    return _call('convert_run_log', {
-      'run_id': runId,
-      'register': true,
-      'agent_visible': true,
-      'enhance': true,
-    });
+  static Future<Map<String, dynamic>> saveFunctionFromRunLog(String runId) {
+    return _call('save_function', {'run_id': runId, 'agent_visible': true});
+  }
+
+  static Future<OmniFlowFunctionRegistrationResult> registerFunctionFromRunLog(
+    String runId,
+  ) async {
+    final payload = await saveFunctionFromRunLog(runId);
+    return OmniFlowFunctionRegistrationResult.fromPayload(
+      payload,
+      runId: runId,
+    );
   }
 
   static Future<Map<String, dynamic>> startHumanTrajectoryLearning({
@@ -117,4 +175,8 @@ class OmniFlowToolClient {
     }
     return value;
   }
+}
+
+extension on String {
+  String? get nullIfEmpty => isEmpty ? null : this;
 }

--- a/ui/lib/models/conversation_thread_target.dart
+++ b/ui/lib/models/conversation_thread_target.dart
@@ -13,6 +13,7 @@ class ConversationThreadTarget {
     this.isNewConversation = false,
     this.fromNativeRoute = false,
     this.requestKey,
+    this.initialMessage,
   });
 
   final int? conversationId;
@@ -24,6 +25,7 @@ class ConversationThreadTarget {
   final bool isNewConversation;
   final bool fromNativeRoute;
   final String? requestKey;
+  final String? initialMessage;
 
   const ConversationThreadTarget.newConversation({
     this.mode = ConversationMode.normal,
@@ -31,6 +33,7 @@ class ConversationThreadTarget {
     this.requestKey,
     this.agentRuntime,
     this.agentId,
+    this.initialMessage,
   }) : conversationId = null,
        agentSessionId = null,
        agentSessionActive = null,
@@ -45,7 +48,8 @@ class ConversationThreadTarget {
     this.agentSessionId,
     this.agentRuntime,
     this.agentSessionActive,
-  }) : isNewConversation = false;
+  }) : initialMessage = null,
+       isNewConversation = false;
 
   const ConversationThreadTarget.agentSession({
     required String sessionId,
@@ -58,6 +62,7 @@ class ConversationThreadTarget {
        agentSessionId = sessionId,
        agentRuntime = runtime,
        mode = ConversationMode.agent,
+       initialMessage = null,
        isNewConversation = false;
 
   bool get hasConversationId => conversationId != null;
@@ -86,6 +91,7 @@ class ConversationThreadTarget {
     bool? isNewConversation,
     bool? fromNativeRoute,
     String? requestKey,
+    String? initialMessage,
     bool clearRequestKey = false,
   }) {
     return ConversationThreadTarget(
@@ -98,6 +104,7 @@ class ConversationThreadTarget {
       isNewConversation: isNewConversation ?? this.isNewConversation,
       fromNativeRoute: fromNativeRoute ?? this.fromNativeRoute,
       requestKey: clearRequestKey ? null : (requestKey ?? this.requestKey),
+      initialMessage: initialMessage ?? this.initialMessage,
     );
   }
 
@@ -164,7 +171,8 @@ class ConversationThreadTarget {
         other.mode == mode &&
         other.isNewConversation == isNewConversation &&
         other.fromNativeRoute == fromNativeRoute &&
-        other.requestKey == requestKey;
+        other.requestKey == requestKey &&
+        other.initialMessage == initialMessage;
   }
 
   @override
@@ -178,6 +186,7 @@ class ConversationThreadTarget {
     isNewConversation,
     fromNativeRoute,
     requestKey,
+    initialMessage,
   );
 
   @override

--- a/ui/test/agent_tool_summary_card_test.dart
+++ b/ui/test/agent_tool_summary_card_test.dart
@@ -92,9 +92,7 @@ void main() {
     expect(icon.size, 18);
   });
 
-  testWidgets('completed VLM tool renders inline result actions', (
-    tester,
-  ) async {
+  testWidgets('completed VLM tool renders GUI completion card', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -125,6 +123,48 @@ void main() {
     expect(find.text('查看 RunLog'), findsOneWidget);
     expect(find.text('注册为复用指令'), findsOneWidget);
     expect(find.byKey(kAgentToolDetailSheetKey), findsNothing);
+  });
+
+  testWidgets('registered GUI result opens its matching Function details', (
+    tester,
+  ) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Scaffold(
+            body: AgentToolSummaryCard(
+              cardData: {
+                'status': 'success',
+                'toolName': 'vlm_task',
+                'toolType': 'builtin',
+                'resultPreviewJson': jsonEncode({
+                  'run_id': 'gui-run-1',
+                  'success': true,
+                  'content': '已完成',
+                  'auto_registered': true,
+                  'registered_function_id': 'recorded_demo',
+                }),
+              },
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/task/omniflow',
+          builder: (context, state) => Scaffold(
+            body: Text('function:${state.uri.queryParameters['functionId']}'),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.tap(find.byKey(const ValueKey('vlm-task-open-functions')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('function:recorded_demo'), findsOneWidget);
   });
 
   testWidgets('unfinished VLM tool still exposes its RunLog', (tester) async {

--- a/ui/test/features/home/pages/command_overlay/services/manual_recording_result_card_test.dart
+++ b/ui/test/features/home/pages/command_overlay/services/manual_recording_result_card_test.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/features/home/pages/command_overlay/services/manual_recording_result_card.dart';
+
+void main() {
+  test('manual recording result uses GUI completion card payload', () {
+    final message = buildManualRecordingResultCard(
+      messageId: 'manual-1',
+      summary: '录制完成',
+      result: {
+        'success': true,
+        'run_log': {
+          'run_id': 'run-1',
+          'steps': [
+            {
+              'action': {
+                'tool': 'swipe',
+                'args': {'direction': 'left'},
+              },
+            },
+            {
+              'action': {
+                'tool': 'press_key',
+                'args': {'key': 'back'},
+              },
+            },
+          ],
+        },
+        'function': {'function_id': 'recorded_demo'},
+      },
+    );
+
+    expect(message.type, 2);
+    final cardData = message.content!['cardData'] as Map<String, dynamic>;
+    final payload =
+        jsonDecode(cardData['resultPreviewJson'] as String)
+            as Map<String, dynamic>;
+    expect(payload['context_type'], 'manual_recording_result');
+    expect(payload['run_id'], 'run-1');
+    expect(payload['action_count'], 2);
+    expect(payload['auto_registered'], isTrue);
+    expect(payload['registered_function_id'], 'recorded_demo');
+    expect(payload.containsKey('actions'), isFalse);
+  });
+}

--- a/ui/test/features/task/run_log/omniflow_execution_center_page_test.dart
+++ b/ui/test/features/task/run_log/omniflow_execution_center_page_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ui/features/task/pages/execution_history/omniflow_execution_center_page.dart';
 import 'package:ui/l10n/generated/app_localizations.dart';
+import 'package:ui/models/conversation_model.dart';
+import 'package:ui/models/conversation_thread_target.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -142,7 +145,7 @@ void main() {
               },
             },
             'function.demo' => <String, Object?>{'success': true},
-            'convert_run_log' => <String, Object?>{
+            'save_function' => <String, Object?>{
               'success': true,
               'function_id': 'function.demo',
             },
@@ -303,12 +306,30 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
+    ConversationThreadTarget? openedTarget;
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => const OmniFlowExecutionCenterPage(),
+        ),
+        GoRoute(
+          path: '/home/chat',
+          builder: (_, state) {
+            final target = state.extra! as ConversationThreadTarget;
+            openedTarget = target;
+            return const Scaffold(body: Text('agent conversation'));
+          },
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp.router(
         locale: Locale('zh'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: OmniFlowExecutionCenterPage(),
+        routerConfig: router,
       ),
     );
     await tester.pumpAndSettle();
@@ -328,70 +349,41 @@ void main() {
     );
     await tester.tap(find.byKey(const ValueKey('function-detail-enhance')));
     await tester.pumpAndSettle();
-    expect(find.text('增强复用指令'), findsOneWidget);
+    expect(find.text('agent conversation'), findsOneWidget);
+    expect(openedTarget?.mode, ConversationMode.agent);
     expect(
-      find.byKey(const ValueKey('function-enhancement-instruction')),
-      findsOneWidget,
+      openedTarget?.initialMessage,
+      contains('function_id: function.demo'),
     );
-    await tester.tap(
-      find.byKey(const ValueKey('function-enhancement-default')),
-    );
-    await tester.pumpAndSettle();
-    expect(
-      toolCalls.any(
-        (call) =>
-            call['name'] == 'update_function' &&
-            (call['arguments'] as Map?)?['function_id'] == 'function.demo' &&
-            (call['arguments'] as Map?)?['mode'] == 'enhance' &&
-            !(call['arguments'] as Map).containsKey('instruction'),
-      ),
-      isTrue,
-    );
-
-    await tester.tap(find.text('演示指令'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('function-detail-run')));
-    await tester.pumpAndSettle();
-    expect(find.text('填写执行参数'), findsOneWidget);
+    expect(toolCalls.any((call) => call['name'] == 'update_function'), isFalse);
   });
 
-  testWidgets('passes optional Function enhancement instruction', (
-    tester,
-  ) async {
-    tester.view.physicalSize = const Size(360, 800);
-    tester.view.devicePixelRatio = 1;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+  test('builds a complete Function enhancement Agent request', () {
+    final prompt = buildFunctionEnhancementPrompt({
+      'function_id': 'function.demo',
+      'name': '演示指令',
+      'steps': <Object?>[],
+    });
 
+    expect(prompt, contains('get_function'));
+    expect(prompt, contains('function_id: function.demo'));
+    expect(prompt, contains('不要执行该指令'));
+  });
+
+  testWidgets('opens the requested Function directly', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         locale: Locale('zh'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: OmniFlowExecutionCenterPage(),
+        home: OmniFlowExecutionCenterPage(initialFunctionId: 'function.demo'),
       ),
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('演示指令'));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('function-detail-enhance')));
-    await tester.pumpAndSettle();
-    await tester.enterText(
-      find.byKey(const ValueKey('function-enhancement-instruction')),
-      '优先使用搜索框，不要依赖菜单位置',
-    );
-    await tester.tap(find.byKey(const ValueKey('function-enhancement-submit')));
-    await tester.pumpAndSettle();
-
-    expect(
-      toolCalls.any(
-        (call) =>
-            call['name'] == 'update_function' &&
-            (call['arguments'] as Map?)?['instruction'] == '优先使用搜索框，不要依赖菜单位置',
-      ),
-      isTrue,
-    );
+    expect(find.byKey(const ValueKey('function-detail-sheet')), findsOneWidget);
+    expect(find.text('演示指令'), findsWidgets);
+    expect(toolCalls.any((call) => call['name'] == 'get_function'), isTrue);
   });
 
   testWidgets('uses consistent Chinese labels across the execution center', (
@@ -451,7 +443,134 @@ void main() {
     expect(find.byKey(const ValueKey('run-log-open-run-1')), findsOneWidget);
     await tester.tap(find.text('注册为复用指令'));
     await tester.pumpAndSettle();
-    expect(toolCalls.any((call) => call['name'] == 'convert_run_log'), isTrue);
+    expect(toolCalls.any((call) => call['name'] == 'save_function'), isTrue);
+    expect(find.byKey(const ValueKey('function-detail-sheet')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('function-detail-enhance')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shows the Function linked to a RunLog and opens it', (
+    tester,
+  ) async {
+    toolResponseOverride = (name, call) {
+      if (name != 'list_functions') return null;
+      return <String, Object?>{
+        'success': true,
+        'functions': <Object?>[
+          <String, Object?>{
+            'function_id': 'function.demo',
+            'source_run_id': 'run-1',
+            'name': '演示指令',
+            'description': '复用已成功执行的轨迹',
+            'input_schema': <String, Object?>{
+              'type': 'object',
+              'properties': <String, Object?>{},
+            },
+            'steps': <Object?>[],
+          },
+        ],
+      };
+    };
+    await tester.pumpWidget(
+      const MaterialApp(
+        locale: Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: OmniFlowExecutionCenterPage(initialTab: 'run_logs'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('查看复用指令'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('run-log-function-run-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('function-detail-sheet')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('function-detail-enhance')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+    'registration uses the saved Function immediately when detail reload fails',
+    (tester) async {
+      toolResponseOverride = (name, call) {
+        if (name == 'save_function') {
+          return <String, Object?>{
+            'success': true,
+            'function_id': 'function.registered',
+            'function': <String, Object?>{
+              'function_id': 'function.registered',
+              'source_run_id': 'run-1',
+              'name': '刚注册的指令',
+              'description': '注册响应已经包含完整 Function',
+              'agent_visible': true,
+              'input_schema': <String, Object?>{
+                'type': 'object',
+                'properties': <String, Object?>{},
+              },
+              'steps': <Object?>[],
+            },
+          };
+        }
+        if (name == 'get_function') {
+          throw PlatformException(code: 'FUNCTION_NOT_READY');
+        }
+        return null;
+      };
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          locale: Locale('zh'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: OmniFlowExecutionCenterPage(initialTab: 'run_logs'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('注册为复用指令'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('function-detail-sheet')),
+        findsOneWidget,
+      );
+      expect(find.text('刚注册的指令'), findsWidgets);
+      expect(find.text('复用指令'), findsWidgets);
+      expect(toolCalls.where((call) => call['name'] == 'get_function'), isEmpty);
+      expect(find.textContaining('StateError: 注册失败'), findsNothing);
+    },
+  );
+
+  testWidgets('keeps Enhance visible on a narrow phone', (tester) async {
+    tester.view.physicalSize = const Size(280, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        locale: Locale('zh'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: OmniFlowExecutionCenterPage(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('演示指令'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('function-detail-enhance')),
+      findsOneWidget,
+    );
+    expect(find.text('增强'), findsOneWidget);
+    expect(find.byKey(const ValueKey('function-detail-run')), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('opens directly on the Run Logs tab', (tester) async {
@@ -500,5 +619,4 @@ void main() {
     expect(find.text('2 VLM calls'), findsOneWidget);
     expect(find.byKey(const ValueKey('run-log-open-run-1')), findsOneWidget);
   });
-
 }

--- a/ui/test/features/task/run_log/omniflow_tool_client_test.dart
+++ b/ui/test/features/task/run_log/omniflow_tool_client_test.dart
@@ -37,7 +37,7 @@ void main() {
     () async {
       await OmniFlowToolClient.listFunctions();
       await OmniFlowToolClient.listRunLogs();
-      await OmniFlowToolClient.convertRunLog('run-1');
+      await OmniFlowToolClient.saveFunctionFromRunLog('run-1');
       await OmniFlowToolClient.replayFunction(
         'function.demo',
         <String, dynamic>{'query': 'ice'},
@@ -48,7 +48,7 @@ void main() {
       expect(calls.map((call) => (call.arguments as Map)['name']), <String>[
         'list_functions',
         'list_run_logs',
-        'convert_run_log',
+        'save_function',
         'function.demo',
       ]);
       expect(
@@ -61,4 +61,39 @@ void main() {
       );
     },
   );
+
+  test('parses the saved Function without a second backend read', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return <String, Object?>{
+            'success': true,
+            'function_id': 'function.saved',
+            'function': <String, Object?>{
+              'function_id': 'function.saved',
+              'name': '已保存指令',
+              'steps': <Object?>[],
+            },
+          };
+        });
+
+    final result = await OmniFlowToolClient.registerFunctionFromRunLog('run-1');
+
+    expect(result.success, isTrue);
+    expect(result.functionId, 'function.saved');
+    expect(result.function?['source_run_id'], 'run-1');
+    expect(calls.map((call) => (call.arguments as Map)['name']), <String>[
+      'save_function',
+    ]);
+  });
+
+  test('rejects a successful registration response without function id', () {
+    final result = OmniFlowFunctionRegistrationResult.fromPayload(
+      <String, dynamic>{'success': true},
+      runId: 'run-1',
+    );
+
+    expect(result.success, isFalse);
+    expect(result.errorMessage, contains('function_id'));
+  });
 }

--- a/ui/test/features/task/run_log/run_log_detail_page_test.dart
+++ b/ui/test/features/task/run_log/run_log_detail_page_test.dart
@@ -12,6 +12,18 @@ void main() {
         .setMockMethodCallHandler(assistChannel, (call) async {
           if (call.method != 'tools/call') return null;
           final arguments = Map<Object?, Object?>.from(call.arguments as Map);
+          if (arguments['name'] == 'list_functions') {
+            return <String, Object?>{
+              'success': true,
+              'functions': <Object?>[
+                <String, Object?>{
+                  'function_id': 'function.settings',
+                  'source_run_id': 'run-1',
+                  'name': '打开设置',
+                },
+              ],
+            };
+          }
           if (arguments['name'] != 'get_run_log') {
             return <String, Object?>{'success': true};
           }
@@ -118,10 +130,20 @@ void main() {
       expect(find.text('Tap · 100, 200'), findsOneWidget);
       expect(find.text('1.23k tokens'), findsOneWidget);
       expect(find.textContaining('"tool": "click"'), findsNothing);
+      expect(find.text('Linked Function'), findsOneWidget);
+      expect(find.text('打开设置'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('run-log-view-function')),
+        findsOneWidget,
+      );
 
       await tester.tap(find.text('Tap · 100, 200'));
       await tester.pumpAndSettle();
 
+      expect(find.text('Action evidence'), findsOneWidget);
+      expect(find.text('Action screenshot'), findsOneWidget);
+      expect(find.text('Before action'), findsNothing);
+      expect(find.text('After action'), findsNothing);
       expect(find.text('Decision'), findsOneWidget);
       expect(find.text('Tap the visible Settings result'), findsNWidgets(2));
       expect(find.text('Raw reasoning (optional)'), findsOneWidget);
@@ -139,10 +161,6 @@ void main() {
         find.text('The Settings result is visible and enabled.'),
         findsOneWidget,
       );
-      await tester.drag(find.byType(ListView).last, const Offset(0, -500));
-      await tester.pumpAndSettle();
-      expect(find.text('Before state'), findsOneWidget);
-      expect(find.text('After state'), findsOneWidget);
     },
   );
 }

--- a/uikit/src/main/java/cn/com/omnimind/uikit/loader/ManualRecordingControlOverlay.kt
+++ b/uikit/src/main/java/cn/com/omnimind/uikit/loader/ManualRecordingControlOverlay.kt
@@ -12,6 +12,7 @@ import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
+import android.provider.Settings
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -81,12 +82,25 @@ object ManualRecordingControlOverlay {
             dismissLocked()
             sessionRunId = runId
             captureStateCallback = onCaptureState
-            val shown = tryShow(
+            var shown = tryShow(
                 context = overlayHandle.context,
                 windowType = overlayHandle.windowType,
                 trusted = overlayHandle.trusted,
                 state = state,
             )
+            if (!shown && overlayHandle.trusted && Settings.canDrawOverlays(fallbackContext)) {
+                shown = tryShow(
+                    context = fallbackContext.applicationContext ?: fallbackContext,
+                    windowType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                    } else {
+                        @Suppress("DEPRECATION")
+                        WindowManager.LayoutParams.TYPE_PHONE
+                    },
+                    trusted = false,
+                    state = state,
+                )
+            }
             if (!shown) {
                 sessionRunId = null
                 captureStateCallback = null
@@ -653,14 +667,7 @@ object ManualRecordingControlOverlay {
                     .setItems(labels) { _, which ->
                         when (which) {
                             0 -> when {
-                                inputTarget == null -> finishManualActionDialog(
-                                    localizedText(
-                                        context,
-                                        "请先点击输入框",
-                                        "Tap an input field first",
-                                    ),
-                                )
-                                inputTarget.password -> finishManualActionDialog(
+                                inputTarget?.password == true -> finishManualActionDialog(
                                     localizedText(
                                         context,
                                         "密码输入不录制",

--- a/uikit/src/main/java/cn/com/omnimind/uikit/loader/ManualTouchRecordLoader.kt
+++ b/uikit/src/main/java/cn/com/omnimind/uikit/loader/ManualTouchRecordLoader.kt
@@ -15,7 +15,6 @@ import android.view.WindowManager
 import cn.com.omnimind.androidgui.AndroidGuiEnvironment
 import cn.com.omnimind.androidgui.AndroidGuiOverlayHost
 import cn.com.omnimind.assists.HumanTrajectoryLearningSession
-import cn.com.omnimind.assists.ManualInputTarget
 import cn.com.omnimind.assists.ManualOverlayTouchGesture
 import cn.com.omnimind.assists.recording.ManualGestureRecognizer
 import cn.com.omnimind.assists.recording.ManualGestureThresholds
@@ -323,7 +322,39 @@ object ManualTouchRecordLoader {
                 enqueueGesture(gesture)
             }
             MotionEvent.ACTION_CANCEL -> {
+                if (!isTracking) return
+                val finishedAtMs = System.currentTimeMillis()
                 isTracking = false
+                val recognized = ManualGestureRecognizer.recognizeCancelledSwipe(
+                    trace = ManualPointerTrace(
+                        startX = startX,
+                        startY = startY,
+                        endX = endX,
+                        endY = endY,
+                        startedAtMs = downAtMs,
+                        finishedAtMs = finishedAtMs,
+                    ),
+                    thresholds = ManualGestureThresholds.overlay(
+                        touchSlopPx = touchSlop,
+                        longPressTimeoutMs = longPressTimeout,
+                    ),
+                ) ?: return
+                enqueueGesture(
+                    ManualOverlayTouchGesture(
+                        actionName = recognized.actionName,
+                        startX = recognized.startX,
+                        startY = recognized.startY,
+                        endX = recognized.endX,
+                        endY = recognized.endY,
+                        durationMs = recognized.durationMs,
+                        distancePx = recognized.distancePx,
+                        direction = recognized.direction,
+                        startedAtMs = recognized.startedAtMs,
+                        finishedAtMs = recognized.finishedAtMs,
+                        displayWidth = currentDisplaySize().x,
+                        displayHeight = currentDisplaySize().y,
+                    ),
+                )
             }
         }
     }
@@ -457,7 +488,6 @@ object ManualTouchRecordLoader {
 
         var executed = false
         var recorded = false
-        var inputTarget: ManualInputTarget? = null
         runCatching {
             withContext(Dispatchers.Main) {
                 synchronized(this@ManualTouchRecordLoader) {
@@ -474,6 +504,7 @@ object ManualTouchRecordLoader {
                 val replayResult = HumanTrajectoryLearningSession.recordOverlayGesture(gesture) {
                     withContext(Dispatchers.Main) {
                         synchronized(this@ManualTouchRecordLoader) {
+                            endSyntheticReplaySuppressionLocked()
                             if (overlayView?.isAttachedToWindow == true &&
                                 HumanTrajectoryLearningSession.isActive() &&
                                 !HumanTrajectoryLearningSession.isPaused()) {
@@ -484,7 +515,6 @@ object ManualTouchRecordLoader {
                 }
                 executed = replayResult.executed
                 recorded = replayResult.recorded
-                inputTarget = replayResult.inputTarget
             } finally {
                 withContext(Dispatchers.Main) {
                     synchronized(this@ManualTouchRecordLoader) {
@@ -500,7 +530,9 @@ object ManualTouchRecordLoader {
         if (executed && recorded) {
             // Keep recording UI static. Per-gesture indicators/status updates add
             // extra overlay input work and can make the control window ANR.
-            inputTarget?.let(ManualRecordingControlOverlay::offerInput)
+            if (gesture.actionName == OobActionSchema.TOOL_CLICK) {
+                detectAndOfferInput(gesture)
+            }
         } else if (executed && !recorded) {
             OmniLog.w(TAG, "manual gesture executed but was not recorded action=${gesture.actionName}")
         }
@@ -517,6 +549,15 @@ object ManualTouchRecordLoader {
         }
         if (!sessionStillActive) return false
         return true
+    }
+
+    private fun detectAndOfferInput(gesture: ManualOverlayTouchGesture) {
+        recordScope.launch {
+            HumanTrajectoryLearningSession.detectManualInputTargetAfterClick(
+                x = gesture.startX,
+                y = gesture.startY,
+            )?.let(ManualRecordingControlOverlay::offerInput)
+        }
     }
 
     private fun beginSyntheticReplaySuppressionLocked() {


### PR DESCRIPTION
## What users get

- Reliably record taps, text input, swipes, and system actions during manual recording
- Save completed recordings to RunLog without dropping captured actions
- Automatically register a completed recording as a reusable command
- Open the registered command directly from the completion result or execution history
- Enhance a reusable command from its detail view
- Start the device MCP service even when the default port is occupied by selecting an available fallback port

## Validation

- Android focused unit tests passed
- Flutter recording, RunLog, reusable-command, and navigation tests passed
- Develop debug APK built successfully
- APK installed and checked on a rooted Android device
- Accessibility service and MCP automatic port fallback verified on device