### PR TITLE
build: prepare v0.5.8.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,7 +170,7 @@ android {
         minSdk = 29
         targetSdk = 35
         versionCode = 1
-        versionName = "0.5.8.3"
+        versionName = "0.5.8.4"
         buildConfigField("String", "IMAGE_BASE_URL", buildConfigString(omnibotImageBaseUrl))
         buildConfigField("String", "IMAGE_MODEL", buildConfigString(omnibotImageModel))
         buildConfigField("String", "IMAGE_API_KEY", buildConfigString(omnibotImageApiKey))


### PR DESCRIPTION
Prepare the next release from the current main baseline.

- Bump the Android app version to 0.5.8.4
- No functional changes beyond the already merged main baseline
- Release artifact will be built from the merged commit