### PR TITLE
feat: keep agent tasks running after screen lock

### DIFF
--- a/androidgui/src/main/java/cn/com/omnimind/androidgui/AndroidGuiEnvironment.kt
+++ b/androidgui/src/main/java/cn/com/omnimind/androidgui/AndroidGuiEnvironment.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.PowerManager
 import android.provider.Settings
 import cn.com.omnimind.accessibility.service.AssistsService
 import cn.com.omnimind.baselib.runlog.Action
@@ -28,6 +29,9 @@ data class AndroidGuiScreenSnapshot(
     val displayHeight: Int,
     val screenshotJpeg: ByteArray?,
 )
+
+/** Raised when a physical-display GUI task can no longer safely continue. */
+class AndroidGuiDisplayOffException : IllegalStateException("android_gui_display_off")
 
 enum class AndroidGuiAccessibilityStatus {
     DISABLED,
@@ -56,6 +60,7 @@ class AndroidGuiEnvironment internal constructor(
     fun isReady(): Boolean = accessibilityStatus() == AndroidGuiAccessibilityStatus.READY
 
     suspend fun awaitReady(timeoutMs: Long = ACCESSIBILITY_READY_TIMEOUT_MS): Boolean {
+        ensureDisplayInteractive()
         if (!isAccessibilityEnabled()) return false
         return withTimeoutOrNull(timeoutMs) {
             while (!platform.isReady()) delay(50L)
@@ -197,6 +202,14 @@ class AndroidGuiEnvironment internal constructor(
             ),
         )
         return action.copy(args = args)
+    }
+
+    private fun ensureDisplayInteractive() {
+        val context = appContext ?: return
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        if (powerManager != null && !powerManager.isInteractive) {
+            throw AndroidGuiDisplayOffException()
+        }
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -211,6 +211,11 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="mediaPlayback" />
+        <service
+            android:name="cn.com.omnimind.bot.task.runtime.TaskRuntimeService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
         <activity
             android:name="cn.com.omnimind.bot.agent.BrowserFileChooserRequestActivity"
             android:exported="false"

--- a/app/src/main/java/cn/com/omnimind/bot/agent/workspace/schedule/WorkspaceScheduledTaskScheduler.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/workspace/schedule/WorkspaceScheduledTaskScheduler.kt
@@ -240,7 +240,7 @@ class WorkspaceScheduledTaskScheduler(
             "scheduledTaskTitle" to task.title,
             "scheduleNotificationEnabled" to task.notificationEnabled
         )
-        AssistsCoreManager(appContext).createAgentTask(
+        AssistsCoreManager.sharedInstanceOrCreate(appContext).createAgentTask(
             MethodCall("createAgentTask", args),
             NoopResult(task.taskId, "createAgentTask")
         )

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -52,6 +52,7 @@ import cn.com.omnimind.bot.util.AssistsUtil
 import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.util.SchemeUtil
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
+import cn.com.omnimind.bot.task.runtime.TaskRuntime
 import cn.com.omnimind.bot.agent.AgentCallback
 import cn.com.omnimind.bot.agent.AgentAlarmToolService
 import cn.com.omnimind.bot.agent.AgentConversationContextCompactor
@@ -1887,6 +1888,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         mainJob.launch {
             try {
                 TaskRuntimeSettings.onTaskStarted(context)
+                TaskRuntime.start(context, taskID)
                 val workspaceMemoryService = WorkspaceMemoryService(context)
                 val preparedContent = prepareChatTaskContent(
                     content = content,
@@ -1962,12 +1964,14 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             } catch (e: PermissionException) {
                 removeChatTaskPersistenceState(taskID)
                 TaskRuntimeSettings.onTaskFinished(context)
+                TaskRuntime.finish(context, taskID)
                 withContext(Dispatchers.Main) {
                     result.error("PERMISSION_ERROR", e.message, null)
                 }
             } catch (e: Exception) {
                 removeChatTaskPersistenceState(taskID)
                 TaskRuntimeSettings.onTaskFinished(context)
+                TaskRuntime.finish(context, taskID)
                 withContext(Dispatchers.Main) {
                     result.error("DO_TASK_ERROR", e.message, null)
                 }
@@ -2150,6 +2154,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             )
         }
         TaskRuntimeSettings.onTaskFinished(context)
+        TaskRuntime.finish(context, taskID)
         if (persistenceState?.isError != true) {
             TaskRuntimeSettings.notifyTaskFinished(
                 context = context,
@@ -4211,6 +4216,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         )
         registerActiveAgentRun(taskId, agentRunContext)
         TaskRuntimeSettings.onTaskStarted(context)
+        TaskRuntime.start(context, taskId)
 
         agentRunScope.launch {
             var historyRepository: AgentConversationHistoryRepository? = null
@@ -5927,6 +5933,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 }
             } finally {
                 TaskRuntimeSettings.onTaskFinished(context)
+                TaskRuntime.finish(context, taskId)
                 clearActiveAgentJob(taskId, agentRunJob)
             }
         }

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -4104,6 +4104,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
             ?.filter { it.key != null }
             ?.associate { it.key.toString() to it.value }
             ?: emptyMap()
+        val runtimeOwned = call.argument<Boolean>("__taskRuntimeOwned") == true
         val taskId = (call.argument<String>("taskId") ?: "").trim()
         val userMessage = AgentTextSanitizer.sanitizeUtf16(
             (call.argument<String>("userMessage") ?: "").toString()
@@ -4178,6 +4179,27 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         }
         if (taskId.isBlank()) {
             result.error("INVALID_ARGUMENTS", "taskId is empty", null)
+            return
+        }
+        if (!runtimeOwned) {
+            val persistedArguments = sanitizeInteropMap(
+                rawCallArguments + mapOf(
+                    "taskId" to taskId,
+                    "userMessage" to userMessage,
+                    "attachments" to rawAttachments,
+                    "userMessageCreatedAt" to userMessageCreatedAt,
+                    "conversationId" to conversationId,
+                    "conversationMode" to resolvedConversationMode,
+                    "reasoningEffort" to reasoningEffort,
+                    "terminalEnvironment" to terminalEnvironment,
+                    "continueMode" to (isContinue || call.argument<Boolean>("continueMode") == true),
+                )
+            )
+            if (!TaskRuntime.enqueueAgent(context, taskId, persistedArguments)) {
+                result.error("TASK_RUNTIME_START_FAILED", "Unable to start task runtime", null)
+                return
+            }
+            result.success("SUCCESS")
             return
         }
         removeFailedAgentRetryContext(taskId)

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -53,6 +53,7 @@ import cn.com.omnimind.assists.controller.http.HttpController
 import cn.com.omnimind.baselib.util.SchemeUtil
 import cn.com.omnimind.bot.util.TaskRuntimeSettings
 import cn.com.omnimind.bot.task.runtime.TaskRuntime
+import cn.com.omnimind.bot.task.runtime.TaskRuntimeStore
 import cn.com.omnimind.bot.agent.AgentCallback
 import cn.com.omnimind.bot.agent.AgentAlarmToolService
 import cn.com.omnimind.bot.agent.AgentConversationContextCompactor
@@ -1124,6 +1125,46 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         OmniLog.d(TAG, "setChannel")
         this.channel = _channel
         FlutterChatSyncBridge.bindCurrentChannel(_channel)
+    }
+
+    /**
+     * Returns the durable Agent envelopes and conversation identifiers.
+     * Flutter calls this after every engine/channel reconnect and loads the
+     * persisted snapshot through the normal history API;
+     * RealtimeHub is intentionally not used as a replay buffer.
+     */
+    fun recoverAgentRuntime(result: MethodChannel.Result) {
+        mainJob.launch {
+            val activeIds = activeAgentTaskIds().toSet()
+            val recovered = withContext(Dispatchers.IO) {
+                TaskRuntimeStore.listPending(context).map { record ->
+                    val conversationId = (record.payload["conversationId"] as? Number)?.toLong()
+                        ?.takeIf { it > 0L }
+                    val mode = normalizeConversationMode(
+                        record.payload["conversationMode"]?.toString().orEmpty(),
+                    )
+                    mapOf<String, Any?>(
+                        "taskId" to record.taskId,
+                        "kind" to record.kind,
+                        "status" to if (record.taskId in activeIds) "running" else record.status.name.lowercase(),
+                        "recoveryState" to if (record.taskId in activeIds) "running" else "queued",
+                        "statusText" to "后台恢复中",
+                        "backgroundRecovered" to true,
+                        "updatedAt" to record.updatedAt,
+                        "conversationId" to conversationId,
+                        "conversationMode" to mode,
+                    ).filterValues { it != null }
+                }
+            }
+            result.success(
+                sanitizeInteropMap(
+                    mapOf(
+                        "tasks" to recovered,
+                        "generatedAt" to System.currentTimeMillis(),
+                    ),
+                ),
+            )
+        }
     }
 
     private fun currentChannelOrNull(): MethodChannel? {
@@ -4094,10 +4135,24 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
         handleCreateOrContinueAgentTask(call, result, isContinue = false)
     }
 
+    internal fun startAgentTaskFromRuntime(
+        call: MethodCall,
+        parentScope: CoroutineScope,
+        result: MethodChannel.Result,
+    ) {
+        handleCreateOrContinueAgentTask(
+            call = call,
+            result = result,
+            isContinue = false,
+            parentScope = parentScope,
+        )
+    }
+
     private fun handleCreateOrContinueAgentTask(
         call: MethodCall,
         result: MethodChannel.Result,
-        isContinue: Boolean
+        isContinue: Boolean,
+        parentScope: CoroutineScope? = null,
     ) {
         val rawCallArguments = (call.arguments as? Map<*, *>)
             ?.entries
@@ -4228,7 +4283,7 @@ class AssistsCoreManager(private val context: Context) : OnMessagePushListener {
                 "continueGeneration" to continueGeneration
             )
         )
-        val agentRunJob = SupervisorJob()
+        val agentRunJob = SupervisorJob(parentScope?.coroutineContext?.get(Job))
         val agentRunScope = CoroutineScope(agentRunJob + Dispatchers.Default)
         val agentRunContext = ActiveAgentRunContext(
             taskId = taskId,

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/AgentTaskRunner.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/AgentTaskRunner.kt
@@ -1,0 +1,34 @@
+package cn.com.omnimind.bot.task.runtime
+
+import cn.com.omnimind.bot.manager.AssistsCoreManager
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+
+internal class AgentTaskRunner(
+    private val manager: AssistsCoreManager,
+) : TaskRunner {
+    override val kind: String = "agent"
+
+    override fun start(
+        task: TaskRuntimeStore.StoredTask,
+        parentScope: CoroutineScope,
+    ): Boolean {
+        if (task.kind != kind) return false
+        val arguments = task.payload.toMutableMap().apply {
+            put("__taskRuntimeOwned", true)
+        }
+        manager.startAgentTaskFromRuntime(
+            call = MethodCall("createAgentTask", arguments),
+            parentScope = parentScope,
+            result = NoOpResult,
+        )
+        return true
+    }
+
+    private object NoOpResult : MethodChannel.Result {
+        override fun success(result: Any?) = Unit
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) = Unit
+        override fun notImplemented() = Unit
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRunner.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRunner.kt
@@ -1,0 +1,12 @@
+package cn.com.omnimind.bot.task.runtime
+
+import kotlinx.coroutines.CoroutineScope
+
+internal interface TaskRunner {
+    val kind: String
+
+    fun start(
+        task: TaskRuntimeStore.StoredTask,
+        parentScope: CoroutineScope,
+    ): Boolean
+}

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntime.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntime.kt
@@ -18,18 +18,31 @@ object TaskRuntime {
     private const val TAG = "TaskRuntime"
     private val activeTaskIds = ConcurrentHashMap.newKeySet<String>()
 
+    fun enqueueAgent(
+        context: Context,
+        taskId: String,
+        payload: Map<String, Any?>,
+    ): Boolean {
+        val normalizedTaskId = taskId.trim()
+        if (normalizedTaskId.isEmpty()) return false
+        if (!TaskRuntimeStore.putAgent(context, normalizedTaskId, payload)) {
+            OmniLog.e(TAG, "Unable to persist agent task taskId=$normalizedTaskId")
+            return false
+        }
+        if (start(context, normalizedTaskId)) return true
+        TaskRuntimeStore.remove(context, normalizedTaskId)
+        return false
+    }
+
     fun start(context: Context, taskId: String): Boolean {
         val normalizedTaskId = taskId.trim()
         if (normalizedTaskId.isEmpty()) {
             OmniLog.w(TAG, "Ignoring task runtime start with empty task id")
             return false
         }
-        val wasEmpty = activeTaskIds.isEmpty()
-        activeTaskIds.add(normalizedTaskId)
-        if (!wasEmpty) return true
-
+        val newlyActive = activeTaskIds.add(normalizedTaskId)
         return sendStartCommand(context).also { started ->
-            if (!started) activeTaskIds.remove(normalizedTaskId)
+            if (!started && newlyActive) activeTaskIds.remove(normalizedTaskId)
         }
     }
 
@@ -40,7 +53,8 @@ object TaskRuntime {
             return false
         }
         activeTaskIds.remove(normalizedTaskId)
-        if (activeTaskIds.isNotEmpty()) return true
+        TaskRuntimeStore.remove(context, normalizedTaskId)
+        if (activeTaskIds.isNotEmpty() || TaskRuntimeStore.listPending(context).isNotEmpty()) return true
 
         return runCatching {
             context.applicationContext.stopService(

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntime.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntime.kt
@@ -1,0 +1,80 @@
+package cn.com.omnimind.bot.task.runtime
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import cn.com.omnimind.baselib.util.OmniLog
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Stable entry point for long-running task lifecycle.
+ *
+ * The first migration keeps the existing Agent runner intact and only moves
+ * its process-lifetime signal to a foreground service. Future runners (for
+ * example DSH) must enter through this same boundary instead of coupling the
+ * task to an Activity or Flutter engine.
+ */
+object TaskRuntime {
+    private const val TAG = "TaskRuntime"
+    private val activeTaskIds = ConcurrentHashMap.newKeySet<String>()
+
+    fun start(context: Context, taskId: String): Boolean {
+        val normalizedTaskId = taskId.trim()
+        if (normalizedTaskId.isEmpty()) {
+            OmniLog.w(TAG, "Ignoring task runtime start with empty task id")
+            return false
+        }
+        val wasEmpty = activeTaskIds.isEmpty()
+        activeTaskIds.add(normalizedTaskId)
+        if (!wasEmpty) return true
+
+        return sendStartCommand(context).also { started ->
+            if (!started) activeTaskIds.remove(normalizedTaskId)
+        }
+    }
+
+    fun finish(context: Context, taskId: String): Boolean {
+        val normalizedTaskId = taskId.trim()
+        if (normalizedTaskId.isEmpty()) {
+            OmniLog.w(TAG, "Ignoring task runtime finish with empty task id")
+            return false
+        }
+        activeTaskIds.remove(normalizedTaskId)
+        if (activeTaskIds.isNotEmpty()) return true
+
+        return runCatching {
+            context.applicationContext.stopService(
+                Intent(context.applicationContext, TaskRuntimeService::class.java),
+            )
+            true
+        }.onFailure { error ->
+            OmniLog.w(
+                TAG,
+                "Unable to stop task runtime taskId=$normalizedTaskId: ${error.message}",
+            )
+        }.getOrDefault(false)
+    }
+
+    private fun sendStartCommand(context: Context): Boolean {
+        val intent = Intent(context.applicationContext, TaskRuntimeService::class.java).apply {
+            action = TaskRuntimeService.ACTION_START
+        }
+        return runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.applicationContext.startForegroundService(intent)
+            } else {
+                context.applicationContext.startService(intent)
+            }
+            true
+        }.onFailure { error ->
+            // Android may reject a foreground-service start when a task is
+            // restored from a background-only entry point. The Agent runner
+            // remains responsible for reporting the task failure; this
+            // boundary must never crash the existing execution path.
+            OmniLog.w(
+                TAG,
+                "Unable to start task runtime foreground service: ${error.message}",
+            )
+        }.getOrDefault(false)
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeService.kt
@@ -14,16 +14,18 @@ import cn.com.omnimind.baselib.util.OmniLog
 import cn.com.omnimind.bot.manager.AssistsCoreManager
 import cn.com.omnimind.bot.R
 import cn.com.omnimind.bot.activity.MainActivity
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Foreground host for user-visible long-running tasks.
  *
- * The service owns the durable launch envelope and re-attaches it to the
- * existing Agent runner. The runner itself stays in AssistsCoreManager so this
- * migration does not duplicate the business loop.
+ * The service owns the durable launch envelope and dispatches it through a
+ * TaskRunner. The runner still delegates to the existing Agent loop so this
+ * boundary does not duplicate or destabilize loop semantics.
  */
 class TaskRuntimeService : Service() {
     companion object {
@@ -39,9 +41,14 @@ class TaskRuntimeService : Service() {
         getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
     private val dispatchedTaskIds = ConcurrentHashMap.newKeySet<String>()
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private lateinit var manager: AssistsCoreManager
+    private lateinit var agentTaskRunner: AgentTaskRunner
 
     override fun onCreate() {
         super.onCreate()
+        manager = AssistsCoreManager.sharedInstanceOrCreate(applicationContext)
+        agentTaskRunner = AgentTaskRunner(manager)
         ensureNotificationChannel()
         startForeground(NOTIFICATION_ID, buildNotification())
         OmniLog.d(TAG, "Task runtime foreground service created")
@@ -65,31 +72,33 @@ class TaskRuntimeService : Service() {
 
     override fun onDestroy() {
         OmniLog.d(TAG, "Task runtime foreground service destroyed")
+        serviceScope.cancel()
         super.onDestroy()
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     private fun dispatchPendingTasks() {
-        val manager = AssistsCoreManager.sharedInstanceOrCreate(applicationContext)
         TaskRuntimeStore.listPending(applicationContext).forEach { record ->
             if (!dispatchedTaskIds.add(record.taskId)) return@forEach
+            if (record.kind != agentTaskRunner.kind) return@forEach
             if (manager.activeAgentTaskIds().contains(record.taskId)) return@forEach
             TaskRuntimeStore.markRunning(applicationContext, record.taskId)
-            val arguments = record.payload.toMutableMap().apply {
-                put("__taskRuntimeOwned", true)
+            val started = runCatching {
+                agentTaskRunner.start(record, serviceScope)
+            }.getOrElse { error ->
+                OmniLog.e(
+                    TAG,
+                    "Unable to start task runner taskId=${record.taskId}: ${error.message}",
+                    error,
+                )
+                false
             }
-            manager.createAgentTask(
-                MethodCall("createAgentTask", arguments),
-                NoOpResult,
-            )
+            if (!started) {
+                dispatchedTaskIds.remove(record.taskId)
+                TaskRuntime.finish(applicationContext, record.taskId)
+            }
         }
-    }
-
-    private object NoOpResult : MethodChannel.Result {
-        override fun success(result: Any?) = Unit
-        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) = Unit
-        override fun notImplemented() = Unit
     }
 
     private fun updateNotification() {

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeService.kt
@@ -11,16 +11,19 @@ import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import cn.com.omnimind.baselib.util.OmniLog
+import cn.com.omnimind.bot.manager.AssistsCoreManager
 import cn.com.omnimind.bot.R
 import cn.com.omnimind.bot.activity.MainActivity
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Foreground host for user-visible long-running tasks.
  *
- * This service deliberately does not own Agent business logic yet. Keeping the
- * existing runner in place makes this first migration low risk: the service
- * supplies Android's foreground execution contract while later work can move
- * the runner behind TaskRuntime without changing callers.
+ * The service owns the durable launch envelope and re-attaches it to the
+ * existing Agent runner. The runner itself stays in AssistsCoreManager so this
+ * migration does not duplicate the business loop.
  */
 class TaskRuntimeService : Service() {
     companion object {
@@ -35,6 +38,7 @@ class TaskRuntimeService : Service() {
     private val notificationManager by lazy {
         getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
+    private val dispatchedTaskIds = ConcurrentHashMap.newKeySet<String>()
 
     override fun onCreate() {
         super.onCreate()
@@ -47,16 +51,16 @@ class TaskRuntimeService : Service() {
         when (intent?.action) {
             ACTION_START -> {
                 updateNotification()
+                dispatchPendingTasks()
             }
 
             else -> {
                 OmniLog.w(TAG, "Ignoring unknown task runtime action=${intent?.action}")
+                dispatchPendingTasks()
             }
         }
 
-        // The first migration has no durable TaskStore yet. Do not recreate a
-        // stale notification without its task set after an unexpected kill.
-        return START_NOT_STICKY
+        return START_STICKY
     }
 
     override fun onDestroy() {
@@ -65,6 +69,28 @@ class TaskRuntimeService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun dispatchPendingTasks() {
+        val manager = AssistsCoreManager.sharedInstanceOrCreate(applicationContext)
+        TaskRuntimeStore.listPending(applicationContext).forEach { record ->
+            if (!dispatchedTaskIds.add(record.taskId)) return@forEach
+            if (manager.activeAgentTaskIds().contains(record.taskId)) return@forEach
+            TaskRuntimeStore.markRunning(applicationContext, record.taskId)
+            val arguments = record.payload.toMutableMap().apply {
+                put("__taskRuntimeOwned", true)
+            }
+            manager.createAgentTask(
+                MethodCall("createAgentTask", arguments),
+                NoOpResult,
+            )
+        }
+    }
+
+    private object NoOpResult : MethodChannel.Result {
+        override fun success(result: Any?) = Unit
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) = Unit
+        override fun notImplemented() = Unit
+    }
 
     private fun updateNotification() {
         notificationManager.notify(NOTIFICATION_ID, buildNotification())

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeService.kt
@@ -1,0 +1,115 @@
+package cn.com.omnimind.bot.task.runtime
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import cn.com.omnimind.baselib.util.OmniLog
+import cn.com.omnimind.bot.R
+import cn.com.omnimind.bot.activity.MainActivity
+
+/**
+ * Foreground host for user-visible long-running tasks.
+ *
+ * This service deliberately does not own Agent business logic yet. Keeping the
+ * existing runner in place makes this first migration low risk: the service
+ * supplies Android's foreground execution contract while later work can move
+ * the runner behind TaskRuntime without changing callers.
+ */
+class TaskRuntimeService : Service() {
+    companion object {
+        private const val TAG = "TaskRuntimeService"
+        const val ACTION_START = "cn.com.omnimind.bot.task.runtime.START"
+
+        private const val CHANNEL_ID = "task_runtime_execution"
+        private const val CHANNEL_NAME = "任务执行"
+        private const val NOTIFICATION_ID = 2048110
+    }
+
+    private val notificationManager by lazy {
+        getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+        OmniLog.d(TAG, "Task runtime foreground service created")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_START -> {
+                updateNotification()
+            }
+
+            else -> {
+                OmniLog.w(TAG, "Ignoring unknown task runtime action=${intent?.action}")
+            }
+        }
+
+        // The first migration has no durable TaskStore yet. Do not recreate a
+        // stale notification without its task set after an unexpected kill.
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        OmniLog.d(TAG, "Task runtime foreground service destroyed")
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun updateNotification() {
+        notificationManager.notify(NOTIFICATION_ID, buildNotification())
+    }
+
+    private fun buildNotification(): Notification {
+        val openAppIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val openAppPendingIntent = PendingIntent.getActivity(
+            this,
+            NOTIFICATION_ID,
+            openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag(),
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(applicationInfo.icon.takeIf { it != 0 } ?: R.mipmap.ic_launcher)
+            .setContentTitle("小万任务执行中")
+            .setContentText("正在后台执行用户发起的任务")
+            .setContentIntent(openAppPendingIntent)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+            .build()
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "小万在后台执行用户发起的任务"
+                setShowBadge(false)
+            },
+        )
+    }
+
+    private fun immutableFlag(): Int =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_IMMUTABLE
+        } else {
+            0
+        }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeStore.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/task/runtime/TaskRuntimeStore.kt
@@ -1,0 +1,93 @@
+package cn.com.omnimind.bot.task.runtime
+
+import android.content.Context
+import cn.com.omnimind.baselib.util.OmniLog
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/**
+ * Small durable queue for tasks that are owned by [TaskRuntime].
+ *
+ * This is deliberately only the launch envelope, not the agent transcript.
+ * Conversation history remains the source of truth for model/tool progress;
+ * the envelope lets the service recreate the runner after a process restart.
+ */
+internal object TaskRuntimeStore {
+    private const val TAG = "TaskRuntimeStore"
+    private const val PREFS = "task_runtime_store_v1"
+    private const val RECORDS_KEY = "records"
+    private val lock = Any()
+    private val gson = Gson()
+    private val recordsType = object : TypeToken<Map<String, StoredTask>>() {}.type
+
+    internal enum class Status {
+        QUEUED,
+        RUNNING,
+    }
+
+    internal data class StoredTask(
+        val taskId: String,
+        val kind: String,
+        val payload: Map<String, Any?>,
+        val status: Status = Status.QUEUED,
+        val updatedAt: Long = System.currentTimeMillis(),
+    )
+
+    fun putAgent(context: Context, taskId: String, payload: Map<String, Any?>): Boolean {
+        val normalized = taskId.trim()
+        if (normalized.isEmpty()) return false
+        return update(context) { records ->
+            records + (normalized to StoredTask(
+                taskId = normalized,
+                kind = "agent",
+                payload = payload,
+                status = Status.QUEUED,
+            ))
+        }
+    }
+
+    fun markRunning(context: Context, taskId: String): Boolean {
+        val normalized = taskId.trim()
+        return update(context) { records ->
+            val record = records[normalized] ?: return@update records
+            records + (normalized to record.copy(
+                status = Status.RUNNING,
+                updatedAt = System.currentTimeMillis(),
+            ))
+        }
+    }
+
+    fun remove(context: Context, taskId: String): Boolean {
+        val normalized = taskId.trim()
+        return update(context) { records -> records - normalized }
+    }
+
+    fun listPending(context: Context): List<StoredTask> = synchronized(lock) {
+        read(context).values
+            .filter { it.kind == "agent" }
+            .sortedBy { it.updatedAt }
+    }
+
+    private fun update(
+        context: Context,
+        transform: (Map<String, StoredTask>) -> Map<String, StoredTask>,
+    ): Boolean = synchronized(lock) {
+        val preferences = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val next = transform(read(preferences))
+        preferences.edit().putString(RECORDS_KEY, gson.toJson(next)).commit()
+    }
+
+    private fun read(context: Context): Map<String, StoredTask> {
+        val preferences = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        return read(preferences)
+    }
+
+    private fun read(preferences: android.content.SharedPreferences): Map<String, StoredTask> {
+        val json = preferences.getString(RECORDS_KEY, null) ?: return emptyMap()
+        return runCatching {
+            gson.fromJson<Map<String, StoredTask>>(json, recordsType) ?: emptyMap()
+        }.onFailure {
+            OmniLog.e(TAG, "Unable to decode task runtime records: ${it.message}")
+        }.getOrDefault(emptyMap())
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
@@ -26,7 +26,6 @@ class AssistsCoreChannel {
     fun onCreate(context: Context) {
         assistsCoreManager = AssistsCoreManager.sharedInstanceOrCreate(context)
         omniFlowToolChannel = OmniFlowToolChannel(context)
-        assistsCoreManager?.setChannel(channel!!);
 
     }
 
@@ -50,6 +49,9 @@ class AssistsCoreChannel {
 
                 "createAgentTask" -> {
                     assistsCoreManager!!.createAgentTask( call, result)
+                }
+                "recoverAgentRuntime" -> {
+                    assistsCoreManager!!.recoverAgentRuntime(result)
                 }
                 "agentSkillList" -> {
                     assistsCoreManager!!.agentSkillList(call, result)

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/AssistsCoreChannel.kt
@@ -24,7 +24,7 @@ class AssistsCoreChannel {
     private var assistsCoreManager: AssistsCoreManager? = null
     private var omniFlowToolChannel: OmniFlowToolChannel? = null
     fun onCreate(context: Context) {
-        assistsCoreManager = AssistsCoreManager(context)
+        assistsCoreManager = AssistsCoreManager.sharedInstanceOrCreate(context)
         omniFlowToolChannel = OmniFlowToolChannel(context)
         assistsCoreManager?.setChannel(channel!!);
 

--- a/omniflow-android/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlow.kt
+++ b/omniflow-android/src/main/java/cn/com/omnimind/bot/omniflow/OmniFlow.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.SystemClock
+import cn.com.omnimind.androidgui.AndroidGuiDisplayOffException
 import cn.com.omnimind.androidgui.AndroidGuiEnvironment
 import cn.com.omnimind.baselib.runlog.Action
 import cn.com.omnimind.baselib.runlog.InternalRunLogStore
@@ -291,6 +292,10 @@ object OmniFlow {
     )
 }
 
+internal class GuiDisplayOffCancellationException : CancellationException(
+    "android_gui_display_off",
+)
+
 class OmniFlowDeviceDispatcher internal constructor(
     context: Context,
     private val request: ExecutionRequest? = null,
@@ -372,6 +377,9 @@ class OmniFlowDeviceDispatcher internal constructor(
             applyPostRunActions(result)
         } catch (error: ManualCompletionRequested) {
             throw error
+        } catch (error: AndroidGuiDisplayOffException) {
+            finishRun(cancelledFailure(activeRun.cancelledDoneReason, error))
+            throw GuiDisplayOffCancellationException()
         } catch (error: CancellationException) {
             finishRun(cancelledFailure(activeRun.cancelledDoneReason, error))
             throw error

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -269,6 +269,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     AssistsMessageService.setOnAgentStreamEventCallback(
       _handleAgentStreamEvent,
     );
+    AssistsMessageService.addOnAgentRuntimeRecoveryCallback(
+      _handleAgentRuntimeRecovery,
+    );
     AssistsMessageService.addOnExternalUserMessageAppendedCallback(
       _handleExternalUserMessageAppended,
     );
@@ -278,6 +281,7 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     AssistsMessageService.setOnAgentContextCompactionStateCallback(
       _handleAgentContextCompactionStateChanged,
     );
+    unawaited(AssistsMessageService.recoverAgentRuntime());
   }
 
   ChatConversationRuntimeState? runtimeFor({

--- a/ui/lib/features/home/pages/chat/services/chat_runtime_event_ingress.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_runtime_event_ingress.dart
@@ -1,6 +1,87 @@
 part of 'chat_conversation_runtime_coordinator.dart';
 
 extension _ChatRuntimeEventIngress on ChatConversationRuntimeCoordinator {
+  void _handleAgentRuntimeRecovery(Map<String, dynamic> payload) {
+    final rawTasks = payload['tasks'];
+    if (rawTasks is! List) return;
+    for (final rawTask in rawTasks.whereType<Map>()) {
+      final task = Map<String, dynamic>.from(
+        rawTask.map((key, value) => MapEntry(key.toString(), value)),
+      );
+      unawaited(_restoreAgentRuntimeTask(task));
+    }
+  }
+
+  Future<void> _restoreAgentRuntimeTask(Map<String, dynamic> task) async {
+    final taskId = (task['taskId'] ?? '').toString().trim();
+    final conversationId = _asPositiveInt(task['conversationId']);
+    if (taskId.isEmpty || conversationId == null) return;
+    final rawMode = (task['conversationMode'] ?? '').toString().trim();
+    final mode = rawMode == 'agent'
+        ? kChatRuntimeModeAgent
+        : _runtimeModeFromConversationMode(rawMode);
+    final runtime = ensureRuntime(
+      conversationId: conversationId,
+      mode: mode,
+      initialChatIslandDisplayLayer: ChatIslandDisplayLayer.mode,
+    );
+    _taskBindings[taskId] = _TaskBinding(
+      conversationId: conversationId,
+      mode: mode,
+    );
+    final historyMode = mode == kChatRuntimeModeAgent
+        ? ConversationMode.agent
+        : mode == kChatRuntimeModeOpenClaw
+        ? ConversationMode.openclaw
+        : ConversationMode.normal;
+    try {
+      final messages = await ConversationHistoryService.getConversationMessages(
+        conversationId,
+        mode: historyMode,
+      );
+      final current = _runtimeForTask(taskId) ?? runtime;
+      _replaceRuntimeMessagesIfChanged(current, messages);
+    } catch (_) {
+      // The native payload remains useful even when legacy migration is busy.
+    }
+    final recoveryCardId = '$taskId-background-recovery';
+    runtime.isAiResponding = true;
+    runtime.isExecutingTask = true;
+    runtime.isDeepThinking = true;
+    runtime.currentThinkingStage = ThinkingStage.thinking.value;
+    runtime.lastAgentTaskId = taskId;
+    runtime.activeThinkingCardId = recoveryCardId;
+    final existingIndex = runtime.messages.indexWhere(
+      (message) => message.id == recoveryCardId,
+    );
+    final card = ChatMessageModel(
+      id: recoveryCardId,
+      type: 2,
+      user: 3,
+      content: <String, dynamic>{
+        'cardData': <String, dynamic>{
+          'type': 'deep_thinking',
+          'isLoading': true,
+          'thinkingContent': LegacyTextLocalizer.isEnglish
+              ? 'Recovering in background…'
+              : '后台恢复中',
+          'stage': ThinkingStage.thinking.value,
+          'taskID': taskId,
+          'cardId': recoveryCardId,
+          'startTime': DateTime.now().millisecondsSinceEpoch,
+        },
+        'id': recoveryCardId,
+      },
+      createAt: DateTime.now(),
+    );
+    if (existingIndex == -1) {
+      runtime.messages.insert(0, card);
+    } else {
+      runtime.messages[existingIndex] = card;
+    }
+    _notifyRuntimeListeners();
+  }
+
   void _handleChatTaskMessage(String taskId, String content, String? type) {
     final binding = _taskBindings[taskId];
     final runtime = _runtimeForTask(taskId);

--- a/ui/lib/services/assists_core_service.dart
+++ b/ui/lib/services/assists_core_service.dart
@@ -44,6 +44,8 @@ typedef AgentContextCompactionStateCallback =
       int? promptTokenThreshold,
     );
 typedef AgentStreamEventCallback = void Function(AgentStreamEvent event);
+typedef AgentRuntimeRecoveryCallback =
+    void Function(Map<String, dynamic> payload);
 typedef ScheduledTaskCancelledCallBack = void Function(String taskId);
 typedef ScheduledTaskExecuteNowCallBack = void Function(String taskId);
 
@@ -274,6 +276,8 @@ class AssistsMessageService {
   static final List<ChatTaskMessageEndCallBack> _onChatTaskMessageEndCallBacks =
       [];
   static final List<AgentStreamEventCallback> _onAgentStreamEventCallbacks = [];
+  static final List<AgentRuntimeRecoveryCallback>
+  _onAgentRuntimeRecoveryCallbacks = [];
 
   static Stream<Map<String, dynamic>> get conversationListChangedStream =>
       _conversationListChangedController.stream;
@@ -421,6 +425,14 @@ class AssistsMessageService {
             callback(event);
           }
           break;
+        case 'onAgentRuntimeRecovery':
+          final payload = Map<String, dynamic>.from(
+            (call.arguments as Map?) ?? const <String, dynamic>{},
+          );
+          for (final callback in _onAgentRuntimeRecoveryCallbacks) {
+            callback(payload);
+          }
+          break;
         case 'onScheduledTaskCancelled':
           final Map<String, dynamic> data = Map<String, dynamic>.from(
             call.arguments,
@@ -560,6 +572,42 @@ class AssistsMessageService {
     AgentStreamEventCallback? callback,
   ) {
     _onAgentStreamEventCallbacks.remove(callback);
+  }
+
+  static void addOnAgentRuntimeRecoveryCallback(
+    AgentRuntimeRecoveryCallback callback,
+  ) {
+    if (!_onAgentRuntimeRecoveryCallbacks.contains(callback)) {
+      _onAgentRuntimeRecoveryCallbacks.add(callback);
+    }
+  }
+
+  static void removeOnAgentRuntimeRecoveryCallback(
+    AgentRuntimeRecoveryCallback callback,
+  ) {
+    _onAgentRuntimeRecoveryCallbacks.remove(callback);
+  }
+
+  /// Replays durable task envelopes after a Flutter engine/channel reconnect.
+  static Future<Map<String, dynamic>> recoverAgentRuntime() async {
+    try {
+      final result = await assistCore.invokeMethod<Map<dynamic, dynamic>>(
+        'recoverAgentRuntime',
+      );
+      final payload = Map<String, dynamic>.from(
+        (result ?? const <dynamic, dynamic>{}).map(
+          (key, value) => MapEntry(key.toString(), value),
+        ),
+      );
+      for (final callback in List<AgentRuntimeRecoveryCallback>.from(
+        _onAgentRuntimeRecoveryCallbacks,
+      )) {
+        callback(payload);
+      }
+      return payload;
+    } catch (_) {
+      return const <String, dynamic>{};
+    }
   }
 
   static void addOnExternalUserMessageAppendedCallback(


### PR DESCRIPTION
## Summary

- Add a unified `TaskRuntime` foreground host for long-running Agent tasks.
- Persist the Agent launch envelope before execution and restore queued/running tasks from `START_STICKY` service restarts.
- Keep the existing Agent Loop unchanged; the foreground service re-attaches to the existing `AssistsCoreManager` runner.
- Reuse a single `AssistsCoreManager` instance across Flutter, scheduled tasks, and service recovery.
- Stop the foreground service only after all active and persisted tasks are finished.

## Why

The Agent execution previously depended on the Activity/Flutter process lifetime. The new runtime boundary keeps execution independent from the UI lifecycle, so screen lock and navigation away from the app do not stop a running Agent task.

## Validation

- `./gradlew --no-daemon --no-parallel :app:compileDevelopStandardDebugKotlin`
- `./gradlew --no-daemon --no-parallel :app:assembleDevelopStandardDebug`
- `./gradlew --no-daemon --no-parallel :app:testDevelopStandardDebugUnitTest`
- Real OPPO PJE110 device install and execution test.
- Sent an Agent task, locked the screen, observed `mWakefulness=Asleep` while `TaskRuntimeService` remained `isForeground=true`, then verified the task returned `OK` and the service stopped after completion.

## Scope / limitations

- This PR does not import DSH/Harness or rewrite the Agent Loop.
- Recovery persists the launch envelope; it is not yet a tool-step-level exactly-once checkpoint.
- Physical-display GUI/VLM actions still require a display; this PR only fixes the execution host lifecycle.
- Force-stopping the app remains an explicit Android stop and is not auto-restored.
