### PR TITLE
chore: bump Android release version to 0.5.8.10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,8 +169,9 @@ android {
         applicationId = "cn.com.omnimind.bot"
         minSdk = 29
         targetSdk = 35
-        versionCode = 1
-        versionName = "0.5.8.8"
+        // Android package versions must increase monotonically for upgrades.
+        versionCode = 2
+        versionName = "0.5.8.10"
         buildConfigField("String", "IMAGE_BASE_URL", buildConfigString(omnibotImageBaseUrl))
         buildConfigField("String", "IMAGE_MODEL", buildConfigString(omnibotImageModel))
         buildConfigField("String", "IMAGE_API_KEY", buildConfigString(omnibotImageApiKey))


### PR DESCRIPTION
## Summary
- bump Android `versionName` to `0.5.8.10`
- bump Android `versionCode` from `1` to `2` so upgrades are accepted by Android
- keep the release tag and APK package version aligned

## Validation
- `./gradlew --no-daemon --no-parallel :app:assembleDevelopStandardDebug -Ptarget=lib/main_standard.dart`

No ACP, MCP, provider, or long-term memory behavior is changed.