### PR TITLE
Platform model display names

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -1617,13 +1617,18 @@ class AssistsCoreManager(private val context: Context) {
         val useProvidedCustomHeaders = call.argument<Boolean>("useProvidedCustomHeaders") == true
         val profileId = call.argument<String>("profileId")?.trim()
         val capability = call.argument<String>("capability")?.trim()
+        val forceRefresh = call.argument<Boolean>("forceRefresh") == true
         val expectedProfileRevision = call.argument<Number>("expectedProfileRevision")?.toLong()
         val expectedProfileBaseUrl = call.argument<String>("expectedProfileBaseUrl")?.trim().orEmpty()
 
         workJob.launch {
             try {
                 if (OmniOfficialProvider.isOfficialProfile(profileId)) {
-                    val models = PlatformAiProvisioner.refreshAndGetModels(capability)
+                    val models = if (forceRefresh) {
+                        PlatformAiProvisioner.refreshAndGetModels(capability)
+                    } else {
+                        PlatformAiProvisioner.ensureReadyAndGetModels(capability)
+                    }
                     withContext(Dispatchers.Main) {
                         result.success(models.map { it.toMap() })
                     }

--- a/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/manager/AssistsCoreManager.kt
@@ -1623,7 +1623,7 @@ class AssistsCoreManager(private val context: Context) {
         workJob.launch {
             try {
                 if (OmniOfficialProvider.isOfficialProfile(profileId)) {
-                    val models = PlatformAiProvisioner.ensureReadyAndGetModels(capability)
+                    val models = PlatformAiProvisioner.refreshAndGetModels(capability)
                     withContext(Dispatchers.Main) {
                         result.success(models.map { it.toMap() })
                     }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/account/AccountModels.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/account/AccountModels.kt
@@ -97,6 +97,7 @@ data class PlatformModelCatalog(
     val version: String? = null,
     val defaults: PlatformModelDefaults = PlatformModelDefaults(),
     val capabilities: PlatformModelCapabilities = PlatformModelCapabilities(),
+    val displayNames: Map<String, String> = emptyMap(),
     val hasOfficialCatalog: Boolean = false,
 )
 

--- a/baselib/src/main/java/cn/com/omnimind/baselib/account/PlatformModelApiClient.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/account/PlatformModelApiClient.kt
@@ -115,6 +115,8 @@ class PlatformModelApiClient(
         @SerializedName("defaults") val defaults: CatalogDefaultsResponse? = null,
         @SerializedName("capabilities")
         val capabilities: CatalogCapabilitiesResponse? = null,
+        @SerializedName("display_names")
+        val displayNames: Map<String, String>? = null,
     )
 
     private data class CatalogDefaultsResponse(
@@ -151,6 +153,16 @@ class PlatformModelApiClient(
         }
         val legacyVoiceDefault = defaults?.legacyVoice.normalizedId()
         val legacyVoiceModels = capabilities?.legacyVoice.normalizedIds()
+        val availableModelIds = models.mapTo(mutableSetOf(), PlatformModel::id)
+        val safeDisplayNames = displayNames.orEmpty().mapNotNull { (rawId, rawName) ->
+            val modelId = rawId.trim()
+            val displayName = rawName.trim()
+            if (modelId in availableModelIds && displayName.isNotEmpty()) {
+                modelId to displayName
+            } else {
+                null
+            }
+        }.toMap()
         return PlatformModelCatalog(
             models = models,
             version = version.normalizedId(),
@@ -170,6 +182,7 @@ class PlatformModelApiClient(
                 tts = firstIds(capabilities?.tts, capabilities?.textToSpeech, legacyVoiceModels),
                 ttsVoices = capabilities?.ttsVoices?.normalizedIds(),
             ),
+            displayNames = safeDisplayNames,
             hasOfficialCatalog = true,
         )
     }

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/PlatformAiProvisioner.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/PlatformAiProvisioner.kt
@@ -5,6 +5,7 @@ import cn.com.omnimind.baselib.account.OmniAccount
 import cn.com.omnimind.baselib.account.PlatformModel
 import cn.com.omnimind.baselib.account.PlatformModelsUnavailableException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -79,12 +80,47 @@ internal fun preserveLastKnownGoodCatalogOrFailure(
         PlatformAiProvisioningStatus(statusText = failureStatusText)
     }
 
+/** Coalesces overlapping catalog requests instead of queuing another fetch. */
+internal class SuspendRequestCoalescer<T> {
+    private val gate = Any()
+    private var inFlight: CompletableDeferred<T>? = null
+
+    suspend fun run(block: suspend () -> T): T {
+        lateinit var request: CompletableDeferred<T>
+        var ownsRequest = false
+        synchronized(gate) {
+            request = inFlight ?: CompletableDeferred<T>().also {
+                inFlight = it
+                ownsRequest = true
+            }
+        }
+        if (!ownsRequest) {
+            return request.await()
+        }
+
+        return try {
+            block().also(request::complete)
+        } catch (error: Throwable) {
+            request.completeExceptionally(error)
+            throw error
+        } finally {
+            synchronized(gate) {
+                if (inFlight === request) {
+                    inFlight = null
+                }
+            }
+        }
+    }
+}
+
 /**
  * Keeps the official provider catalog separate from device BYOK configuration.
  * Synchronizing the catalog never mutates the user's scene bindings.
  */
 object PlatformAiProvisioner {
     private val mutex = Mutex()
+    private val catalogSynchronization =
+        SuspendRequestCoalescer<PlatformAiProvisioningStatus>()
     private val embeddingRefreshGate = Any()
 
     @Volatile
@@ -109,6 +145,17 @@ object PlatformAiProvisioner {
         settings: AiSettings? = null,
         forceRefresh: Boolean = settings != null,
         preserveReadyCatalogOnFailure: Boolean = false,
+    ): PlatformAiProvisioningStatus =
+        catalogSynchronization.run {
+            synchronizeOnce(
+                forceRefresh = forceRefresh,
+                preserveReadyCatalogOnFailure = preserveReadyCatalogOnFailure,
+            )
+        }
+
+    private suspend fun synchronizeOnce(
+        forceRefresh: Boolean,
+        preserveReadyCatalogOnFailure: Boolean,
     ): PlatformAiProvisioningStatus =
         mutex.withLock {
             if (!OmniOfficialProvider.shouldExpose()) {

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/PlatformAiProvisioner.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/PlatformAiProvisioner.kt
@@ -155,16 +155,16 @@ object PlatformAiProvisioner {
                     ready = true,
                     statusText = "官方文本模型已就绪",
                     defaultModelId = selected.id,
-                    models = selection.textModels.toOptions(),
+                    models = selection.textModels.toOptions(catalog.displayNames),
                     catalogVersion = catalog.version,
                     defaultVisionModelId = selection.defaultVisionModel?.id,
                     defaultImageModelId = selection.defaultImageModel?.id,
                     defaultEmbeddingModelId = selection.defaultEmbeddingModel?.id,
                     defaultTtsModelId = selection.defaultTtsModel?.id,
-                    visionModels = selection.visionModels.toOptions(),
-                    imageModels = selection.imageModels.toOptions(),
-                    embeddingModels = selection.embeddingModels.toOptions(),
-                    ttsModels = selection.ttsModels.toOptions(),
+                    visionModels = selection.visionModels.toOptions(catalog.displayNames),
+                    imageModels = selection.imageModels.toOptions(catalog.displayNames),
+                    embeddingModels = selection.embeddingModels.toOptions(catalog.displayNames),
+                    ttsModels = selection.ttsModels.toOptions(catalog.displayNames),
                     ttsVoiceAliases = selection.ttsVoiceAliases,
                     defaultTtsVoiceAlias = selection.defaultTtsVoiceAlias,
                 )
@@ -229,6 +229,22 @@ object PlatformAiProvisioner {
         return readyStatus.modelsForCapability(normalizedCapability)
     }
 
+    suspend fun refreshAndGetModels(
+        capability: String? = null,
+    ): List<ProviderModelOption> {
+        val normalizedCapability = capability?.trim()?.lowercase().orEmpty()
+        val refreshed = synchronize(
+            forceRefresh = true,
+            preserveReadyCatalogOnFailure = true,
+        )
+        if (!refreshed.hasReadyTextCatalog()) {
+            throw PlatformModelsUnavailableException(
+                refreshed.statusText.ifBlank { "官方模型暂时不可用" }
+            )
+        }
+        return refreshed.modelsForCapability(normalizedCapability)
+    }
+
     suspend fun deactivate() {
         mutex.withLock { deactivateLocked() }
     }
@@ -268,11 +284,13 @@ object PlatformAiProvisioner {
         }
     }
 
-    private fun List<PlatformModel>.toOptions(): List<ProviderModelOption> =
+    private fun List<PlatformModel>.toOptions(
+        displayNames: Map<String, String>,
+    ): List<ProviderModelOption> =
         map { model ->
             ProviderModelOption(
                 id = model.id,
-                displayName = model.id,
+                displayName = displayNames[model.id].orEmpty().ifBlank { model.id },
                 ownedBy = model.ownedBy,
             )
         }

--- a/baselib/src/test/java/cn/com/omnimind/baselib/account/AccountApiClientTest.kt
+++ b/baselib/src/test/java/cn/com/omnimind/baselib/account/AccountApiClientTest.kt
@@ -36,6 +36,10 @@ class AccountApiClientTest {
                     "base_url":"https://internal.invalid",
                     "key":"must-not-be-mapped"
                   },{
+                    "id":"opus-6",
+                    "owned_by":"custom",
+                    "supported_endpoint_types":["openai"]
+                  },{
                     "id":"image-model",
                     "supported_endpoint_types":["image-generation"]
                   },{
@@ -46,6 +50,10 @@ class AccountApiClientTest {
                   }],
                   "official_catalog":{
                     "version":"2",
+                    "display_names":{
+                      "opus-6":"opus 6☺️",
+                      "hidden-model":"Must not leak"
+                    },
                     "defaults":{
                       "text":"Qwen3.5-Plus",
                       "image":"image-model",
@@ -55,7 +63,7 @@ class AccountApiClientTest {
                       "tts_voice":"default_zh"
                     },
                     "capabilities":{
-                      "text":["Qwen3.5-Plus"],
+                      "text":["Qwen3.5-Plus","opus-6"],
                       "image":["image-model"],
                       "embedding":["embedding-model"],
                       "vision":["Qwen3.5-Plus"],
@@ -77,12 +85,13 @@ class AccountApiClientTest {
         val models = catalog.models
 
         assertEquals(
-            listOf("Qwen3.5-Plus", "image-model", "embedding-model", "voice-model"),
+            listOf("Qwen3.5-Plus", "opus-6", "image-model", "embedding-model", "voice-model"),
             models.map(PlatformModel::id),
         )
         assertEquals(listOf("openai"), models.first().supportedEndpointTypes)
         assertTrue(catalog.hasOfficialCatalog)
         assertEquals("2", catalog.version)
+        assertEquals(mapOf("opus-6" to "opus 6☺️"), catalog.displayNames)
         assertEquals("image-model", catalog.defaults.image)
         assertEquals("embedding-model", catalog.defaults.embedding)
         assertEquals("voice-model", catalog.defaults.tts)

--- a/baselib/src/test/java/cn/com/omnimind/baselib/llm/PlatformAiProvisionerPolicyTest.kt
+++ b/baselib/src/test/java/cn/com/omnimind/baselib/llm/PlatformAiProvisionerPolicyTest.kt
@@ -1,11 +1,47 @@
 package cn.com.omnimind.baselib.llm
 
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PlatformAiProvisionerPolicyTest {
+    @Test
+    fun `overlapping catalog requests share one in-flight refresh`() = runBlocking {
+        val coalescer = SuspendRequestCoalescer<String>()
+        val calls = AtomicInteger()
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        val first = async {
+            coalescer.run {
+                calls.incrementAndGet()
+                started.complete(Unit)
+                release.await()
+                "fresh catalog"
+            }
+        }
+        started.await()
+        val second = async {
+            coalescer.run {
+                calls.incrementAndGet()
+                "duplicate catalog"
+            }
+        }
+        yield()
+
+        assertEquals(1, calls.get())
+        release.complete(Unit)
+        assertEquals("fresh catalog", first.await())
+        assertEquals("fresh catalog", second.await())
+        assertEquals(1, calls.get())
+    }
+
     @Test
     fun `official model lists are selected by requested capability`() {
         val status = PlatformAiProvisioningStatus(

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -169,6 +169,9 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   /// 用 Overlay 直接挂面板可以彻底跳过这条路径。
   OverlayGlassPopupHandle<ConversationModelSelection>?
   _conversationModelSelectorHandle;
+  final ConversationModelSelectorOpeningGuard
+  _conversationModelSelectorOpeningGuard =
+      ConversationModelSelectorOpeningGuard();
 
   // ===================== State =====================
   bool _isPopupVisible = false;

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -5,9 +5,7 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
   Future<void> _loadNormalChatModelContext() =>
       _loadNormalChatModelContextInternal();
 
-  Future<void> _loadNormalChatModelContextInternal({
-    bool awaitOfficialCatalogRefresh = false,
-  }) async {
+  Future<void> _loadNormalChatModelContextInternal() async {
     try {
       final results = await Future.wait<dynamic>([
         ModelProviderConfigService.loadChatModelGroups(refresh: false),
@@ -33,26 +31,10 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
           overrideSelection: _activeConversationModelOverrideSelection,
         );
       });
-      final activeSelection = _activeDispatchSceneSelection;
-      final activeProfile = activeSelection == null
-          ? null
-          : profiles
-                .where(
-                  (profile) => profile.id == activeSelection.providerProfileId,
-                )
-                .firstOrNull;
-      final shouldAwaitOfficialRefresh =
-          awaitOfficialCatalogRefresh &&
-          activeProfile?.sourceType == 'omnibot_official';
-      // Normal page loading must paint from cache immediately. The explicit
-      // model picker is the exception: its small official catalog is awaited
-      // once so newly published display names appear on the first opening.
-      // Large/custom Provider catalogs still refresh in the background.
-      if (shouldAwaitOfficialRefresh) {
-        await _refreshActiveChatProviderModelsInBackground();
-      } else {
-        unawaited(_refreshActiveChatProviderModelsInBackground());
-      }
+      // Normal page loading paints from cache immediately. Provider refreshes
+      // remain background work; only the explicit selector path force-refreshes
+      // the small official catalog before it opens.
+      unawaited(_refreshActiveChatProviderModelsInBackground());
       await _syncInvalidNormalConversationOverrideIfNeeded();
       await _syncActiveNormalConversationPromptTokenThreshold();
     } catch (e) {
@@ -114,6 +96,44 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     } catch (_) {
       // Cached Provider models remain usable when the background refresh
       // fails. The next explicit model-picker refresh can retry it.
+    }
+  }
+
+  Future<void> _refreshOfficialChatProviderModelsForSelector() async {
+    try {
+      final group =
+          await ModelProviderConfigService.refreshOfficialChatModelGroup();
+      if (!mounted || group == null) {
+        return;
+      }
+      final profiles = List<ModelProviderProfileSummary>.from(
+        _modelProviderProfiles,
+      );
+      final profileIndex = profiles.indexWhere(
+        (profile) => profile.id == group.profile.id,
+      );
+      if (profileIndex >= 0) {
+        profiles[profileIndex] = group.profile;
+      } else {
+        profiles.add(group.profile);
+      }
+      final next = <String, List<ProviderModelOption>>{
+        for (final entry in _modelOptionsByProfileId.entries)
+          entry.key: List<ProviderModelOption>.from(entry.value),
+        group.profile.id: List<ProviderModelOption>.from(group.models),
+      };
+      setState(() {
+        _modelProviderProfiles = profiles;
+        _modelOptionsByProfileId = _mergeChatModelOptions(
+          profiles: profiles,
+          source: next,
+          sceneCatalog: _sceneCatalog,
+          overrideSelection: _activeConversationModelOverrideSelection,
+        );
+      });
+    } catch (_) {
+      // Keep the already-loaded cache available while offline. The next
+      // explicit selector opening will retry the official catalog refresh.
     }
   }
 
@@ -539,121 +559,126 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
   Future<void> _openConversationModelSelector(
     BuildContext anchorContext,
   ) async {
-    if (_conversationModelSelectorHandle != null) {
-      // 已经开着,不重开。
+    if (_conversationModelSelectorHandle != null ||
+        !_conversationModelSelectorOpeningGuard.tryBegin()) {
+      // 已经打开或正在等待目录刷新，不重开。
       return;
     }
-    if (_showSlashCommandPanel ||
-        _showModelMentionPanel ||
-        _openClawPanelExpanded) {
-      setState(() {
-        _showSlashCommandPanel = false;
-        _showModelMentionPanel = false;
-        _openClawPanelExpanded = false;
-      });
-    }
-    final activeSelection = _activeDispatchSceneSelection;
-    // Refresh the scene binding and Provider catalog at the point of use.
-    // ACP runtime startup can finish before the Flutter scene snapshot does;
-    // relying on the initial snapshot can therefore show the Provider's
-    // default model even after a different Provider model was selected.
-    await _loadNormalChatModelContextInternal(
-      awaitOfficialCatalogRefresh: true,
-    );
-    final refreshedSelection = _activeDispatchSceneSelection ?? activeSelection;
-    final refreshedProviderModels = refreshedSelection == null
-        ? const <ProviderModelOption>[]
-        : (_modelOptionsByProfileId[refreshedSelection.providerProfileId] ??
-              const <ProviderModelOption>[]);
-    if (refreshedSelection != null && refreshedProviderModels.length <= 1) {
-      await _loadCachedProviderModelsForChatSelector(refreshedSelection);
-    }
-    final selectorProfiles = _modelProviderProfiles;
-    final selectorOptions = _modelOptionsByProfileId;
-    final hasSelectorModels = selectorProfiles.any((profile) {
-      return profile.configured &&
-          (selectorOptions[profile.id] ?? const <ProviderModelOption>[])
-              .isNotEmpty;
-    });
-    if (!hasSelectorModels) {
-      return;
-    }
-    if (!mounted || !anchorContext.mounted) {
-      return;
-    }
-    // 关键：不能调 `_inputFocusNode.unfocus()`，也不能用 `showGlassPopup`
-    // (push Navigator route)。两条路径都会让 TextField 失焦 → 软键盘塌陷 →
-    // 输入栏下沉 → popup 锚点错位(锚点是 popup 弹出瞬间按按钮在屏幕上的位置算的，
-    // 键盘塌陷后按钮位置已经变了)。
-    //
-    // Flutter 框架细节(重要)：`Route.requestFocus = false` **不能** 阻止 push
-    // 时的焦点迁移——`ModalRoute.didPush` 里检查的是 `navigator.widget.requestFocus`
-    // (Navigator 的 requestFocus),不是 Route 的。详见 routes.dart:1668。要彻底
-    // 跳过这条焦点迁移路径，唯一干净的办法是不走 Navigator 路由——直接挂到 Overlay。
-    // 这里走 [showOverlayGlassPopup],它把 OverlayEntry + Material + tap-outside +
-    // BackButtonListener + DismissOverlayOnKeyboardHide + playReverse 清理时序
-    // 都封装好了。
-    final anchorBox = anchorContext.findRenderObject() as RenderBox?;
-    final anchorRect = glassPopupAnchorFromContext(anchorContext);
-    if (anchorBox == null || !anchorBox.hasSize || anchorRect == null) {
-      return;
-    }
-    final popupWidth = math
-        .max(260.0, anchorBox.size.width)
-        .clamp(260.0, 320.0)
-        .toDouble();
-    const popupMaxHeight = 360.0;
-
-    final currentSelection = _activeDispatchSceneSelection == null
-        ? null
-        : ConversationModelSelection(
-            providerProfileId: _activeDispatchSceneSelection!.providerProfileId,
-            modelId: _activeDispatchSceneSelection!.modelId,
-          );
-    final handle = showOverlayGlassPopup<ConversationModelSelection>(
-      context: context,
-      anchor: anchorRect,
-      builder: (handle) => ConversationModelSelectorContent(
-        width: popupWidth,
-        maxHeight: popupMaxHeight,
-        profiles: selectorProfiles,
-        providerModelsByProfileId: selectorOptions,
-        currentSelection: currentSelection,
-        // 软键盘"确定"提交搜索时:先打开 popup 的"一次性键盘隐藏豁免",再 unfocus
-        // —— 这样 IME 塌陷不会被 DismissOverlayOnKeyboardHide 当作"用户想关 popup"
-        // 误关掉,搜索结果列表得以保留。
-        onSearchSubmitted: () {
-          handle.keepOpenOnNextKeyboardHide();
-          FocusManager.instance.primaryFocus?.unfocus();
-        },
-        // dismiss 内部会立刻 complete future,让下面 await 的逻辑并行起跑;
-        // 收起动画在后台跑完,UI 更响应。
-        onSelect: (selection) => unawaited(handle.dismiss(selection)),
-      ),
-    );
-    setState(() {
-      _conversationModelSelectorHandle = handle;
-    });
-
     try {
-      final selected = await handle.future;
-      if (selected == null) {
+      if (_showSlashCommandPanel ||
+          _showModelMentionPanel ||
+          _openClawPanelExpanded) {
+        setState(() {
+          _showSlashCommandPanel = false;
+          _showModelMentionPanel = false;
+          _openClawPanelExpanded = false;
+        });
+      }
+      final activeSelection = _activeDispatchSceneSelection;
+      // Refresh the scene binding at the point of use, then independently
+      // force-refresh the configured official profile. The active Provider may
+      // be BYOK, while the selector still shows the official group.
+      await _loadNormalChatModelContextInternal();
+      await _refreshOfficialChatProviderModelsForSelector();
+      final refreshedSelection =
+          _activeDispatchSceneSelection ?? activeSelection;
+      final refreshedProviderModels = refreshedSelection == null
+          ? const <ProviderModelOption>[]
+          : (_modelOptionsByProfileId[refreshedSelection.providerProfileId] ??
+                const <ProviderModelOption>[]);
+      if (refreshedSelection != null && refreshedProviderModels.length <= 1) {
+        await _loadCachedProviderModelsForChatSelector(refreshedSelection);
+      }
+      final selectorProfiles = _modelProviderProfiles;
+      final selectorOptions = _modelOptionsByProfileId;
+      final hasSelectorModels = selectorProfiles.any((profile) {
+        return profile.configured &&
+            (selectorOptions[profile.id] ?? const <ProviderModelOption>[])
+                .isNotEmpty;
+      });
+      if (!hasSelectorModels) {
         return;
       }
-      await _applyDispatchSceneModelSelection(
-        providerProfileId: selected.providerProfileId,
-        modelId: selected.modelId,
+      if (!mounted || !anchorContext.mounted) {
+        return;
+      }
+      // 关键：不能调 `_inputFocusNode.unfocus()`，也不能用 `showGlassPopup`
+      // (push Navigator route)。两条路径都会让 TextField 失焦 → 软键盘塌陷 →
+      // 输入栏下沉 → popup 锚点错位(锚点是 popup 弹出瞬间按按钮在屏幕上的位置算的，
+      // 键盘塌陷后按钮位置已经变了)。
+      //
+      // Flutter 框架细节(重要)：`Route.requestFocus = false` **不能** 阻止 push
+      // 时的焦点迁移——`ModalRoute.didPush` 里检查的是 `navigator.widget.requestFocus`
+      // (Navigator 的 requestFocus),不是 Route 的。详见 routes.dart:1668。要彻底
+      // 跳过这条焦点迁移路径，唯一干净的办法是不走 Navigator 路由——直接挂到 Overlay。
+      // 这里走 [showOverlayGlassPopup],它把 OverlayEntry + Material + tap-outside +
+      // BackButtonListener + DismissOverlayOnKeyboardHide + playReverse 清理时序
+      // 都封装好了。
+      final anchorBox = anchorContext.findRenderObject() as RenderBox?;
+      final anchorRect = glassPopupAnchorFromContext(anchorContext);
+      if (anchorBox == null || !anchorBox.hasSize || anchorRect == null) {
+        return;
+      }
+      final popupWidth = math
+          .max(260.0, anchorBox.size.width)
+          .clamp(260.0, 320.0)
+          .toDouble();
+      const popupMaxHeight = 360.0;
+
+      final currentSelection = _activeDispatchSceneSelection == null
+          ? null
+          : ConversationModelSelection(
+              providerProfileId:
+                  _activeDispatchSceneSelection!.providerProfileId,
+              modelId: _activeDispatchSceneSelection!.modelId,
+            );
+      final handle = showOverlayGlassPopup<ConversationModelSelection>(
+        context: context,
+        anchor: anchorRect,
+        builder: (handle) => ConversationModelSelectorContent(
+          width: popupWidth,
+          maxHeight: popupMaxHeight,
+          profiles: selectorProfiles,
+          providerModelsByProfileId: selectorOptions,
+          currentSelection: currentSelection,
+          // 软键盘"确定"提交搜索时:先打开 popup 的"一次性键盘隐藏豁免",再 unfocus
+          // —— 这样 IME 塌陷不会被 DismissOverlayOnKeyboardHide 当作"用户想关 popup"
+          // 误关掉,搜索结果列表得以保留。
+          onSearchSubmitted: () {
+            handle.keepOpenOnNextKeyboardHide();
+            FocusManager.instance.primaryFocus?.unfocus();
+          },
+          // dismiss 内部会立刻 complete future,让下面 await 的逻辑并行起跑;
+          // 收起动画在后台跑完,UI 更响应。
+          onSelect: (selection) => unawaited(handle.dismiss(selection)),
+        ),
       );
-    } finally {
-      if (_conversationModelSelectorHandle == handle) {
-        if (mounted) {
-          setState(() {
+      setState(() {
+        _conversationModelSelectorHandle = handle;
+      });
+
+      try {
+        final selected = await handle.future;
+        if (selected == null) {
+          return;
+        }
+        await _applyDispatchSceneModelSelection(
+          providerProfileId: selected.providerProfileId,
+          modelId: selected.modelId,
+        );
+      } finally {
+        if (_conversationModelSelectorHandle == handle) {
+          if (mounted) {
+            setState(() {
+              _conversationModelSelectorHandle = null;
+            });
+          } else {
             _conversationModelSelectorHandle = null;
-          });
-        } else {
-          _conversationModelSelectorHandle = null;
+          }
         }
       }
+    } finally {
+      _conversationModelSelectorOpeningGuard.finish();
     }
   }
 

--- a/ui/lib/features/home/pages/chat/chat_page_model_context.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_model_context.dart
@@ -2,7 +2,12 @@ part of 'chat_page.dart';
 
 mixin _ChatPageModelContextMixin on _ChatPageStateBase {
   @override
-  Future<void> _loadNormalChatModelContext() async {
+  Future<void> _loadNormalChatModelContext() =>
+      _loadNormalChatModelContextInternal();
+
+  Future<void> _loadNormalChatModelContextInternal({
+    bool awaitOfficialCatalogRefresh = false,
+  }) async {
     try {
       final results = await Future.wait<dynamic>([
         ModelProviderConfigService.loadChatModelGroups(refresh: false),
@@ -28,10 +33,26 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
           overrideSelection: _activeConversationModelOverrideSelection,
         );
       });
-      // The first frame must use the Provider cache. Refresh only the active
-      // Provider in the background so an 88-model /models response (or an
-      // unrelated configured Provider) cannot block the chat page.
-      unawaited(_refreshActiveChatProviderModelsInBackground());
+      final activeSelection = _activeDispatchSceneSelection;
+      final activeProfile = activeSelection == null
+          ? null
+          : profiles
+                .where(
+                  (profile) => profile.id == activeSelection.providerProfileId,
+                )
+                .firstOrNull;
+      final shouldAwaitOfficialRefresh =
+          awaitOfficialCatalogRefresh &&
+          activeProfile?.sourceType == 'omnibot_official';
+      // Normal page loading must paint from cache immediately. The explicit
+      // model picker is the exception: its small official catalog is awaited
+      // once so newly published display names appear on the first opening.
+      // Large/custom Provider catalogs still refresh in the background.
+      if (shouldAwaitOfficialRefresh) {
+        await _refreshActiveChatProviderModelsInBackground();
+      } else {
+        unawaited(_refreshActiveChatProviderModelsInBackground());
+      }
       await _syncInvalidNormalConversationOverrideIfNeeded();
       await _syncActiveNormalConversationPromptTokenThreshold();
     } catch (e) {
@@ -536,7 +557,9 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
     // ACP runtime startup can finish before the Flutter scene snapshot does;
     // relying on the initial snapshot can therefore show the Provider's
     // default model even after a different Provider model was selected.
-    await _loadNormalChatModelContext();
+    await _loadNormalChatModelContextInternal(
+      awaitOfficialCatalogRefresh: true,
+    );
     final refreshedSelection = _activeDispatchSceneSelection ?? activeSelection;
     final refreshedProviderModels = refreshedSelection == null
         ? const <ProviderModelOption>[]
@@ -553,6 +576,9 @@ mixin _ChatPageModelContextMixin on _ChatPageStateBase {
               .isNotEmpty;
     });
     if (!hasSelectorModels) {
+      return;
+    }
+    if (!mounted || !anchorContext.mounted) {
       return;
     }
     // 关键：不能调 `_inputFocusNode.unfocus()`，也不能用 `showGlassPopup`

--- a/ui/lib/features/home/pages/chat/chat_page_models.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_models.dart
@@ -51,6 +51,24 @@ enum ChatIslandDisplayLayer {
 
 enum ChatMessageListMutationKind { none, content, structure }
 
+/// Prevents a second selector open from entering while the first is awaiting
+/// its catalog refresh and has not created an overlay handle yet.
+class ConversationModelSelectorOpeningGuard {
+  bool _opening = false;
+
+  bool get isOpening => _opening;
+
+  bool tryBegin() {
+    if (_opening) return false;
+    _opening = true;
+    return true;
+  }
+
+  void finish() {
+    _opening = false;
+  }
+}
+
 bool shouldReloadConversationMessagesChanged({
   required String? reason,
   required bool hasInFlightTask,

--- a/ui/lib/services/model_provider_config_service.dart
+++ b/ui/lib/services/model_provider_config_service.dart
@@ -355,6 +355,9 @@ class ProviderModelGroup {
 }
 
 class ModelProviderConfigService {
+  static const String _kOfficialProfileId = 'omnibot-official-ai';
+  static const String _kOfficialSourceType = 'omnibot_official';
+  static const String _kOfficialProfileName = 'OmniBot 官方 AI';
   static const String _kManualModelIdsKey = 'manual_provider_model_ids_v2';
   static const String _kHiddenChatModelIdsKey =
       'hidden_chat_provider_model_ids_v1';
@@ -622,6 +625,7 @@ class ModelProviderConfigService {
     String? profileId,
     String providerName = '',
     String? capability,
+    bool forceRefresh = false,
   }) async {
     // Capture the persisted profile before starting the network request. A
     // response obtained for an older profile revision must never replace the
@@ -642,6 +646,7 @@ class ModelProviderConfigService {
             'profileId': profileId.trim(),
           if (capability != null && capability.trim().isNotEmpty)
             'capability': capability.trim(),
+          if (forceRefresh) 'forceRefresh': true,
           if (profileSnapshot != null)
             'expectedProfileRevision': profileSnapshot.revision,
           if (profileSnapshot != null)
@@ -652,17 +657,30 @@ class ModelProviderConfigService {
         .where((item) => item.id.isNotEmpty)
         .toList();
 
-    var cacheBase = normalizeApiBase(apiBase) ?? '';
-    if (cacheBase.isEmpty && profileSnapshot != null) {
-      cacheBase = normalizeApiBase(profileSnapshot.baseUrl) ?? '';
+    // A cold official catalog may not expose its synthetic profile until the
+    // forced native refresh finishes. Resolve it again so that first response
+    // is cached for subsequent page loads just like an already-ready catalog.
+    var cacheProfileSnapshot = profileSnapshot;
+    if (cacheProfileSnapshot == null &&
+        targetProfileId == _kOfficialProfileId) {
+      final refreshedProfile = await _findProfileById(_kOfficialProfileId);
+      if (refreshedProfile?.sourceType == _kOfficialSourceType) {
+        cacheProfileSnapshot = refreshedProfile;
+      }
     }
-    if (cacheBase.isEmpty) {
+
+    var cacheBase = normalizeApiBase(apiBase) ?? '';
+    if (cacheBase.isEmpty && cacheProfileSnapshot != null) {
+      cacheBase = normalizeApiBase(cacheProfileSnapshot.baseUrl) ?? '';
+    }
+    if (cacheBase.isEmpty &&
+        cacheProfileSnapshot?.sourceType != _kOfficialSourceType) {
       final config = await getConfig();
       cacheBase = normalizeApiBase(config.baseUrl) ?? '';
     }
     var resolvedProviderName = providerName.trim();
-    if (resolvedProviderName.isEmpty && profileSnapshot != null) {
-      resolvedProviderName = profileSnapshot.name;
+    if (resolvedProviderName.isEmpty && cacheProfileSnapshot != null) {
+      resolvedProviderName = cacheProfileSnapshot.name;
     }
     final enrichedModels = await enrichModelsForProfile(
       profileId: targetProfileId ?? '',
@@ -672,27 +690,28 @@ class ModelProviderConfigService {
     );
     final normalizedCapability = capability?.trim().toLowerCase() ?? '';
     final isNonTextCapabilityScopedOfficialRequest =
-        profileSnapshot?.sourceType == 'omnibot_official' &&
+        cacheProfileSnapshot?.sourceType == _kOfficialSourceType &&
         normalizedCapability.isNotEmpty &&
         normalizedCapability != 'text';
     if (targetProfileId != null &&
-        profileSnapshot != null &&
+        cacheProfileSnapshot != null &&
         !isNonTextCapabilityScopedOfficialRequest) {
       try {
         final latestProfile = await _findProfileById(targetProfileId);
         final requestedBase = normalizeApiBase(apiBase) ?? '';
-        final snapshotBase = normalizeApiBase(profileSnapshot.baseUrl) ?? '';
+        final snapshotBase =
+            normalizeApiBase(cacheProfileSnapshot.baseUrl) ?? '';
         final requestMatchesSnapshot =
             requestedBase.isEmpty ||
             (snapshotBase.isNotEmpty && requestedBase == snapshotBase);
         if (latestProfile != null &&
             requestMatchesSnapshot &&
-            _sameProfileCacheIdentity(profileSnapshot, latestProfile)) {
+            _sameProfileCacheIdentity(cacheProfileSnapshot, latestProfile)) {
           await _saveCachedFetchedModels(
             profileId: targetProfileId,
             apiBase: cacheBase,
             models: enrichedModels,
-            profileRevision: profileSnapshot.revision,
+            profileRevision: cacheProfileSnapshot.revision,
           );
         }
       } catch (_) {
@@ -996,6 +1015,32 @@ class ModelProviderConfigService {
         );
         return ProviderModelGroup(profile: profile, models: models);
       }),
+    );
+  }
+
+  /// Forces the small platform-owned text catalog independently of whichever
+  /// BYOK/custom profile is currently active in the conversation.
+  static Future<ProviderModelGroup?> refreshOfficialChatModelGroup() async {
+    var officialProfile = await _findProfileById(_kOfficialProfileId);
+    final fetched = await fetchModels(
+      profileId: _kOfficialProfileId,
+      providerName: officialProfile?.name ?? _kOfficialProfileName,
+      capability: 'text',
+      forceRefresh: true,
+    );
+    officialProfile ??= await _findProfileById(_kOfficialProfileId);
+    if (officialProfile == null ||
+        officialProfile.sourceType != _kOfficialSourceType ||
+        !officialProfile.configured) {
+      return null;
+    }
+    final cached = await getChatModelOptionsForProfile(
+      officialProfile.id,
+      profile: officialProfile,
+    );
+    return ProviderModelGroup(
+      profile: officialProfile,
+      models: cached.isNotEmpty ? cached : fetched,
     );
   }
 

--- a/ui/lib/widgets/conversation_model_selector.dart
+++ b/ui/lib/widgets/conversation_model_selector.dart
@@ -365,6 +365,7 @@ class _ConversationModelSelectorContentState
     required ModelProviderProfileSummary profile,
     required ProviderModelOption model,
   }) {
+    final displayName = model.displayName.trim();
     final selected =
         widget.currentSelection?.providerProfileId == profile.id &&
         widget.currentSelection?.modelId == model.id;
@@ -420,7 +421,7 @@ class _ConversationModelSelectorContentState
                 const SizedBox(width: 6),
                 Expanded(
                   child: Text(
-                    model.id,
+                    displayName.isEmpty ? model.id : displayName,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(

--- a/ui/test/features/home/pages/chat/chat_page_models_test.dart
+++ b/ui/test/features/home/pages/chat/chat_page_models_test.dart
@@ -1,9 +1,35 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ui/features/home/pages/chat/chat_page_models.dart';
 import 'package:ui/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart';
 import 'package:ui/models/chat_message_model.dart';
 
 void main() {
+  test('model selector ignores repeated opens during a slow refresh', () async {
+    final guard = ConversationModelSelectorOpeningGuard();
+    final release = Completer<void>();
+
+    Future<bool> open() async {
+      if (!guard.tryBegin()) return false;
+      try {
+        await release.future;
+        return true;
+      } finally {
+        guard.finish();
+      }
+    }
+
+    final first = open();
+    expect(guard.isOpening, isTrue);
+    expect(await open(), isFalse);
+    release.complete();
+    expect(await first, isTrue);
+    expect(guard.isOpening, isFalse);
+    expect(guard.tryBegin(), isTrue);
+    guard.finish();
+  });
+
   group('ChatConversationRuntimeCoordinator.replaceConversationSnapshot '
       'preserveLiveStreamingState', () {
     final coordinator = ChatConversationRuntimeCoordinator.instance;

--- a/ui/test/services/model_provider_config_service_test.dart
+++ b/ui/test/services/model_provider_config_service_test.dart
@@ -158,9 +158,153 @@ void main() {
       );
       expect(arguments['expectedProfileRevision'], 9);
       expect(arguments['capability'], 'embedding');
+      expect(arguments.containsKey('forceRefresh'), isFalse);
       expect(
         arguments['expectedProfileBaseUrl'],
         'https://provider.example/v1',
+      );
+    },
+  );
+
+  test(
+    'explicit official refresh works with active BYOK and a cold cache',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await StorageService.init();
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final fetchCalls = <MethodCall>[];
+      var officialCatalogReady = false;
+      messenger.setMockMethodCallHandler(assistCoreChannel, (call) async {
+        switch (call.method) {
+          case 'listModelProviderProfiles':
+            return <String, dynamic>{
+              'profiles': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'id': 'byok-provider',
+                  'name': 'BYOK Provider',
+                  'baseUrl': 'https://byok.example/v1',
+                  'configured': true,
+                  'revision': 4,
+                },
+                if (officialCatalogReady)
+                  <String, dynamic>{
+                    'id': 'omnibot-official-ai',
+                    'name': 'OmniBot 官方 AI',
+                    'sourceType': 'omnibot_official',
+                    'readOnly': true,
+                    'ready': true,
+                    'configured': true,
+                    'revision': 0,
+                  },
+              ],
+              'editingProfileId': 'byok-provider',
+            };
+          case 'fetchProviderModels':
+            fetchCalls.add(call);
+            officialCatalogReady = true;
+            return <Map<String, dynamic>>[
+              <String, dynamic>{'id': 'opus-6', 'displayName': 'opus 6☺️'},
+            ];
+          default:
+            throw PlatformException(code: 'unexpected_method');
+        }
+      });
+      addTearDown(
+        () => messenger.setMockMethodCallHandler(assistCoreChannel, null),
+      );
+
+      final group =
+          await ModelProviderConfigService.refreshOfficialChatModelGroup();
+
+      expect(group, isNotNull);
+      expect(group!.profile.id, 'omnibot-official-ai');
+      expect(group.profile.sourceType, 'omnibot_official');
+      expect(group.models.single.id, 'opus-6');
+      expect(group.models.single.displayName, 'opus 6☺️');
+      final arguments = Map<dynamic, dynamic>.from(
+        fetchCalls.single.arguments as Map,
+      );
+      expect(arguments['profileId'], 'omnibot-official-ai');
+      expect(arguments['capability'], 'text');
+      expect(arguments['forceRefresh'], isTrue);
+      expect(
+        (await ModelProviderConfigService.getCachedFetchedModels(
+          profileId: 'omnibot-official-ai',
+          profileRevision: 0,
+        )).single.displayName,
+        'opus 6☺️',
+      );
+    },
+  );
+
+  test(
+    'explicit official refresh replaces an expired cached catalog',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await StorageService.init();
+      await ModelProviderConfigService.saveCachedFetchedModels(
+        profileId: 'omnibot-official-ai',
+        apiBase: '',
+        profileRevision: 0,
+        models: const <ProviderModelOption>[
+          ProviderModelOption(id: 'old-model', displayName: 'old-model'),
+        ],
+      );
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      final fetchCalls = <MethodCall>[];
+      messenger.setMockMethodCallHandler(assistCoreChannel, (call) async {
+        switch (call.method) {
+          case 'listModelProviderProfiles':
+            return <String, dynamic>{
+              'profiles': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'id': 'byok-provider',
+                  'name': 'BYOK Provider',
+                  'baseUrl': 'https://byok.example/v1',
+                  'configured': true,
+                  'revision': 4,
+                },
+                <String, dynamic>{
+                  'id': 'omnibot-official-ai',
+                  'name': 'OmniBot 官方 AI',
+                  'sourceType': 'omnibot_official',
+                  'readOnly': true,
+                  'ready': true,
+                  'configured': true,
+                  'revision': 0,
+                },
+              ],
+              'editingProfileId': 'byok-provider',
+            };
+          case 'fetchProviderModels':
+            fetchCalls.add(call);
+            return <Map<String, dynamic>>[
+              <String, dynamic>{'id': 'new-model', 'displayName': 'New Model'},
+            ];
+          default:
+            throw PlatformException(code: 'unexpected_method');
+        }
+      });
+      addTearDown(
+        () => messenger.setMockMethodCallHandler(assistCoreChannel, null),
+      );
+
+      final group =
+          await ModelProviderConfigService.refreshOfficialChatModelGroup();
+
+      expect(group!.models.map((model) => model.id), <String>['new-model']);
+      final arguments = Map<dynamic, dynamic>.from(
+        fetchCalls.single.arguments as Map,
+      );
+      expect(arguments['forceRefresh'], isTrue);
+      expect(
+        (await ModelProviderConfigService.getCachedFetchedModels(
+          profileId: 'omnibot-official-ai',
+          profileRevision: 0,
+        )).map((model) => model.id),
+        <String>['new-model'],
       );
     },
   );
@@ -494,6 +638,7 @@ void main() {
         fetchCalls.single.arguments as Map,
       );
       expect(arguments['capability'], 'text');
+      expect(arguments.containsKey('forceRefresh'), isFalse);
       expect(
         (await ModelProviderConfigService.getCachedFetchedModels(
           profileId: 'omnibot-official-ai',

--- a/ui/test/widgets/conversation_model_selector_test.dart
+++ b/ui/test/widgets/conversation_model_selector_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/services/model_provider_config_service.dart';
+import 'package:ui/widgets/conversation_model_selector.dart';
+
+void main() {
+  const officialProfile = ModelProviderProfileSummary(
+    id: 'official',
+    name: 'OmniBot 官方 AI',
+    baseUrl: '',
+    apiKey: '',
+    customHeaders: <String, String>{},
+    sourceType: 'omnibot_official',
+    readOnly: true,
+    ready: true,
+    statusText: '',
+    configured: true,
+  );
+
+  Future<void> pumpSelector(
+    WidgetTester tester, {
+    required ProviderModelOption model,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ConversationModelSelectorContent(
+            width: 320,
+            maxHeight: 360,
+            profiles: const <ModelProviderProfileSummary>[officialProfile],
+            providerModelsByProfileId: <String, List<ProviderModelOption>>{
+              officialProfile.id: <ProviderModelOption>[model],
+            },
+            currentSelection: ConversationModelSelection(
+              providerProfileId: officialProfile.id,
+              modelId: model.id,
+            ),
+            showSearchField: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('shows the catalog display name and keeps the model ID tooltip', (
+    tester,
+  ) async {
+    await pumpSelector(
+      tester,
+      model: const ProviderModelOption(id: 'opus-6', displayName: 'opus 6☺️'),
+    );
+
+    expect(find.text('opus 6☺️'), findsOneWidget);
+    expect(find.text('opus-6'), findsNothing);
+    expect(find.byTooltip('opus-6'), findsOneWidget);
+  });
+
+  testWidgets('falls back to the model ID when display name is blank', (
+    tester,
+  ) async {
+    await pumpSelector(
+      tester,
+      model: const ProviderModelOption(id: 'opus-6', displayName: '   '),
+    );
+
+    expect(find.text('opus-6'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 变更摘要

接入平台官方模型目录的 `display_names` 字段，使 App 可以显示服务端下发的友好模型名称。修复服务端已经返回“opus 6☺️”，但模型选择器仍固定显示内部 ID `opus-6` 的问题。

同时修复模型选择器在 BYOK 场景下无法及时刷新官方目录、普通后台加载重复强刷目录，以及慢网下并发刷新和重复打开弹层的问题。

## 变更类型

- [x] Bug 修复
- [x] 新功能
- [ ] 重构
- [ ] 文档更新
- [x] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

无。

## 主要改动

1. 解析官方模型目录中的 `display_names`，仅接受目录中真实存在且名称非空的模型映射。
2. 打开模型选择器时独立刷新官方模型目录，不再依赖当前活跃 Provider；当前使用 BYOK 或其他自定义 Provider 时，也能获得最新官方模型。
3. 仅显式打开模型选择器时强制刷新官方目录；启动、切换会话和恢复前台等普通后台路径继续复用已就绪缓存。
4. 合并并发中的官方目录同步，避免后台同步尚未结束时再次排队执行强制刷新。
5. 在模型选择器首次异步等待前设置 opening guard，避免慢网等待期间重复点击创建多个 Overlay。
6. 模型选择器优先显示友好名称，名称缺失时回退到模型 ID；长按仍可查看真实模型 ID。
7. 显示名称仅用于 UI，实际请求、模型白名单、路由和计费仍使用原始模型 ID。
8. 网络刷新失败时继续保留已有缓存，不影响离线或临时网络异常场景。

## 审查意见修复

- [x] 当前 Provider 为 BYOK 时，首次打开选择器会独立刷新官方目录。
- [x] 官方缓存为空时，可在首次打开选择器时加载官方模型。
- [x] 官方缓存过期时，显式刷新会替换旧目录和旧显示名称。
- [x] 普通后台加载不携带强制刷新标记，继续复用已就绪目录。
- [x] 并发目录同步合并为一次实际请求，不再叠加慢网等待。
- [x] 选择器 opening guard 在第一个 `await` 前设置，连续点击不会重复创建弹层。

## 测试说明

- [x] 已执行相关 Flutter 测试
- [x] 已执行 baselib 策略测试
- [x] 已验证 App Kotlin 编译
- [x] 已完成前序完整构建和 Android 真机验证

审查修复后验证：

- Flutter 相关测试共 43 项通过：
  - Model Provider 服务与缓存测试 23 项；
  - Chat 页面模型辅助逻辑及 opening guard 测试 18 项；
  - 模型选择器显示名称与 ID 回退测试 2 项。
- 覆盖当前 Provider 为 BYOK、官方缓存为空和缓存过期场景。
- 覆盖普通后台缓存路径、显式强制刷新、慢网重复点击和并发请求合并场景。
- `PlatformAiProvisionerPolicyTest` 通过。
- `:app:compileDevelopStandardDebugKotlin` 通过。
- `git diff --check` 通过。
- Flutter 静态检查未发现本次改动新增的诊断；相关文件仍只有仓库既有 warning。

本 PR 前序完整验证：

- App 单元测试共 569 项：562 项通过；7 项因 Windows 环境不存在 `/bin/sh` 无法执行。
- 环境型失败仅涉及 5 个 `RemoteCodexAppServerSessionTest` 和 2 个 `EnvironmentSetupLogicTest`，与本次平台模型改动无关。
- `assembleDevelopStandardDebug` 完整构建成功。
- 已安装到 Android 真机，版本为 0.5.8.12。
- 真机首次打开模型选择器即可看到“opus 6☺️”。
- 选择“opus 6☺️”后重启 App，选中状态正确保留。
- 使用内部模型 ID `opus-6` 发起真实请求，模型成功返回 `OK`，服务端 `/v1/chat/completions` 记录为 HTTP 200。
- 未发现 `AndroidRuntime` 或 `FATAL EXCEPTION`。

## UI 变更（如有）

模型选择器现在显示服务端下发的友好名称，例如：

- `Qwen3.5 Plus`
- `DeepSeek V4 Flash`
- `DeepSeek V4 Pro`
- `Qwen3.7 Plus`
- `opus 6☺️`

真机验证截图：

<!-- 请在这里拖入 final-picker-05812.png -->

## 风险与回滚

风险较低：

- `display_names` 为可选字段，旧网关未返回该字段时会自动回退显示模型 ID。
- 友好名称仅影响界面展示，不参与模型请求、白名单判断、路由或计费。
- 只有显式打开模型选择器时才强制刷新官方目录，普通后台加载继续使用已就绪缓存。
- 并发同步会复用同一个进行中的请求，慢网或离线时不会重复排队刷新。
- 官方目录刷新失败时继续使用本地缓存，不会导致已有模型不可用。
- 已同步最新 `main 0.5.8.12`，没有覆盖 main 的界面样式修改。

如需回滚，可回退本 PR 的平台模型显示名称及目录刷新相关提交；服务端新增字段为可选字段，不影响旧客户端。

## 自检清单

- [x] 代码遵循项目现有风格
- [x] 无新增明显警告或错误日志
- [x] 已补充审查指出的 BYOK、缓存和并发场景测试
- [x] 已确认不会影响请求模型 ID、白名单、路由或计费
- [x] 已确认不会影响无关模块
