### PR TITLE
fix: restore Xiaowan conversation context

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/AgentConversationModePolicy.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/AgentConversationModePolicy.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 object AgentConversationModePolicy {
+    /** Canonical durable mode for the shared Agent/ACP conversation surface. */
+    const val AGENT_MODE = "agent"
     const val NORMAL_MODE = "normal"
     const val SUBAGENT_MODE = "subagent"
     const val CHAT_ONLY_MODE = "chat_only"

--- a/app/src/main/java/cn/com/omnimind/bot/agent/XiaowanAcpConnection.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/XiaowanAcpConnection.kt
@@ -367,7 +367,7 @@ private class XiaowanAgentSession(
                     ?: return arguments
                 return arguments + mapOf(
                     "parentConversationId" to conversationId,
-                    "parentConversationMode" to AgentConversationModePolicy.NORMAL_MODE
+                    "parentConversationMode" to AgentConversationModePolicy.AGENT_MODE
                 )
             }
         },
@@ -398,11 +398,35 @@ private class XiaowanAgentSession(
                 "inMemoryMessages=${messages.size} historySource=" +
                 if (conversationId != null) "conversation" else "session_memory"
         )
-        val conversationMode = (meta as? JsonObject)
+        val requestedConversationMode = (meta as? JsonObject)
             ?.get("conversationMode")
             ?.jsonPrimitive
             ?.content
-            ?: AgentConversationModePolicy.NORMAL_MODE
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        // The durable Conversation is authoritative when an older caller
+        // omits local ACP metadata. Otherwise a session/prompt silently
+        // falls back to `normal` and reads an empty bucket from an Agent
+        // conversation, even though the database contains the full history.
+        val persistedConversationMode = conversationId
+            ?.let { id ->
+                runCatching {
+                    cn.com.omnimind.baselib.database.DatabaseHelper
+                        .getConversationById(id)
+                        ?.mode
+                        ?.trim()
+                        ?.takeIf { it.isNotEmpty() }
+                }.getOrNull()
+            }
+        val conversationMode = persistedConversationMode
+            ?: requestedConversationMode
+            ?: AgentConversationModePolicy.AGENT_MODE
+        Log.i(
+            TAG,
+            "prompt context conversation=${conversationId ?: "unbound"} " +
+                "conversationMode=$conversationMode " +
+                "modeSource=${if (persistedConversationMode != null) "conversation" else "acp_meta_or_agent_default"}"
+        )
         val reasoningEffort = normalizeXiaowanReasoningEffort(
             (meta as? JsonObject)
                 ?.get("reasoningEffort")

--- a/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/conversation/AgentConversationHistoryRepository.kt
@@ -157,10 +157,11 @@ class AgentConversationHistoryRepository(
         fallbackStatus: String = STATUS_RUNNING,
         fallbackSummary: String = ""
     ) = withContext(Dispatchers.IO) {
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
         val normalizedEntryId = entryId.trim()
         val existing = loadThreadEntryByIdSafe(
             conversationId = conversationId,
-            conversationMode = conversationMode,
+            conversationMode = effectiveConversationMode,
             entryId = normalizedEntryId
         )
         // ACP tool/call ids are scoped to a single provider turn. Providers
@@ -191,7 +192,7 @@ class AgentConversationHistoryRepository(
         } else {
             loadThreadEntryByIdSafe(
                 conversationId = conversationId,
-                conversationMode = conversationMode,
+                conversationMode = effectiveConversationMode,
                 entryId = storageEntryId
             )
         }
@@ -225,7 +226,7 @@ class AgentConversationHistoryRepository(
             AgentConversationEntry(
                 id = storageExisting?.id ?: 0,
                 conversationId = conversationId,
-                conversationMode = conversationMode,
+                conversationMode = effectiveConversationMode,
                 entryId = storageEntryId,
                 entryType = ENTRY_TYPE_TOOL_EVENT,
                 status = normalizedStatus,
@@ -245,10 +246,11 @@ class AgentConversationHistoryRepository(
         payload: Map<String, Any?>,
         createdAt: Long = System.currentTimeMillis()
     ) = withContext(Dispatchers.IO) {
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
         upsertEntry(
             AgentConversationEntry(
                 conversationId = conversationId,
-                conversationMode = conversationMode,
+                conversationMode = effectiveConversationMode,
                 entryId = entryId,
                 entryType = ENTRY_TYPE_STREAM_EVENT,
                 status = STATUS_SUCCESS,
@@ -266,7 +268,11 @@ class AgentConversationHistoryRepository(
         messages: List<Map<String, Any?>>
     ) = withContext(Dispatchers.IO) {
         val existingConversation = DatabaseHelper.getConversationById(conversationId)
-        val existingEntries = loadThreadEntriesAscSafePaged(conversationId, conversationMode)
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
+        val existingEntries = loadThreadEntriesAscSafePaged(
+            conversationId,
+            effectiveConversationMode
+        )
         val existingToolPayloads = existingEntries
             .filter { it.entryType == ENTRY_TYPE_TOOL_EVENT }
             .associate { entry ->
@@ -283,7 +289,7 @@ class AgentConversationHistoryRepository(
             incomingMessages = messages
         )
         var remappedCutoffEntryDbId: Long? = null
-        conversationModeCandidates(conversationMode).forEach { storageMode ->
+        conversationModeCandidates(effectiveConversationMode).forEach { storageMode ->
             DatabaseHelper.deleteAgentConversationThread(conversationId, storageMode)
         }
         ConversationSnapshotOrdering.prepareForStorage(mergedMessages).forEach { prepared ->
@@ -331,7 +337,7 @@ class AgentConversationHistoryRepository(
             val insertedId = upsertEntry(
                 AgentConversationEntry(
                     conversationId = conversationId,
-                    conversationMode = conversationMode,
+                    conversationMode = effectiveConversationMode,
                     entryId = entryId,
                     entryType = type,
                     status = status,
@@ -368,7 +374,8 @@ class AgentConversationHistoryRepository(
         conversationMode: String,
         finalizeInterruptedEntries: Boolean = true
     ): List<Map<String, Any?>> = withContext(Dispatchers.IO) {
-        val entries = loadThreadEntriesDescSafePaged(conversationId, conversationMode)
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
+        val entries = loadThreadEntriesDescSafePaged(conversationId, effectiveConversationMode)
         val displayEntries = if (finalizeInterruptedEntries) {
             normalizeEntriesForDisplay(entries)
         } else {
@@ -384,10 +391,16 @@ class AgentConversationHistoryRepository(
         limit: Int,
         offset: Int
     ): Pair<List<Map<String, Any?>>, Boolean> = withContext(Dispatchers.IO) {
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
         val totalCount = DatabaseHelper.countAgentConversationThreadEntries(
-            conversationId, conversationMode
+            conversationId, effectiveConversationMode
         )
-        val entries = loadThreadEntriesDescPagedSafe(conversationId, conversationMode, limit, offset)
+        val entries = loadThreadEntriesDescPagedSafe(
+            conversationId,
+            effectiveConversationMode,
+            limit,
+            offset
+        )
         val normalized = if (offset == 0) {
             normalizeEntriesForDisplay(entries)
         } else {
@@ -403,7 +416,8 @@ class AgentConversationHistoryRepository(
         conversationId: Long,
         conversationMode: String
     ) = withContext(Dispatchers.IO) {
-        conversationModeCandidates(conversationMode).forEach { storageMode ->
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
+        conversationModeCandidates(effectiveConversationMode).forEach { storageMode ->
             DatabaseHelper.deleteAgentConversationThread(conversationId, storageMode)
         }
         resetContextSummary(conversationId)
@@ -437,8 +451,9 @@ class AgentConversationHistoryRepository(
             return@withContext PromptSeed(emptyList())
         }
         val conversation = DatabaseHelper.getConversationById(conversationId)
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
         val normalizedEntries = normalizeInterruptedToolEntries(
-            loadThreadEntriesAscSafePaged(conversationId, conversationMode)
+            loadThreadEntriesAscSafePaged(conversationId, effectiveConversationMode)
         )
         AgentConversationHistorySupport.buildPromptSeedFromEntries(
             entries = normalizedEntries,
@@ -452,8 +467,9 @@ class AgentConversationHistoryRepository(
         conversationMode: String
     ): ContextCompactionCandidate? = withContext(Dispatchers.IO) {
         val conversation = DatabaseHelper.getConversationById(conversationId) ?: return@withContext null
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
         val normalizedEntries = normalizeInterruptedToolEntries(
-            loadThreadEntriesAscSafePaged(conversationId, conversationMode)
+            loadThreadEntriesAscSafePaged(conversationId, effectiveConversationMode)
         )
         val selection = AgentConversationHistorySupport.selectEntriesToCompact(
             entries = normalizedEntries,
@@ -514,9 +530,10 @@ class AgentConversationHistoryRepository(
         status: String,
         createdAt: Long
     ) = withContext(Dispatchers.IO) {
+        val effectiveConversationMode = resolveConversationMode(conversationId, conversationMode)
         val existing = loadThreadEntryByIdSafe(
             conversationId = conversationId,
-            conversationMode = conversationMode,
+            conversationMode = effectiveConversationMode,
             entryId = entryId
         )
         val resolvedPayload = if (
@@ -536,7 +553,7 @@ class AgentConversationHistoryRepository(
             AgentConversationEntry(
                 id = existing?.id ?: 0,
                 conversationId = conversationId,
-                conversationMode = conversationMode,
+                conversationMode = effectiveConversationMode,
                 entryId = entryId,
                 entryType = entryType,
                 status = status,
@@ -559,7 +576,7 @@ class AgentConversationHistoryRepository(
 
     private fun canonicalConversationMode(mode: String): String {
         return when (mode.trim().lowercase()) {
-            "agent", "codex", "acp", "coding" -> "agent"
+            "", "normal", "agent", "codex", "acp", "coding" -> "agent"
             else -> mode.trim().lowercase().ifEmpty { "normal" }
         }
     }
@@ -750,10 +767,30 @@ class AgentConversationHistoryRepository(
     private fun conversationModeCandidates(conversationMode: String): List<String> {
         val normalized = conversationMode.trim().lowercase().ifEmpty { "normal" }
         return if (normalized in setOf("agent", "codex", "acp", "coding")) {
-            listOf("agent", "codex")
+            // `normal` is the pre-ACP Xiaowan bucket. Keep it readable while
+            // all new writes use canonical `agent`.
+            listOf("agent", "codex", "normal")
         } else {
             listOf(normalized)
         }
+    }
+
+    /**
+     * The Conversation row is the durable ownership boundary. UI callers may
+     * still arrive through an old route and say `normal`/`codex`; allowing
+     * that hint to select a different history bucket is what made context
+     * disappear after a refresh or session/load. Use the requested mode only
+     * for a not-yet-materialized conversation.
+     */
+    private suspend fun resolveConversationMode(
+        conversationId: Long,
+        requestedMode: String
+    ): String {
+        val persistedMode = DatabaseHelper.getConversationById(conversationId)
+            ?.mode
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        return canonicalConversationMode(persistedMode ?: requestedMode)
     }
 
     private suspend fun loadThreadEntriesDescPagedSafe(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentSessionBindingRepository.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentSessionBindingRepository.kt
@@ -273,7 +273,9 @@ internal class AgentSessionBindingRepository(
     }
 
     companion object {
-        const val AGENT_MODE_STORAGE_VALUE = "codex"
+        // `codex` remains a read-compatible legacy alias, but new bindings
+        // must use the canonical Agent conversation mode.
+        const val AGENT_MODE_STORAGE_VALUE = "agent"
     }
 }
 

--- a/app/src/main/java/cn/com/omnimind/bot/webchat/ConversationDomainService.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/webchat/ConversationDomainService.kt
@@ -508,7 +508,9 @@ class ConversationDomainService(
     fun normalizeConversationMode(rawMode: String?): String {
         val normalized = rawMode?.trim()?.lowercase().orEmpty()
         return when (normalized) {
-            "", "normal" -> "normal"
+            // Xiaowan used to be stored as `normal`. It is now the built-in
+            // ACP Agent. Pure chat has its explicit `chat_only` mode.
+            "", "normal" -> AGENT_MODE_STORAGE_VALUE
             "agent", "codex", "acp", "coding" -> AGENT_MODE_STORAGE_VALUE
             "chat", "chatonly", "chat-only" -> "chat_only"
             else -> normalized

--- a/ui/lib/features/home/pages/agent/agent_sessions_page.dart
+++ b/ui/lib/features/home/pages/agent/agent_sessions_page.dart
@@ -215,6 +215,7 @@ class _AgentSessionsPageState extends State<AgentSessionsPage> {
       }
       final response = await AgentRuntimeService.loadSession(
         sessionId: session.threadId,
+        conversationMode: ConversationMode.agent.storageValue,
       );
       final conversationId = _intValue(response['conversationId']);
       if (conversationId == null) {

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -205,7 +205,9 @@ abstract class _ChatPageStateBase extends State<ChatPage>
   String _openClawToken = '';
   String _openClawUserId = '';
   ChatSurfaceMode _activeSurfaceMode = ChatSurfaceMode.normal;
-  ChatPageMode _activeConversationMode = ChatPageMode.normal;
+  // The default Xiaowan surface is the built-in ACP Agent. `normal` remains
+  // a compatibility page state for old routes, not a second runtime mode.
+  ChatPageMode _activeConversationMode = ChatPageMode.agent;
   bool _showSlashCommandPanel = false;
   bool _showModelMentionPanel = false;
   bool _openClawPanelExpanded = false;
@@ -540,7 +542,9 @@ abstract class _ChatPageStateBase extends State<ChatPage>
         return targetMode!;
       }
     }
-    return ConversationMode.normal;
+    // Xiaowan used to be exposed as `normal`. Keep the page state compatible,
+    // but route its durable conversation and ACP history through Agent.
+    return ConversationMode.agent;
   }
 
   ChatPageMode _pageModeForConversationMode(ConversationMode mode) =>
@@ -777,7 +781,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
     }
     _storeDraftForActiveConversationMode();
     await _persistVisibleThreadTargetIfNeeded();
-    final target = _newThreadTargetForConversationMode(ConversationMode.normal);
+    final target = _newThreadTargetForConversationMode(ConversationMode.agent);
     if (!mounted) {
       return;
     }
@@ -803,7 +807,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
 
   Future<void> _togglePureChatConversationMode() async {
     final nextMode = _isPureChatSelected
-        ? ConversationMode.normal
+        ? ConversationMode.agent
         : ConversationMode.chatOnly;
     final nextTarget = _newThreadTargetForConversationMode(nextMode);
     await _applyConversationThreadTarget(nextTarget);

--- a/ui/lib/features/home/pages/chat/chat_page_agent.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_agent.dart
@@ -362,7 +362,7 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
   }
 
   ConversationThreadTarget _resolveAgentExitTarget() {
-    return _newThreadTargetForConversationMode(ConversationMode.normal);
+    return _newThreadTargetForConversationMode(ConversationMode.agent);
   }
 
   @override
@@ -467,6 +467,7 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
       }
       final response = await AgentRuntimeService.loadSession(
         sessionId: threadId,
+        conversationMode: ConversationMode.agent.storageValue,
       );
       if (!mounted) return;
       final resolvedThreadId =
@@ -1951,10 +1952,16 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
     String threadId,
   ) async {
     try {
-      return await AgentRuntimeService.readSession(sessionId: threadId);
+      return await AgentRuntimeService.readSession(
+        sessionId: threadId,
+        conversationMode: ConversationMode.agent.storageValue,
+      );
     } catch (error) {
       debugPrint('Agent thread/read failed, falling back to resume: $error');
-      return AgentRuntimeService.loadSession(sessionId: threadId);
+      return AgentRuntimeService.loadSession(
+        sessionId: threadId,
+        conversationMode: ConversationMode.agent.storageValue,
+      );
     }
   }
 

--- a/ui/lib/features/home/pages/chat/chat_page_agent.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_agent.dart
@@ -1729,6 +1729,10 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
         model: turnModel,
         effort: _activeAgentReasoningEffort,
         collaborationMode: collaborationModeForTurn,
+        // The Agent page owns ConversationMode.agent. Keep the mode on the
+        // canonical ACP prompt so built-in agents read the same durable
+        // history bucket that this page writes.
+        conversationMode: ConversationMode.agent.storageValue,
       );
       final resolvedThreadId = _asAgentString(response['threadId']);
       if (resolvedThreadId != null && remoteCodex) {

--- a/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_lifecycle.dart
@@ -170,7 +170,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
       }
     }
 
-    final resolvedMode = normalizedPreferredMode ?? ConversationMode.normal;
+    final resolvedMode = normalizedPreferredMode ?? ConversationMode.agent;
     final savedTarget =
         await ConversationHistoryService.getCurrentConversationTarget(
           mode: resolvedMode,
@@ -354,6 +354,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
         conversationId: conversationId,
         agentId: requestedAgentId.isEmpty ? null : requestedAgentId,
         includeHistory: false,
+        conversationMode: target.mode.storageValue,
       );
       try {
         status = await AgentRuntimeService.status();
@@ -1064,7 +1065,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     final staged = _activeStagedSharedOpenDraft();
     if (staged != null && staged.hasContent) {
       return ConversationThreadTarget.newConversation(
-        mode: ConversationMode.normal,
+        mode: ConversationMode.agent,
         fromNativeRoute: true,
         requestKey: staged.requestKey,
       );
@@ -1078,7 +1079,7 @@ mixin _ChatPageLifecycleMixin on _ChatPageStateBase {
     _stagedSharedOpenDraftExpiresAt =
         DateTime.now().millisecondsSinceEpoch + 5000;
     return ConversationThreadTarget.newConversation(
-      mode: ConversationMode.normal,
+      mode: ConversationMode.agent,
       fromNativeRoute: true,
       requestKey: payload.requestKey,
     );

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -839,7 +839,12 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
       if (!isEphemeralRuntime(conversationId: conversationId, mode: mode)) {
         schedulePersistRuntimeConversation(
           conversationId: conversationId,
-          mode: kChatRuntimeModeAgent,
+          // ACP execution can be hosted by the normal chat runtime (for
+          // example Xiaowan) as well as the dedicated Agent page. Persist
+          // into the runtime that admitted the event; using the Agent mode
+          // here strands normal-chat history in a different storage bucket,
+          // so the next Xiaowan prompt cannot reconstruct its context.
+          mode: mode,
           persistMessages: true,
         );
       }

--- a/ui/lib/features/home/pages/chat_history/chat_history_page.dart
+++ b/ui/lib/features/home/pages/chat_history/chat_history_page.dart
@@ -233,6 +233,7 @@ class _ChatHistoryPageState extends State<ChatHistoryPage> {
     GoRouterManager.push(
       '/home/chat',
       extra: ConversationThreadTarget.newConversation(
+        mode: ConversationMode.agent,
         requestKey: DateTime.now().microsecondsSinceEpoch.toString(),
       ),
     );

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -1242,7 +1242,7 @@ class _ChatBotSheetState extends State<ChatBotSheet>
         text: userMessage,
         attachments: attachments,
         model: dispatchScene?.effectiveModel.trim(),
-        conversationMode: ConversationMode.normal.storageValue,
+        conversationMode: ConversationMode.agent.storageValue,
       );
       _acpSessionId = (response['sessionId'] ?? response['threadId'])
           ?.toString()

--- a/ui/lib/features/home/widgets/home_drawer.dart
+++ b/ui/lib/features/home/widgets/home_drawer.dart
@@ -95,7 +95,7 @@ class HomeDrawer extends ConsumerStatefulWidget {
   const HomeDrawer({
     super.key,
     this.memoryCount,
-    this.newConversationMode = ConversationMode.normal,
+    this.newConversationMode = ConversationMode.agent,
     this.embedded = false,
     this.closeOnNavigate = true,
     this.onThreadTargetSelected,

--- a/ui/lib/features/home/widgets/home_drawer_actions.dart
+++ b/ui/lib/features/home/widgets/home_drawer_actions.dart
@@ -49,7 +49,7 @@ extension _HomeDrawerActions on HomeDrawerState {
     // 都会被 AgentConversationModePolicy 过滤掉)。chatOnly 保持继承,因为那是用户
     // 主动选择的纯聊天模式。
     final newMode = widget.newConversationMode == ConversationMode.subagent
-        ? ConversationMode.normal
+        ? ConversationMode.agent
         : widget.newConversationMode;
     _openThreadTarget(
       ConversationThreadTarget.newConversation(

--- a/ui/lib/models/conversation_model.dart
+++ b/ui/lib/models/conversation_model.dart
@@ -75,7 +75,7 @@ class ConversationModel {
 
   ConversationModel({
     required this.id,
-    this.mode = ConversationMode.normal,
+    this.mode = ConversationMode.agent,
     this.agentCwd,
     this.agentId,
     this.isArchived = false,

--- a/ui/lib/models/conversation_thread_target.dart
+++ b/ui/lib/models/conversation_thread_target.dart
@@ -28,7 +28,7 @@ class ConversationThreadTarget {
   final String? initialMessage;
 
   const ConversationThreadTarget.newConversation({
-    this.mode = ConversationMode.normal,
+    this.mode = ConversationMode.agent,
     this.fromNativeRoute = false,
     this.requestKey,
     this.agentRuntime,
@@ -41,7 +41,7 @@ class ConversationThreadTarget {
 
   const ConversationThreadTarget.existing({
     required this.conversationId,
-    this.mode = ConversationMode.normal,
+    this.mode = ConversationMode.agent,
     this.fromNativeRoute = false,
     this.requestKey,
     this.agentId,

--- a/ui/lib/services/agent_runtime_service.dart
+++ b/ui/lib/services/agent_runtime_service.dart
@@ -810,12 +810,15 @@ class AgentRuntimeService {
     String? sessionId,
     int? conversationId,
     String? agentId,
+    String? conversationMode,
   }) {
     return _invokeMap('session/load', {
       if (sessionId != null) 'sessionId': sessionId,
       if (conversationId != null) 'conversationId': conversationId,
       if (agentId != null && agentId.trim().isNotEmpty)
         'agentId': agentId.trim(),
+      if (conversationMode != null && conversationMode.trim().isNotEmpty)
+        'conversationMode': conversationMode.trim(),
     });
   }
 
@@ -824,6 +827,7 @@ class AgentRuntimeService {
     int? conversationId,
     String? agentId,
     bool includeHistory = true,
+    String? conversationMode,
   }) {
     return _invokeMap('session/load', {
       if (sessionId != null) 'sessionId': sessionId,
@@ -831,6 +835,8 @@ class AgentRuntimeService {
       if (agentId != null && agentId.trim().isNotEmpty)
         'agentId': agentId.trim(),
       'includeHistory': includeHistory,
+      if (conversationMode != null && conversationMode.trim().isNotEmpty)
+        'conversationMode': conversationMode.trim(),
     });
   }
 

--- a/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
+++ b/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ui/features/home/pages/chat/chat_page_models.dart';
 import 'package:ui/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart';
 import 'package:ui/models/chat_message_model.dart';
+import 'package:ui/models/conversation_model.dart';
 import 'package:ui/services/voice_playback_coordinator.dart';
 
 void main() {
@@ -172,6 +173,47 @@ void main() {
     );
     expect(runtime.isAiResponding, isTrue);
   });
+
+  test(
+    'persists normal ACP events into the normal conversation history',
+    () async {
+      const conversationId = 2005;
+      const turnId = 'turn-xiaowan-normal-history';
+
+      applyAcp(
+        conversationId,
+        'turn/started',
+        turnId: turnId,
+        mode: kChatRuntimeModeNormal,
+      );
+      applyAcp(
+        conversationId,
+        'session/update',
+        turnId: turnId,
+        mode: kChatRuntimeModeNormal,
+        params: <String, dynamic>{
+          'sessionId': 'session-xiaowan-normal-history',
+          'update': <String, dynamic>{
+            'sessionUpdate': 'agent_message_chunk',
+            'messageId': 'message-normal-history',
+            'content': <String, dynamic>{'text': '第一轮回复'},
+          },
+        },
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      final replaceCalls = recordedMethodCalls
+          .where((call) => call.method == 'replaceConversationMessages')
+          .toList();
+      expect(replaceCalls, isNotEmpty);
+      expect(replaceCalls.last.arguments['conversationId'], conversationId);
+      expect(
+        replaceCalls.last.arguments['mode'],
+        ConversationMode.normal.storageValue,
+      );
+    },
+  );
 
   test(
     'begins a turn without a visible thinking placeholder before ACP output',


### PR DESCRIPTION
## Summary

修复小万在同一个 conversation 中无法继承上一轮上下文的问题，并把默认小万入口统一到 ACP `agent` 模式。

## Root cause

历史读写曾同时依赖调用方传入的 `conversationMode`。旧页面或 `session/load` 传入 `normal`/`codex` 时，会把同一个 conversation 路由到错误的历史分区；消息仍可能显示在 UI 中，但下一轮 prompt 的 history seed 为空或不完整。

## Changes

- 以 Conversation 数据库记录的 mode 作为历史归属边界，不再让旧路由传入的 mode 覆盖已存在会话的真实归属。
- 小万默认、新建会话、Agent 页面、`session/load`/`session/read` 和快捷入口统一使用 ACP `agent` mode。
- 旧的 `normal` 历史仍可读取，并在后续写入时归一到 `agent`；旧 `codex` 分区也保留兼容读取，既有会话不删除。
- `chat_only`、`subagent`、OpenClaw 仍是独立模式，不会被强行改成 Agent。
- 保持共享 `conversationId`、ACP session 和现有事件持久化边界，不引入第二套历史协议。

## Expected behavior

- 在同一个小万 conversation 中先说“我叫小明”，再问“我叫什么”，第二轮会带上第一轮历史。
- 刷新页面、执行 `session/load` 或重新进入历史会话后，上下文仍从同一个 conversation 的 history seed 恢复。
- 新建普通聊天进入的是 ACP Agent 表现；切换到纯聊天时仍不启用工具能力。
- 旧会话的消息和上下文保持可见、可继续，不需要清库或重新创建会话。

## Validation

- `git diff --check` 通过。
- ACP 相关 Android 单元测试通过：`AgentConversationModePolicyTest`、`AgentConversationHistorySupportTest`、`AgentOrchestratorTest`。
- 最新工作区版本已构建并安装到真机 `PJE110`，版本 `0.5.8.14`，未清除应用数据。
- PR 分支的 CI 继续负责干净环境下的完整编译与 Flutter 检查；本机后续复跑因当前环境没有可用 JDK 被阻断。

## Scope note

本 PR 只包含会话上下文归属、默认 Agent mode 和兼容迁移；工作区中其他未提交的 OmniFlow、取消任务和日志修改没有带入。
