### PR TITLE
fix(agent): 修复 Anthropic 协议工具续接与消息重复

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmClient.kt
@@ -440,7 +440,9 @@ class HttpAgentLlmClient(
             json = json,
             includeReasoningInAssistantMessage = routeInfo.requiresReasoningEcho,
             bufferLeadingTextUntilInlineThinkTag = shouldBufferLeadingInlineThinkTag(routeInfo),
-            guardLeadingReasoningLeak = shouldGuardNvidiaKimiReasoningLeak(routeInfo)
+            guardLeadingReasoningLeak = shouldGuardNvidiaKimiReasoningLeak(routeInfo),
+            captureAnthropicContentBlocks = routeInfo.requiresAnthropicThinkingReplay,
+            anthropicSourceModel = routeInfo.resolvedModel
         )
         var lastReasoning = ""
         var lastReasoningEmitLength = 0

--- a/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/llm/AgentLlmStreamAccumulator.kt
@@ -13,6 +13,9 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import cn.com.omnimind.baselib.util.OmniLog
+import cn.com.omnimind.baselib.llm.AnthropicMessageProtocolState
+import cn.com.omnimind.baselib.llm.ChatCompletionProtocolMetadata
+import cn.com.omnimind.baselib.llm.ChatCompletionProtocolState
 import cn.com.omnimind.baselib.llm.decodeChatCompletionUsage
 import java.util.SortedMap
 import java.util.TreeMap
@@ -21,7 +24,9 @@ class AgentLlmStreamAccumulator(
     private val json: Json,
     private val includeReasoningInAssistantMessage: Boolean = false,
     private val bufferLeadingTextUntilInlineThinkTag: Boolean = false,
-    private val guardLeadingReasoningLeak: Boolean = false
+    private val guardLeadingReasoningLeak: Boolean = false,
+    private val captureAnthropicContentBlocks: Boolean = false,
+    private val anthropicSourceModel: String? = null
 ) {
     companion object {
         private const val TAG = "AgentLlmStreamAccumulator"
@@ -46,6 +51,7 @@ class AgentLlmStreamAccumulator(
     private val reasoningBuffer = StringBuilder()
     private val inlineTextBuffer = StringBuilder()
     private val toolCallBuilders: SortedMap<Int, MutableToolCallBuilder> = TreeMap()
+    private val anthropicContentBlocks: SortedMap<Int, JsonObject> = TreeMap()
     private var providerError: StreamProviderError? = null
     private var finishReason: String? = null
     private var usage: ChatCompletionUsage? = null
@@ -104,7 +110,7 @@ class AgentLlmStreamAccumulator(
         usage = decodeUsage(root["usage"]) ?: usage
         decodeTokensPerSecond = decodeTimings(root["timings"]) ?: decodeTokensPerSecond
 
-        var chunkHasPayload = false
+        var chunkHasPayload = consumeAnthropicContentBlock(root)
         val choices = root["choices"] as? JsonArray
         choices?.forEach { choiceElement ->
             val choice = choiceElement as? JsonObject ?: return@forEach
@@ -233,7 +239,8 @@ class AgentLlmStreamAccumulator(
     fun hasAssistantPayload(): Boolean {
         return contentBuffer.isNotEmpty() ||
             reasoningBuffer.isNotEmpty() ||
-            toolCallBuilders.isNotEmpty()
+            toolCallBuilders.isNotEmpty() ||
+            anthropicContentBlocks.isNotEmpty()
     }
 
     fun canFinalizeOnClosed(): Boolean {
@@ -290,7 +297,19 @@ class AgentLlmStreamAccumulator(
                             toolCalls.isNotEmpty() ||
                             finishReasonIndicatesToolCall(finishReason)
                         )
-                }
+                },
+                protocolState = anthropicContentBlocks
+                    .takeIf { captureAnthropicContentBlocks && it.isNotEmpty() }
+                    ?.let { blocks ->
+                        ChatCompletionProtocolState(
+                            anthropic = AnthropicMessageProtocolState(
+                                sourceModel = anthropicSourceModel
+                                    ?.trim()
+                                    ?.takeIf { it.isNotEmpty() },
+                                contentBlocks = JsonArray(blocks.values.toList())
+                            )
+                        )
+                    }
             ),
             reasoning = reasoning,
             finishReason = finishReason,
@@ -309,6 +328,17 @@ class AgentLlmStreamAccumulator(
         )
 
         return turn
+    }
+
+    private fun consumeAnthropicContentBlock(root: JsonObject): Boolean {
+        if (!captureAnthropicContentBlocks) return false
+        val replay = root[ChatCompletionProtocolMetadata.ANTHROPIC_STREAM_BLOCK_FIELD]
+            as? JsonObject
+            ?: return false
+        val index = replay["index"]?.jsonPrimitive?.intOrNull ?: return false
+        val block = replay["block"] as? JsonObject ?: return false
+        anthropicContentBlocks[index] = block
+        return true
     }
 
     private fun reconcileMisindexedToolCallArguments() {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentOrchestrator.kt
@@ -2,7 +2,9 @@ package cn.com.omnimind.bot.agent
 
 import cn.com.omnimind.baselib.i18n.AppLocaleManager
 import cn.com.omnimind.baselib.llm.AssistantToolCall
+import cn.com.omnimind.baselib.llm.AnthropicMessageProtocolState
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import cn.com.omnimind.baselib.llm.ChatCompletionProtocolState
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionStreamOptions
 import cn.com.omnimind.baselib.llm.ChatCompletionTool
@@ -408,7 +410,8 @@ class AgentOrchestrator(
                     ),
                     toolCalls = toolCalls.ifEmpty { null },
                     reasoningContent = turn.message.reasoningContent
-                        ?.takeIf { it.isNotBlank() }
+                        ?.takeIf { it.isNotBlank() },
+                    protocolState = turn.message.protocolState
                 )
                 memory.add(assistantMessageForMemory)
                 latestPromptTokens?.let { promptTokens ->
@@ -1088,7 +1091,12 @@ class AgentOrchestrator(
         val toolResultMessage = ChatCompletionMessage(
             role = "tool",
             toolCallId = toolCall.id,
-            content = content
+            content = content,
+            protocolState = ChatCompletionProtocolState(
+                anthropic = AnthropicMessageProtocolState(
+                    toolResultIsError = !isSuccessfulToolResult(result)
+                )
+            )
         )
         memory.add(toolResultMessage)
         callback.onToolReplayReady(

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerAnthropicTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerAnthropicTest.kt
@@ -1,6 +1,9 @@
 package cn.com.omnimind.bot.agent
 
 import cn.com.omnimind.assists.controller.http.HttpController
+import cn.com.omnimind.baselib.llm.AnthropicMessageProtocolState
+import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import cn.com.omnimind.baselib.llm.ChatCompletionProtocolState
 import cn.com.omnimind.baselib.llm.contentText
 import java.io.BufferedReader
 import java.io.BufferedWriter
@@ -12,6 +15,7 @@ import java.nio.charset.StandardCharsets
 import kotlin.concurrent.thread
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Request
@@ -351,6 +355,133 @@ class HttpControllerAnthropicTest {
         )
         assertEquals(20, turn.usage?.promptTokens)
         assertEquals(4, turn.usage?.completionTokens)
+    }
+
+    @Test
+    fun `anthropic tool loop replays signed thinking blocks unchanged`() {
+        val chunks = mutableListOf<String>()
+        val wrapped = HttpController.wrapAnthropicListener(
+            object : EventSourceListener() {
+                override fun onEvent(
+                    eventSource: EventSource,
+                    id: String?,
+                    type: String?,
+                    data: String
+                ) {
+                    chunks += data
+                }
+            }
+        )
+        val source = dummyEventSource()
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_start",
+            """{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_delta",
+            """{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Need inspect."}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_delta",
+            """{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"opaque-signature"}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_stop",
+            """{"type":"content_block_stop","index":0}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_start",
+            """{"type":"content_block_start","index":1,"content_block":{"type":"text","text":"Running command."}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_stop",
+            """{"type":"content_block_stop","index":1}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_start",
+            """{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"tool_9","name":"terminal_execute","input":{}}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_delta",
+            """{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"pwd\"}"}}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "content_block_stop",
+            """{"type":"content_block_stop","index":2}"""
+        )
+        wrapped.onEvent(
+            source,
+            null,
+            "message_delta",
+            """{"type":"message_delta","delta":{"stop_reason":"tool_use"}}"""
+        )
+        wrapped.onEvent(source, null, "message_stop", """{"type":"message_stop"}""")
+
+        val accumulator = AgentLlmStreamAccumulator(
+            json = json,
+            captureAnthropicContentBlocks = true,
+            anthropicSourceModel = "deepseek-v4-flash-vision-exp"
+        )
+        chunks.forEach(accumulator::consume)
+        val assistant = accumulator.buildTurn().message
+        val replayBlocks = assistant.protocolState?.anthropic?.contentBlocks
+        assertNotNull(replayBlocks)
+        assertEquals("thinking", replayBlocks!![0].jsonObject["type"]?.jsonPrimitive?.content)
+        assertEquals(
+            "opaque-signature",
+            replayBlocks[0].jsonObject["signature"]?.jsonPrimitive?.content
+        )
+        assertEquals("Running command.", assistant.contentText())
+
+        val toolResult = ChatCompletionMessage(
+            role = "tool",
+            toolCallId = "tool_9",
+            content = JsonPrimitive("permission denied"),
+            protocolState = ChatCompletionProtocolState(
+                anthropic = AnthropicMessageProtocolState(toolResultIsError = true)
+            )
+        )
+        val replayMethod = HttpController::class.java.getDeclaredMethod(
+            "resolveAnthropicReplayContentBlocks",
+            ChatCompletionMessage::class.java,
+            String::class.java
+        )
+        replayMethod.isAccessible = true
+        val replayedAssistantBlocks = replayMethod.invoke(
+            HttpController,
+            assistant,
+            "deepseek-v4-flash-vision-exp"
+        )
+        assertEquals(replayBlocks, replayedAssistantBlocks)
+        assertEquals(
+            null,
+            replayMethod.invoke(HttpController, assistant, "claude-sonnet-other")
+        )
+
+        val errorMethod = HttpController::class.java.getDeclaredMethod(
+            "anthropicToolResultIsError",
+            ChatCompletionMessage::class.java
+        )
+        errorMethod.isAccessible = true
+        assertEquals(true, errorMethod.invoke(HttpController, toolResult))
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerResponsesTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/HttpControllerResponsesTest.kt
@@ -13,6 +13,7 @@ import okhttp3.Request
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -44,6 +45,43 @@ class HttpControllerResponsesTest {
             "omnibot:v1:0123456789abcdef0123:conversation:42",
             root["prompt_cache_key"]?.jsonPrimitive?.content
         )
+    }
+
+    @Test
+    fun `chat completions wire body excludes provider private state`() {
+        val method = HttpController::class.java.getDeclaredMethod(
+            "stripAnthropicOnlyFieldsForOpenAiCompatible",
+            String::class.java
+        )
+        method.isAccessible = true
+        val payload = method.invoke(
+            HttpController,
+            """
+                {
+                  "model": "gpt-4.1",
+                  "messages": [
+                    {"role":"user","content":"inspect"},
+                    {
+                      "role":"assistant",
+                      "content":"running",
+                      "tool_calls":[{"id":"call_1","type":"function","function":{"name":"shell","arguments":"{}"}}],
+                      "_omnibot_protocol_state":{"anthropic":{"source_model":"claude","content_blocks":[{"type":"thinking","thinking":"private","signature":"opaque"}]}}
+                    },
+                    {
+                      "role":"tool",
+                      "tool_call_id":"call_1",
+                      "content":"done",
+                      "_omnibot_protocol_state":{"anthropic":{"tool_result_is_error":false}}
+                    }
+                  ]
+                }
+            """.trimIndent()
+        ) as String
+
+        assertFalse(payload.contains("_omnibot_protocol_state"))
+        val messages = json.parseToJsonElement(payload).jsonObject["messages"]!!.jsonArray
+        assertEquals("call_1", messages[2].jsonObject["tool_call_id"]?.jsonPrimitive?.content)
+        assertEquals("running", messages[1].jsonObject["content"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -79,6 +117,14 @@ class HttpControllerResponsesTest {
                     {
                       "role": "assistant",
                       "content": "It is sunny.",
+                      "_omnibot_protocol_state": {
+                        "anthropic": {
+                          "source_model": "claude",
+                          "content_blocks": [
+                            {"type":"thinking","thinking":"private","signature":"opaque"}
+                          ]
+                        }
+                      },
                       "tool_calls": [
                         {
                           "id": "call_1",
@@ -95,6 +141,7 @@ class HttpControllerResponsesTest {
         ) as String
 
         val root = json.parseToJsonElement(payload).jsonObject
+        assertFalse(payload.contains("_omnibot_protocol_state"))
         assertEquals("gpt-4.1-mini", root["model"]?.jsonPrimitive?.content)
         assertEquals(
             "omnibot:v1:test:conversation:42",

--- a/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
+++ b/assists/src/main/java/cn/com/omnimind/assists/controller/http/HttpController.kt
@@ -10,6 +10,7 @@ import cn.com.omnimind.baselib.llm.AssistantToolCallFunction
 import cn.com.omnimind.baselib.llm.AiRequestLogEntry
 import cn.com.omnimind.baselib.llm.AiRequestLogStore
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
+import cn.com.omnimind.baselib.llm.ChatCompletionProtocolMetadata
 import cn.com.omnimind.baselib.llm.ChatCompletionRequest
 import cn.com.omnimind.baselib.llm.ChatCompletionStreamOptions
 import cn.com.omnimind.baselib.llm.DeepSeekProvider
@@ -759,16 +760,19 @@ object HttpController {
         }
     }
 
-    private fun buildAnthropicAssistantContent(message: ChatCompletionMessage): Any? {
-        val content = JSONArray()
-        message.reasoningContent?.trim()?.takeIf { it.isNotEmpty() }?.let { reasoning ->
-            val reasoningBlock = JSONObject()
-            reasoningBlock.put("type", "text")
-            reasoningBlock.put("text", reasoning)
-            content.put(
-                reasoningBlock
-            )
+    private fun buildAnthropicAssistantContent(
+        message: ChatCompletionMessage,
+        targetModel: String
+    ): Any? {
+        val replayBlocks = resolveAnthropicReplayContentBlocks(message, targetModel)
+        if (replayBlocks != null) {
+            return JSONArray(replayBlocks.toString())
         }
+
+        val content = JSONArray()
+        // Internal reasoning text is not an Anthropic content block. Replaying
+        // it as visible text changes the transcript and cannot replace the
+        // signed thinking block required by the Messages API.
         appendAnthropicContentBlocks(content, message.content)
         message.toolCalls.orEmpty().forEach { toolCall ->
             val inputJson = runCatching { JSONObject(toolCall.function.arguments) }.getOrElse { JSONObject() }
@@ -786,7 +790,6 @@ object HttpController {
         }
         if (
             content.length() == 1 &&
-            message.reasoningContent.isNullOrBlank() &&
             message.toolCalls.isNullOrEmpty()
         ) {
             val single = content.optJSONObject(0)
@@ -795,6 +798,23 @@ object HttpController {
             }
         }
         return content
+    }
+
+    private fun resolveAnthropicReplayContentBlocks(
+        message: ChatCompletionMessage,
+        targetModel: String
+    ): KxJsonArray? {
+        val anthropicState = message.protocolState?.anthropic ?: return null
+        val sourceModel = anthropicState.sourceModel?.trim().orEmpty()
+        return anthropicState.contentBlocks?.takeIf { blocks ->
+            blocks.isNotEmpty() && (
+                sourceModel.isEmpty() || sourceModel.equals(targetModel.trim(), ignoreCase = true)
+            )
+        }
+    }
+
+    private fun anthropicToolResultIsError(message: ChatCompletionMessage): Boolean? {
+        return message.protocolState?.anthropic?.toolResultIsError
     }
 
     private fun buildAnthropicTextBlock(text: String): JSONObject {
@@ -1218,7 +1238,7 @@ object HttpController {
         for (msg in nonSystemMessages) {
             when (msg.role) {
                 "assistant" -> {
-                    val content = buildAnthropicAssistantContent(msg)
+                    val content = buildAnthropicAssistantContent(msg, request.model)
                     if (content != null) {
                         messages.put(buildAnthropicMessage("assistant", content))
                     }
@@ -1234,6 +1254,9 @@ object HttpController {
                             if (it is kotlinx.serialization.json.JsonPrimitive) it.content else it.toString()
                         } ?: ""
                     )
+                    anthropicToolResultIsError(msg)?.let { isError ->
+                        toolResultBlock.put("is_error", isError)
+                    }
                     // Try to merge with previous user message if it's a tool_result batch
                     val lastMsg = if (messages.length() > 0) messages.optJSONObject(messages.length() - 1) else null
                     if (lastMsg != null && lastMsg.optString("role") == "user" &&
@@ -1963,11 +1986,70 @@ object HttpController {
         }
     }
 
+    private class AnthropicStreamBlockBuilder(
+        private val initialBlock: KxJsonObject
+    ) {
+        private val blockType = (initialBlock["type"] as? JsonPrimitive)
+            ?.contentOrNull
+            .orEmpty()
+        private val text = StringBuilder(
+            (initialBlock["text"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+        )
+        private val thinking = StringBuilder(
+            (initialBlock["thinking"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+        )
+        private val signature = StringBuilder(
+            (initialBlock["signature"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+        )
+        private val inputJson = StringBuilder()
+
+        fun appendText(value: String) {
+            text.append(value)
+        }
+
+        fun appendThinking(value: String) {
+            thinking.append(value)
+        }
+
+        fun appendSignature(value: String) {
+            signature.append(value)
+        }
+
+        fun appendInputJson(value: String) {
+            inputJson.append(value)
+        }
+
+        fun build(): KxJsonObject {
+            val fields = initialBlock.toMutableMap()
+            when (blockType) {
+                "text" -> fields["text"] = JsonPrimitive(text.toString())
+                "thinking" -> {
+                    fields["thinking"] = JsonPrimitive(thinking.toString())
+                    if (signature.isNotEmpty()) {
+                        fields["signature"] = JsonPrimitive(signature.toString())
+                    }
+                }
+                "tool_use" -> {
+                    val parsedInput = inputJson
+                        .takeIf { it.isNotEmpty() }
+                        ?.toString()
+                        ?.let { raw ->
+                            runCatching { completionJson.parseToJsonElement(raw) }.getOrNull()
+                        }
+                    if (parsedInput != null) {
+                        fields["input"] = parsedInput
+                    }
+                }
+            }
+            return KxJsonObject(fields)
+        }
+    }
+
     fun wrapAnthropicListener(outer: EventSourceListener): EventSourceListener {
         return object : EventSourceListener() {
             // per-stream state
-            private val toolUseBlocks = mutableMapOf<Int, KxJsonObject>() // index → {id, name}
-            private val toolArgBuffers = mutableMapOf<Int, StringBuilder>() // index → partial json
+            private val contentBlocks = sortedMapOf<Int, AnthropicStreamBlockBuilder>()
+            private val emittedContentBlockIndexes = mutableSetOf<Int>()
             private val usage = AnthropicUsageAccumulator()
 
             override fun onOpen(eventSource: EventSource, response: okhttp3.Response) {
@@ -2035,15 +2117,15 @@ object HttpController {
                     "content_block_start" -> {
                         val index = intField(json, "index") ?: 0
                         val block = objectField(json, "content_block") ?: return
+                        contentBlocks[index] = AnthropicStreamBlockBuilder(block)
                         when (stringField(block, "type")) {
                             "tool_use" -> {
                                 val toolId = stringField(block, "id").ifEmpty { "tool_$index" }
                                 val toolName = stringField(block, "name")
-                                toolUseBlocks[index] = buildJsonObject {
-                                    put("id", JsonPrimitive(toolId))
-                                    put("name", JsonPrimitive(toolName))
-                                }
-                                toolArgBuffers[index] = StringBuilder()
+                                val initialInput = block["input"]
+                                    ?.takeUnless { it is KxJsonObject && it.isEmpty() }
+                                    ?.toString()
+                                    .orEmpty()
                                 // emit tool_call header chunk
                                 val chunk = buildOpenAIChunk(
                                     deltaJson = buildJsonObject {
@@ -2059,7 +2141,7 @@ object HttpController {
                                                             "function",
                                                             buildJsonObject {
                                                                 put("name", JsonPrimitive(toolName))
-                                                                put("arguments", JsonPrimitive(""))
+                                                                put("arguments", JsonPrimitive(initialInput))
                                                             }
                                                         )
                                                     }
@@ -2083,6 +2165,22 @@ object HttpController {
                                     outer.onEvent(eventSource, id, type, chunk)
                                 }
                             }
+                            "thinking" -> {
+                                val thinking = stringField(block, "thinking")
+                                if (thinking.isNotEmpty()) {
+                                    outer.onEvent(
+                                        eventSource,
+                                        id,
+                                        type,
+                                        buildOpenAIChunk(
+                                            deltaJson = buildJsonObject {
+                                                put("reasoning_content", JsonPrimitive(thinking))
+                                            },
+                                            finishReason = null
+                                        )
+                                    )
+                                }
+                            }
                         }
                     }
                     "content_block_delta" -> {
@@ -2091,6 +2189,7 @@ object HttpController {
                         when (stringField(delta, "type")) {
                             "text_delta" -> {
                                 val text = stringField(delta, "text")
+                                contentBlocks[index]?.appendText(text)
                                 val chunk = buildOpenAIChunk(
                                     deltaJson = buildJsonObject {
                                         put("content", JsonPrimitive(text))
@@ -2101,7 +2200,7 @@ object HttpController {
                             }
                             "input_json_delta" -> {
                                 val partialJson = stringField(delta, "partial_json")
-                                toolArgBuffers[index]?.append(partialJson)
+                                contentBlocks[index]?.appendInputJson(partialJson)
                                 val chunk = buildOpenAIChunk(
                                     deltaJson = buildJsonObject {
                                         put(
@@ -2127,6 +2226,7 @@ object HttpController {
                             }
                             "thinking_delta" -> {
                                 val thinking = stringField(delta, "thinking")
+                                contentBlocks[index]?.appendThinking(thinking)
                                 if (thinking.isNotEmpty()) {
                                     val chunk = buildOpenAIChunk(
                                         deltaJson = buildJsonObject {
@@ -2137,7 +2237,16 @@ object HttpController {
                                     outer.onEvent(eventSource, id, type, chunk)
                                 }
                             }
+                            "signature_delta" -> {
+                                contentBlocks[index]?.appendSignature(
+                                    stringField(delta, "signature")
+                                )
+                            }
                         }
+                    }
+                    "content_block_stop" -> {
+                        val index = intField(json, "index") ?: 0
+                        emitAnthropicContentBlock(eventSource, id, type, index)
                     }
                     "message_delta" -> {
                         usage.merge(objectField(json, "usage"))
@@ -2156,6 +2265,9 @@ object HttpController {
                         }
                     }
                     "message_stop" -> {
+                        contentBlocks.keys.forEach { index ->
+                            emitAnthropicContentBlock(eventSource, id, type, index)
+                        }
                         outer.onEvent(eventSource, id, type, "[DONE]")
                     }
                     "error" -> {
@@ -2190,6 +2302,30 @@ object HttpController {
                 response: okhttp3.Response?
             ) {
                 outer.onFailure(eventSource, t, response)
+            }
+
+            private fun emitAnthropicContentBlock(
+                eventSource: EventSource,
+                id: String?,
+                type: String?,
+                index: Int
+            ) {
+                val block = contentBlocks[index]?.build() ?: return
+                if (!emittedContentBlockIndexes.add(index)) return
+                outer.onEvent(
+                    eventSource,
+                    id,
+                    type,
+                    buildJsonObject {
+                        put(
+                            ChatCompletionProtocolMetadata.ANTHROPIC_STREAM_BLOCK_FIELD,
+                            buildJsonObject {
+                                put("index", index)
+                                put("block", block)
+                            }
+                        )
+                    }.toString()
+                )
             }
 
             private fun buildOpenAIChunk(
@@ -2793,7 +2929,10 @@ object HttpController {
         return when (payload) {
             is KxJsonObject -> KxJsonObject(
                 payload
-                    .filterKeys { it != "cache_control" }
+                    .filterKeys {
+                        it != "cache_control" &&
+                            it != ChatCompletionProtocolMetadata.STATE_FIELD
+                    }
                     .mapValues { (_, value) -> stripAnthropicOnlyFields(value) }
             )
             is KxJsonArray -> KxJsonArray(payload.map(::stripAnthropicOnlyFields))

--- a/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAIChatCompletionModels.kt
+++ b/baselib/src/main/java/cn/com/omnimind/baselib/llm/OpenAIChatCompletionModels.kt
@@ -63,8 +63,35 @@ data class ChatCompletionMessage(
     val reasoningContent: String? = null,
     @SerialName("tool_call_id")
     val toolCallId: String? = null,
-    val name: String? = null
+    val name: String? = null,
+    @SerialName(ChatCompletionProtocolMetadata.STATE_FIELD)
+    val protocolState: ChatCompletionProtocolState? = null
 )
+
+/**
+ * Provider-owned state that must survive the agent tool loop but must never be
+ * emitted as part of an OpenAI wire request. Each protocol adapter is solely
+ * responsible for reading its own state at the final serialization boundary.
+ */
+@Serializable
+data class ChatCompletionProtocolState(
+    val anthropic: AnthropicMessageProtocolState? = null
+)
+
+@Serializable
+data class AnthropicMessageProtocolState(
+    @SerialName("source_model")
+    val sourceModel: String? = null,
+    @SerialName("content_blocks")
+    val contentBlocks: JsonArray? = null,
+    @SerialName("tool_result_is_error")
+    val toolResultIsError: Boolean? = null
+)
+
+object ChatCompletionProtocolMetadata {
+    const val STATE_FIELD = "_omnibot_protocol_state"
+    const val ANTHROPIC_STREAM_BLOCK_FIELD = "_omnibot_anthropic_content_block"
+}
 
 @Serializable
 data class ChatCompletionTool(

--- a/ui/lib/features/home/pages/chat/chat_page_models.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_models.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:ui/features/home/pages/chat/utils/agent_run_timeline.dart';
+import 'package:ui/features/home/pages/chat/utils/chat_message_identity.dart';
 import 'package:ui/models/chat_message_model.dart';
 import 'package:ui/services/agent_message_kinds.dart';
 
@@ -160,7 +161,7 @@ class ObservableChatMessageList extends ChangeNotifier
   }
 
   void replaceAllMessages(Iterable<ChatMessageModel> messages) {
-    final nextMessages = List<ChatMessageModel>.from(messages);
+    final nextMessages = canonicalizeChatMessagesById(messages);
     final affectsPageChrome =
         _batchAffectsPageChrome(_messages) ||
         _batchAffectsPageChrome(nextMessages);
@@ -270,16 +271,7 @@ class ObservableChatMessageList extends ChangeNotifier
 
   @override
   void addAll(Iterable<ChatMessageModel> iterable) {
-    final nextMessages = List<ChatMessageModel>.from(iterable);
-    if (nextMessages.isEmpty) {
-      return;
-    }
-    _messages.addAll(nextMessages);
-    _messageNotifiers.addAll(nextMessages.map(ChatMessageListItemNotifier.new));
-    _recordStructureMutation(
-      affectsPageChrome: _batchAffectsPageChrome(nextMessages),
-    );
-    notifyListeners();
+    insertAll(length, iterable);
   }
 
   @override
@@ -299,6 +291,13 @@ class ObservableChatMessageList extends ChangeNotifier
 
   @override
   void insert(int index, ChatMessageModel element) {
+    final existingIndex = _messages.indexWhere(
+      (message) => message.id == element.id && element.id.trim().isNotEmpty,
+    );
+    if (existingIndex >= 0) {
+      this[existingIndex] = element;
+      return;
+    }
     _messages.insert(index, element);
     _messageNotifiers.insert(index, ChatMessageListItemNotifier(element));
     _recordStructureMutation(
@@ -309,18 +308,44 @@ class ObservableChatMessageList extends ChangeNotifier
 
   @override
   void insertAll(int index, Iterable<ChatMessageModel> iterable) {
-    final nextMessages = List<ChatMessageModel>.from(iterable);
+    final nextMessages = canonicalizeChatMessagesById(iterable);
     if (nextMessages.isEmpty) {
       return;
     }
-    _messages.insertAll(index, nextMessages);
-    _messageNotifiers.insertAll(
-      index,
-      nextMessages.map(ChatMessageListItemNotifier.new),
-    );
-    _recordStructureMutation(
-      affectsPageChrome: _batchAffectsPageChrome(nextMessages),
-    );
+    var insertionIndex = index;
+    var structureChanged = false;
+    var affectsPageChrome = false;
+    for (final message in nextMessages) {
+      final existingIndex = _messages.indexWhere(
+        (current) => current.id == message.id && message.id.trim().isNotEmpty,
+      );
+      if (existingIndex >= 0) {
+        final previous = _messages[existingIndex];
+        _messages[existingIndex] = message;
+        _messageNotifiers[existingIndex].update(message);
+        structureChanged =
+            structureChanged || _timelineStructureChanged(previous, message);
+        affectsPageChrome =
+            affectsPageChrome ||
+            _messageAffectsPageChrome(previous) ||
+            _messageAffectsPageChrome(message);
+        continue;
+      }
+      _messages.insert(insertionIndex, message);
+      _messageNotifiers.insert(
+        insertionIndex,
+        ChatMessageListItemNotifier(message),
+      );
+      insertionIndex += 1;
+      structureChanged = true;
+      affectsPageChrome =
+          affectsPageChrome || _messageAffectsPageChrome(message);
+    }
+    if (structureChanged) {
+      _recordStructureMutation(affectsPageChrome: affectsPageChrome);
+    } else {
+      _recordContentMutation(affectsPageChrome: affectsPageChrome);
+    }
     notifyListeners();
   }
 

--- a/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_conversation_runtime_coordinator.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:ui/features/home/pages/chat/chat_page_models.dart';
+import 'package:ui/features/home/pages/chat/utils/chat_message_identity.dart';
 import 'package:ui/features/home/pages/authorize/authorize_page_args.dart';
 import 'package:ui/features/home/pages/chat/utils/stream_text_merge.dart';
 import 'package:ui/features/home/pages/command_overlay/constants/messages.dart';
@@ -307,7 +308,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     }
     if (runtime.messages.isEmpty && initialMessages != null) {
       runtime.messages.addAll(
-        _dedupeEquivalentAgentUserMessages(initialMessages),
+        canonicalizeChatMessagesById(
+          _dedupeEquivalentAgentUserMessages(initialMessages),
+        ),
       );
     }
     if (conversation != null) {
@@ -371,7 +374,9 @@ class ChatConversationRuntimeCoordinator extends ChangeNotifier {
     ChatBrowserSessionSnapshot? browserSessionSnapshot,
     bool preserveLiveStreamingState = false,
   }) {
-    final normalizedMessages = _dedupeEquivalentAgentUserMessages(messages);
+    final normalizedMessages = canonicalizeChatMessagesById(
+      _dedupeEquivalentAgentUserMessages(messages),
+    );
     final runtime = ensureRuntime(
       conversationId: conversationId,
       mode: mode,

--- a/ui/lib/features/home/pages/chat/utils/agent_run_timeline.dart
+++ b/ui/lib/features/home/pages/chat/utils/agent_run_timeline.dart
@@ -1,5 +1,6 @@
 import 'package:ui/models/chat_message_model.dart';
 import 'package:ui/services/agent_message_kinds.dart';
+import 'package:ui/features/home/pages/chat/utils/chat_message_identity.dart';
 
 class AgentRunTimelineEntry {
   const AgentRunTimelineEntry.message(this.message) : group = null;
@@ -150,6 +151,8 @@ List<AgentRunTimelineEntry> buildAgentRunTimelineEntries(
   if (messages.isEmpty) {
     return const <AgentRunTimelineEntry>[];
   }
+
+  messages = canonicalizeChatMessagesById(messages);
 
   final normalizedActiveTaskIds = activeTaskIds
       .map((item) => item.trim())

--- a/ui/lib/features/home/pages/chat/utils/chat_message_identity.dart
+++ b/ui/lib/features/home/pages/chat/utils/chat_message_identity.dart
@@ -1,0 +1,26 @@
+import 'package:ui/models/chat_message_model.dart';
+
+/// A conversation entry ID identifies one logical row for its entire lifetime.
+/// Keep the first slot (stable chronology) and the newest value (latest stream
+/// snapshot) when a native snapshot or reducer replay contains the same ID.
+List<ChatMessageModel> canonicalizeChatMessagesById(
+  Iterable<ChatMessageModel> messages,
+) {
+  final canonical = <ChatMessageModel>[];
+  final indexById = <String, int>{};
+  for (final message in messages) {
+    final id = message.id.trim();
+    if (id.isEmpty) {
+      canonical.add(message);
+      continue;
+    }
+    final existingIndex = indexById[id];
+    if (existingIndex == null) {
+      indexById[id] = canonical.length;
+      canonical.add(message);
+    } else {
+      canonical[existingIndex] = message;
+    }
+  }
+  return canonical;
+}

--- a/ui/test/features/home/pages/chat/chat_page_models_test.dart
+++ b/ui/test/features/home/pages/chat/chat_page_models_test.dart
@@ -151,6 +151,30 @@ void main() {
         expect(structuralNotifications, 0);
       },
     );
+
+    test('snapshot keeps one latest row for each message id', () {
+      const conversationId = 0xD56;
+      const mode = kChatRuntimeModeAgent;
+      coordinator.replaceConversationSnapshot(
+        conversationId: conversationId,
+        mode: mode,
+        messages: <ChatMessageModel>[
+          ChatMessageModel.assistantMessage('old', id: 'same-id'),
+          ChatMessageModel.assistantMessage('other', id: 'other-id'),
+          ChatMessageModel.assistantMessage('latest', id: 'same-id'),
+        ],
+      );
+
+      final messages = coordinator
+          .runtimeFor(conversationId: conversationId, mode: mode)!
+          .messages;
+      expect(messages, hasLength(2));
+      expect(messages.map((message) => message.id), <String>[
+        'same-id',
+        'other-id',
+      ]);
+      expect(messages.first.text, 'latest');
+    });
   });
 
   group('shouldReloadConversationMessagesChanged', () {
@@ -378,7 +402,9 @@ void main() {
 
     test('operator []= records content-kind mutation', () {
       list.insert(0, ChatMessageModel.assistantMessage('hi', id: 'm-1'));
-      list[0] = ChatMessageModel.assistantMessage('hi there', id: 'm-1');
+      list[0] = list[0].copyWith(
+        content: <String, dynamic>{'text': 'hi there', 'id': 'm-1'},
+      );
       expect(list.lastMutationKind, ChatMessageListMutationKind.content);
     });
 
@@ -394,6 +420,17 @@ void main() {
       list[0] = ChatMessageModel.assistantMessage('hi there', id: 'm-1');
       expect(perItemNotifyCount, 1);
       expect(lastObserved?.text, 'hi there');
+    });
+
+    test('inserting an existing id updates its row without adding a slot', () {
+      list.insert(0, ChatMessageModel.assistantMessage('old', id: 'm-1'));
+      final notifier = list.listenableAt(0);
+
+      list.insert(1, ChatMessageModel.assistantMessage('latest', id: 'm-1'));
+
+      expect(list, hasLength(1));
+      expect(list.single.text, 'latest');
+      expect(list.listenableAt(0), same(notifier));
     });
   });
 }

--- a/ui/test/features/home/pages/chat/utils/agent_run_timeline_test.dart
+++ b/ui/test/features/home/pages/chat/utils/agent_run_timeline_test.dart
@@ -13,6 +13,25 @@ void main() {
     expect(entries.first.group?.visibleMessagesNewestFirst.single.text, '最终回答');
   });
 
+  test('duplicate message ids occupy one timeline slot with latest data', () {
+    final messages = _buildCompletedRunMessages();
+    final thinking = messages.firstWhere(
+      (message) => message.cardData?['type'] == 'deep_thinking',
+    );
+    final entries = buildAgentRunTimelineEntries(<ChatMessageModel>[
+      thinking,
+      ...messages,
+    ]);
+
+    expect(entries.first.group?.thinkingCount, 1);
+    expect(
+      entries.first.group?.processMessagesOldestFirst.where(
+        (message) => message.id == thinking.id,
+      ),
+      hasLength(1),
+    );
+  });
+
   test('keeps every prose message visible when history lacks isFinal', () {
     final messages = <ChatMessageModel>[
       _assistantMessage(


### PR DESCRIPTION
## 变更说明

修复 Anthropic 协议在工具调用续接过程中丢失 thinking、签名及工具结果状态的问题，同时解决运行时快照导致思考状态和任务取消消息重复显示的问题。

## 主要改动

- 按原始顺序保留并续传 Anthropic thinking、签名及工具调用内容块。
- 正确传递工具执行失败状态，切换模型时不复用旧模型的 thinking 状态。
- 隔离 Anthropic 私有状态，避免影响 OpenAI Chat Completions 和 Responses 协议。
- 按消息 ID 合并运行时快照，避免重复显示思考状态、工具记录及取消消息。
- 补充相关回归测试。

## 验证情况

已在 RMX5200 真机上使用 DeepSeek 官方 API，通过 Anthropic 协议完成基础验证，原问题未再复现。当前测试范围有限，仍需通过更多场景进一步确认稳定性。