### PR TITLE
fix(flutter): 修复 Release 构建中插件注册失败

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -9,6 +9,13 @@
 -keepattributes RuntimeVisibleAnnotations,RuntimeInvisibleAnnotations,AnnotationDefault
 -keepattributes Signature,InnerClasses,EnclosingMethod
 
+# FlutterEngineConnectionRegistry keys plugins by their concrete runtime class.
+# Keep each FlutterPlugin implementation as a distinct class so R8 cannot merge
+# unrelated plugins and make later registrations look like duplicates.
+-keep,allowobfuscation,allowshrinking class * implements io.flutter.embedding.engine.plugins.FlutterPlugin {
+    <init>(...);
+}
+
 # OkHttpManager resolves this value by its binary class and field names.
 -keep class cn.com.omnimind.bot.BuildConfig {
     public static final java.lang.String BASE_URL;


### PR DESCRIPTION
## 变更摘要

修复 Release 混淆后 Flutter 插件实现类被 R8 合并，导致后续插件被误判为重复注册、WebView Pigeon 通道无法建立的问题。

## 主要改动

- 保持 `FlutterPlugin` 实现类的运行时类型独立，避免无关插件被水平合并
- 继续允许未使用插件裁剪和类名混淆，保留 R8 的收缩能力

## 验证

已在 RMX5200 真机使用 Release 构建验证，HTML 预览可正常加载。

| 修复前 | 修复后 |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/976204f2-16b5-45d4-aefc-84cb7b8b83f3" alt="修复前：HTML 预览失败" width="420" /> | <img src="https://github.com/user-attachments/assets/fc29b79a-aef0-4154-ba95-937459f347dc" alt="修复后：HTML 预览正常" width="420" /> |

## 风险与回滚

规则仅约束 `FlutterPlugin` 实现类的合并优化；如需回滚，移除对应 R8 keep 规则即可。