### PR TITLE
将手动录制入口移至命令面板

### DIFF
--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -193,7 +193,24 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
       return <Map<String, dynamic>>[_buildReasoningEffortCommandCard()];
     }
 
-    final commands = <Map<String, dynamic>>[];
+    final commands = <Map<String, dynamic>>[
+      <String, dynamic>{
+        'cardId': 'slash-command-record',
+        'toolName': '/record',
+        'toolTitle': '/record',
+        'displayName': '/record',
+        'toolType': 'command',
+        'toolTypeLabel': LegacyTextLocalizer.isEnglish ? 'Recording' : '录制',
+        'status': 'running',
+        'statusLabel': LegacyTextLocalizer.isEnglish ? 'Action' : '操作',
+        'summary': LegacyTextLocalizer.isEnglish
+            ? 'Manually record a reusable operation flow'
+            : '手动录制可复用的操作流程',
+        'progress': LegacyTextLocalizer.isEnglish
+            ? 'Start recording from the floating control'
+            : '通过悬浮控件开始录制',
+      },
+    ];
     if (_supportsManualContextCompaction) {
       commands.add(<String, dynamic>{
         'cardId': 'slash-command-compact',
@@ -479,6 +496,11 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
         .toString()
         .trim();
     switch (command) {
+      case '/record':
+        _messageController.clear();
+        _hideSlashCommandPanel();
+        unawaited(_startManualRecordingCommand('/record'));
+        break;
       case '/compact':
         unawaited(_executeManualContextCompactionCommand());
         break;
@@ -1327,9 +1349,6 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                       onCancelTask: _onCancelTask,
                       onPopupVisibilityChanged: _onPopupVisibilityChanged,
                       onTerminalTap: _handleTerminalToolTap,
-                      onManualRecordingTap: _activeMode == ChatPageMode.normal
-                          ? () => _startManualRecordingCommand('手动录制')
-                          : null,
                       useLargeComposerStyle: true,
                       useAttachmentPickerForPlus: true,
                       onPickAttachment: _pickAttachments,

--- a/ui/lib/features/home/pages/chat/widgets/chat_input_wrapper.dart
+++ b/ui/lib/features/home/pages/chat/widgets/chat_input_wrapper.dart
@@ -11,7 +11,6 @@ class ChatInputWrapper extends StatelessWidget {
   final VoidCallback onCancelTask;
   final void Function(bool) onPopupVisibilityChanged;
   final FutureOr<void> Function()? onTerminalTap;
-  final FutureOr<void> Function()? onManualRecordingTap;
   final bool? openClawEnabled;
   final ValueChanged<bool>? onToggleOpenClaw;
   final VoidCallback? onLongPressOpenClaw;
@@ -52,7 +51,6 @@ class ChatInputWrapper extends StatelessWidget {
     required this.onCancelTask,
     required this.onPopupVisibilityChanged,
     this.onTerminalTap,
-    this.onManualRecordingTap,
     this.openClawEnabled,
     this.onToggleOpenClaw,
     this.onLongPressOpenClaw,
@@ -102,7 +100,6 @@ class ChatInputWrapper extends StatelessWidget {
             onCancelTask: onCancelTask,
             onPopupVisibilityChanged: onPopupVisibilityChanged,
             onTerminalTap: onTerminalTap,
-            onManualRecordingTap: onManualRecordingTap,
             openClawEnabled: openClawEnabled,
             onToggleOpenClaw: onToggleOpenClaw,
             onLongPressOpenClaw: onLongPressOpenClaw,

--- a/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
+++ b/ui/lib/features/home/pages/command_overlay/chat_bot_sheet.dart
@@ -454,6 +454,12 @@ class _ChatBotSheetState extends State<ChatBotSheet>
     });
   }
 
+  Future<void> _startManualRecordingFromCommandPanel() async {
+    _messageController.clear();
+    _hideSlashCommandPanel();
+    await _startManualRecordingCommand('/record');
+  }
+
   bool _isPointerInside(GlobalKey key, Offset position) {
     final context = key.currentContext;
     if (context == null) return false;
@@ -508,6 +514,11 @@ class _ChatBotSheetState extends State<ChatBotSheet>
   Future<bool> _tryHandleSlashCommand(String messageText) async {
     final trimmed = messageText.trim();
     if (!trimmed.startsWith('/')) return false;
+
+    if (trimmed == '/record') {
+      await _startManualRecordingFromCommandPanel();
+      return true;
+    }
 
     if (!trimmed.startsWith('/openclaw')) {
       _showSnackBar(
@@ -2562,34 +2573,82 @@ class _ChatBotSheetState extends State<ChatBotSheet>
                         ),
                       ],
                     )
-                  : InkWell(
-                      onTap: () {
-                        _showOpenClawCommandPanel(expand: true);
-                      },
-                      borderRadius: BorderRadius.circular(10),
-                      child: Row(
-                        children: [
-                          Icon(Icons.link, size: 16, color: panelAccentColor),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Text(
-                              'OpenClaw',
-                              style: TextStyle(
-                                fontSize: 13,
-                                fontWeight: FontWeight.w600,
-                                color: panelTextColor,
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        InkWell(
+                          onTap: () => unawaited(
+                            _startManualRecordingFromCommandPanel(),
+                          ),
+                          borderRadius: BorderRadius.circular(10),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 4),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.route_rounded,
+                                  size: 16,
+                                  color: panelAccentColor,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    '/record',
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w600,
+                                      color: panelTextColor,
+                                    ),
+                                  ),
+                                ),
+                                Text(
+                                  LegacyTextLocalizer.isEnglish
+                                      ? 'Manual recording'
+                                      : '手动录制',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: panelSecondaryTextColor,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        Divider(height: 12, color: palette.borderSubtle),
+                        InkWell(
+                          onTap: () {
+                            _showOpenClawCommandPanel(expand: true);
+                          },
+                          borderRadius: BorderRadius.circular(10),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.link,
+                                size: 16,
+                                color: panelAccentColor,
                               ),
-                            ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  'OpenClaw',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                    color: panelTextColor,
+                                  ),
+                                ),
+                              ),
+                              Text(
+                                LegacyTextLocalizer.isEnglish ? 'Config' : '配置',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: panelSecondaryTextColor,
+                                ),
+                              ),
+                            ],
                           ),
-                          Text(
-                            LegacyTextLocalizer.isEnglish ? 'Config' : '配置',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: panelSecondaryTextColor,
-                            ),
-                          ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
             ),
     );
@@ -2610,7 +2669,6 @@ class _ChatBotSheetState extends State<ChatBotSheet>
         onInputHeightChanged: _onInputHeightChanged,
         openClawEnabled: _openClawEnabled,
         onToggleOpenClaw: _setOpenClawEnabled,
-        onManualRecordingTap: () => _startManualRecordingCommand('手动录制'),
         useLargeComposerStyle: true,
         useAttachmentPickerForPlus: true,
         onPickAttachment: _pickAttachments,

--- a/ui/lib/features/home/pages/command_overlay/command_overlay.dart
+++ b/ui/lib/features/home/pages/command_overlay/command_overlay.dart
@@ -228,6 +228,18 @@ class _CommandOverlayState extends State<CommandOverlay> {
     });
   }
 
+  Future<void> _startManualRecordingFromCommandPanel() async {
+    _messageController.clear();
+    _hideSlashCommandPanel();
+    await ManualRecordingFlowController.startStandalone(
+      context: context,
+      inputFocusNode: _inputFocusNode,
+      userMessageText: '/record',
+      recordDebugScreenshots: true,
+      isMounted: () => mounted,
+    );
+  }
+
   bool _isPointerInside(GlobalKey key, Offset position) {
     final context = key.currentContext;
     if (context == null) return false;
@@ -283,6 +295,11 @@ class _CommandOverlayState extends State<CommandOverlay> {
   Future<bool> _tryHandleSlashCommand(String messageText) async {
     final trimmed = messageText.trim();
     if (!trimmed.startsWith('/')) return false;
+
+    if (trimmed == '/record') {
+      await _startManualRecordingFromCommandPanel();
+      return true;
+    }
 
     // 只拦截 /openclaw 本地配置命令，其他斜杠命令（如 /model、/help 等）
     // 透传给 OpenClaw 网关或作为普通消息发送
@@ -626,34 +643,80 @@ class _CommandOverlayState extends State<CommandOverlay> {
                         ),
                       ],
                     )
-                  : InkWell(
-                      onTap: () {
-                        _showOpenClawCommandPanel(expand: true);
-                      },
-                      borderRadius: BorderRadius.circular(10),
-                      child: Row(
-                        children: [
-                          Icon(Icons.link, size: 16, color: panelAccentColor),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Text(
-                              'OpenClaw',
-                              style: TextStyle(
-                                fontSize: 13,
-                                fontWeight: FontWeight.w600,
-                                color: panelTextColor,
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        InkWell(
+                          onTap: () => unawaited(
+                            _startManualRecordingFromCommandPanel(),
+                          ),
+                          borderRadius: BorderRadius.circular(10),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 4),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.route_rounded,
+                                  size: 16,
+                                  color: panelAccentColor,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    '/record',
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w600,
+                                      color: panelTextColor,
+                                    ),
+                                  ),
+                                ),
+                                Text(
+                                  '手动录制',
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: panelSecondaryTextColor,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        Divider(height: 12, color: palette.borderSubtle),
+                        InkWell(
+                          onTap: () {
+                            _showOpenClawCommandPanel(expand: true);
+                          },
+                          borderRadius: BorderRadius.circular(10),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.link,
+                                size: 16,
+                                color: panelAccentColor,
                               ),
-                            ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  'OpenClaw',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                    color: panelTextColor,
+                                  ),
+                                ),
+                              ),
+                              Text(
+                                '配置',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: panelSecondaryTextColor,
+                                ),
+                              ),
+                            ],
                           ),
-                          Text(
-                            '配置',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: panelSecondaryTextColor,
-                            ),
-                          ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
             ),
     );
@@ -730,14 +793,6 @@ class _CommandOverlayState extends State<CommandOverlay> {
                       onToggleOpenClaw: _setOpenClawEnabled,
                       onLongPressOpenClaw: () =>
                           _showOpenClawCommandPanel(expand: true),
-                      onManualRecordingTap: () =>
-                          ManualRecordingFlowController.startStandalone(
-                            context: context,
-                            inputFocusNode: _inputFocusNode,
-                            userMessageText: '手动录制',
-                            recordDebugScreenshots: true,
-                            isMounted: () => mounted,
-                          ),
                       useLargeComposerStyle: true,
                       useFrostedGlass: true, // command_overlay 使用毛玻璃效果
                       useAttachmentPickerForPlus: true,

--- a/ui/lib/features/home/pages/command_overlay/services/manual_recording_flow_controller.dart
+++ b/ui/lib/features/home/pages/command_overlay/services/manual_recording_flow_controller.dart
@@ -31,7 +31,8 @@ class ManualRecordingFlowController {
 
   static bool isCommand(String messageText) {
     final normalized = messageText.trim().toLowerCase();
-    return normalized == '手动录制' ||
+    return normalized == '/record' ||
+        normalized == '手动录制' ||
         normalized == '开始手动录制' ||
         normalized == '人工录制' ||
         normalized == '录制轨迹' ||

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_actions.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_actions.dart
@@ -1,33 +1,6 @@
 part of 'chat_input_area.dart';
 
 extension _ChatInputActionSupport on _ChatInputAreaStateBase {
-  Widget _buildManualRecordingButton({required double iconSize}) {
-    final palette = context.omniPalette;
-    final color = context.isDarkTheme
-        ? palette.accentPrimary
-        : const Color(0xFF6D5BD0);
-    return IconButton(
-      key: const ValueKey('chat-input-manual-recording-button'),
-      padding: EdgeInsets.zero,
-      iconSize: iconSize,
-      tooltip: Localizations.localeOf(context).languageCode == 'en'
-          ? 'Manual recording'
-          : '手动录制',
-      icon: Container(
-        width: 24,
-        height: 24,
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.12),
-          shape: BoxShape.circle,
-        ),
-        child: Icon(Icons.gesture_rounded, size: iconSize, color: color),
-      ),
-      onPressed: widget.isProcessing
-          ? null
-          : () => unawaited(Future<void>.sync(widget.onManualRecordingTap!)),
-    );
-  }
-
   Widget _buildTerminalButton({required double iconSize}) {
     return IconButton(
       padding: EdgeInsets.zero,

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area.dart
@@ -141,7 +141,6 @@ class ChatInputArea extends StatefulWidget {
   final ValueChanged<bool>? onToggleOpenClaw;
   final VoidCallback? onLongPressOpenClaw;
   final FutureOr<void> Function()? onTerminalTap;
-  final FutureOr<void> Function()? onManualRecordingTap;
 
   /// 是否使用毛玻璃效果（command_overlay 使用毛玻璃，chatbotsheet 使用白色+阴影）
   final bool useFrostedGlass;
@@ -182,7 +181,6 @@ class ChatInputArea extends StatefulWidget {
     this.onToggleOpenClaw,
     this.onLongPressOpenClaw,
     this.onTerminalTap,
-    this.onManualRecordingTap,
     this.useFrostedGlass = false,
     this.useLargeComposerStyle = false,
     this.useAttachmentPickerForPlus = false,

--- a/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
+++ b/ui/lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart
@@ -199,14 +199,6 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
         _buildModelPickerButton(compact: false),
         const SizedBox(width: 4),
       ],
-      if (widget.onManualRecordingTap != null) ...[
-        SizedBox(
-          width: 28,
-          height: 28,
-          child: _buildManualRecordingButton(iconSize: 20),
-        ),
-        const SizedBox(width: 4),
-      ],
       if (_shouldShowAgentPermissionSelector) ...[
         SizedBox(
           width: 28,
@@ -563,14 +555,6 @@ mixin _ChatInputAreaComposerMixin on _ChatInputAreaStateBase {
         ],
         if (_shouldShowModelPicker) ...[
           _buildModelPickerButton(compact: true),
-          const SizedBox(width: 2),
-        ],
-        if (widget.onManualRecordingTap != null) ...[
-          SizedBox(
-            width: 24,
-            height: 24,
-            child: _buildManualRecordingButton(iconSize: 18),
-          ),
           const SizedBox(width: 2),
         ],
         if (_shouldShowAgentPermissionSelector) ...[

--- a/ui/test/features/home/pages/command_overlay/services/manual_recording_flow_controller_test.dart
+++ b/ui/test/features/home/pages/command_overlay/services/manual_recording_flow_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:ui/features/home/pages/command_overlay/services/manual_recording
 
 void main() {
   test('recognizes manual recording commands before agent dispatch', () {
+    expect(ManualRecordingFlowController.isCommand('/record'), isTrue);
     expect(ManualRecordingFlowController.isCommand('手动录制'), isTrue);
     expect(
       ManualRecordingFlowController.isCommand(' manual recording '),
@@ -28,6 +29,19 @@ void main() {
 
     expect(manualRoute, greaterThanOrEqualTo(0));
     expect(modelCheck, greaterThan(manualRoute));
+  });
+
+  test('manual recording is exposed through the command panel', () {
+    final commandPanelSource = File(
+      'lib/features/home/pages/chat/chat_page_ui.dart',
+    ).readAsStringSync();
+    final composerSource = File(
+      'lib/features/home/pages/command_overlay/widgets/chat_input_area_composer.dart',
+    ).readAsStringSync();
+
+    expect(commandPanelSource, contains("'cardId': 'slash-command-record'"));
+    expect(commandPanelSource, contains("case '/record':"));
+    expect(composerSource, isNot(contains('_buildManualRecordingButton')));
   });
 
   testWidgets('keeps recording completion inline when conversion fails', (

--- a/ui/test/features/home/pages/command_overlay/widgets/chat_input_area_test.dart
+++ b/ui/test/features/home/pages/command_overlay/widgets/chat_input_area_test.dart
@@ -108,87 +108,6 @@ void main() {
     expect(tapped, isTrue);
   });
 
-  testWidgets('manual recording icon invokes callback', (tester) async {
-    var tapped = false;
-    await tester.pumpWidget(
-      _buildTestApp(
-        contextUsageRatio: null,
-        useLargeComposerStyle: true,
-        onManualRecordingTap: () {
-          tapped = true;
-        },
-      ),
-    );
-    await tester.pump();
-
-    final button = find.byKey(
-      const ValueKey('chat-input-manual-recording-button'),
-    );
-    expect(button, findsOneWidget);
-    await tester.tap(button);
-    await tester.pump();
-
-    expect(tapped, isTrue);
-  });
-
-  testWidgets('opens vlm-core RunLog recording menu', (tester) async {
-    final inputKey = GlobalKey<ChatInputAreaState>();
-    final controller = TextEditingController();
-    final focusNode = FocusNode();
-    addTearDown(controller.dispose);
-    addTearDown(focusNode.dispose);
-    var popupVisible = false;
-    await tester.pumpWidget(
-      DefaultAssetBundle(
-        bundle: _TestAssetBundle(),
-        child: MaterialApp(
-          home: StatefulBuilder(
-            builder: (context, setState) {
-              return Scaffold(
-                body: Column(
-                  children: [
-                    ChatInputArea(
-                      key: inputKey,
-                      controller: controller,
-                      focusNode: focusNode,
-                      isProcessing: false,
-                      onSendMessage: () {},
-                      onCancelTask: () {},
-                      onPopupVisibilityChanged: (visible) {
-                        setState(() => popupVisible = visible);
-                      },
-                    ),
-                    if (popupVisible)
-                      inputKey.currentState?.buildPopupMenu() ??
-                          const SizedBox.shrink(),
-                  ],
-                ),
-              );
-            },
-          ),
-        ),
-      ),
-    );
-    await tester.pump();
-
-    expect(
-      find.byKey(const ValueKey('chat-input-trajectory-button')),
-      findsOneWidget,
-    );
-    await tester.tap(
-      find.byKey(const ValueKey('chat-input-trajectory-button')),
-    );
-    await tester.pump();
-
-    expect(
-      find.byKey(const ValueKey('chat-input-trajectory-popup')),
-      findsOneWidget,
-    );
-    expect(find.text('RunLog'), findsOneWidget);
-    expect(find.text('Previous'), findsOneWidget);
-    expect(find.text('Record'), findsOneWidget);
-  });
-
   testWidgets('agent permission selector opens menu and selects mode', (
     tester,
   ) async {
@@ -1173,7 +1092,6 @@ Widget _buildTestApp({
   FocusNode? focusNode,
   bool hasExternalSendPayload = false,
   VoidCallback? onSendMessage,
-  FutureOr<void> Function()? onManualRecordingTap,
 }) {
   return DefaultAssetBundle(
     bundle: _TestAssetBundle(),
@@ -1184,7 +1102,6 @@ Widget _buildTestApp({
           focusNode: focusNode ?? FocusNode(),
           isProcessing: false,
           onSendMessage: onSendMessage ?? () {},
-          onManualRecordingTap: onManualRecordingTap,
           onCancelTask: () {},
           useLargeComposerStyle: useLargeComposerStyle,
           hasExternalSendPayload: hasExternalSendPayload,


### PR DESCRIPTION
## 变更说明

手动录制并非高频操作，原入口长期占用输入框空间，且图标样式与其他操作图标不够统一。

本次将手动录制入口移至命令面板，通过 `/record` 启动，并同步清理原输入框按钮及相关废弃代码，进一步打磨输入区域的视觉与交互细节。

## 验证

已在 RMX5200 真机完成基本功能验证。