### PR TITLE
feat(agent): 接入 Kimi Code 与 Kimi/DSH Web UI

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AcpAgentProfileStore.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AcpAgentProfileStore.kt
@@ -156,6 +156,20 @@ internal val DEEPSEEK_HARNESS_NPM_PACKAGE_SPECS = listOf(
     "@deepseek-ai/dsh@$DEEPSEEK_HARNESS_NPM_CHANNEL",
     "@openma/deepseek-harness-acp@latest",
 )
+
+internal const val KIMI_CODE_NPM_PACKAGE_SPEC =
+    "@moonshot-ai/kimi-code@latest"
+internal const val KIMI_CODE_PREPARATION_REVISION = "kimi-code-npm-v1"
+internal const val KIMI_CODE_NPM_INSTALL_COMMAND =
+    "npm install -g --prefix /root/.npm-global --registry=https://registry.npmmirror.com " +
+        "$KIMI_CODE_NPM_PACKAGE_SPEC || " +
+        "npm install -g --prefix /root/.npm-global $KIMI_CODE_NPM_PACKAGE_SPEC"
+internal const val KIMI_CODE_NATIVE_HEALTH_COMMAND =
+    "PATH=/root/.npm-global/bin:\$PATH; export PATH; " +
+        "command -v kimi >/dev/null 2>&1 && " +
+        "node -e 'const [major, minor] = process.versions.node.split(\".\").map(Number); " +
+        "if (major < 22 || (major === 22 && minor < 19)) process.exit(1)'"
+
 internal const val DEEPSEEK_HARNESS_INSTALL_SCRIPT_PATH =
     "/root/.dsh/omnibot-acp/install-dsh-runtime.sh"
 internal const val DEEPSEEK_HARNESS_ACP_PATCH_PATH =
@@ -708,6 +722,7 @@ internal class AcpAgentProfileStore(context: Context) {
     companion object {
         const val CODEX_AGENT_ID = "codex-acp"
         const val DEEPSEEK_HARNESS_AGENT_ID = "deepseek-harness-acp"
+        const val KIMI_CODE_AGENT_ID = "kimi-code-acp"
         const val XIAOWAN_AGENT_ID = "xiaowan-acp"
         const val DEFAULT_AGENT_ID = XIAOWAN_AGENT_ID
 
@@ -738,6 +753,14 @@ internal class AcpAgentProfileStore(context: Context) {
                 name = "OpenCode",
                 description = "OpenCode ACP server",
                 command = "opencode",
+                arguments = listOf("acp"),
+                builtIn = true
+            ),
+            AcpAgentProfile(
+                id = KIMI_CODE_AGENT_ID,
+                name = "Kimi Code",
+                description = "Kimi Code official ACP profile",
+                command = "kimi",
                 arguments = listOf("acp"),
                 builtIn = true
             ),
@@ -790,6 +813,16 @@ internal class AcpAgentProfileStore(context: Context) {
                         "/root/.npm-global/bin/opencode && " +
                         "test -x /root/.npm-global/bin/opencode",
                 harnessAdapter = AcpHarnessAdapters.openCode,
+                usesSharedProvider = true,
+            ),
+            KIMI_CODE_AGENT_ID to AcpOfficialRuntime(
+                discoveryCommand = "kimi",
+                managedAdapterPackage = KIMI_CODE_NPM_PACKAGE_SPEC,
+                terminalPackageId = "kimi",
+                managedAdapterHealthCommand = KIMI_CODE_NATIVE_HEALTH_COMMAND,
+                managedInstallCommand = KIMI_CODE_NPM_INSTALL_COMMAND,
+                preparationRevision = KIMI_CODE_PREPARATION_REVISION,
+                harnessAdapter = AcpHarnessAdapters.kimiCode,
                 usesSharedProvider = true,
             ),
             DEEPSEEK_HARNESS_AGENT_ID to AcpOfficialRuntime(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AcpHarnessAdapters.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AcpHarnessAdapters.kt
@@ -37,6 +37,7 @@ internal enum class AcpHarnessProviderConfigKind {
     CLAUDE_CODE,
     OPEN_CODE,
     DEEPSEEK_HARNESS,
+    KIMI_CODE,
 }
 
 internal interface AcpHarnessAdapter {
@@ -117,6 +118,18 @@ internal object AcpHarnessAdapters {
     val openCode: AcpHarnessAdapter = object : AcpHarnessAdapter {
         override val mcpTransport = AcpHarnessMcpTransport.SESSION_DECLARATION
         override val providerConfigKind = AcpHarnessProviderConfigKind.OPEN_CODE
+    }
+
+    val kimiCode: AcpHarnessAdapter = object : AcpHarnessAdapter {
+        override val mcpTransport = AcpHarnessMcpTransport.SESSION_DECLARATION
+        override val providerConfigKind = AcpHarnessProviderConfigKind.KIMI_CODE
+
+        override fun launchEnvironment(
+            provider: AgentProviderCredentials?,
+            model: String?,
+            rawConfig: String,
+            mcpState: McpServerState,
+        ): Map<String, String> = buildKimiCodeModelEnvironment(provider, model)
     }
 
     val deepSeekHarness: AcpHarnessAdapter = object : AcpHarnessAdapter {
@@ -288,6 +301,7 @@ private val DEEPSEEK_HARNESS_PERMISSION_MODES = setOf(
     "danger-full-access"
 )
 private const val DEEPSEEK_HARNESS_PERSISTENCE_HOME = "/root/.dsh/omnibot-acp-clean"
+internal const val DEEPSEEK_HARNESS_WEB_HOME = "/root/.dsh/omnibot-web"
 
 internal data class DeepSeekHarnessConfig(
     val baseUrl: String = DEEPSEEK_PUBLIC_BASE_URL,
@@ -311,6 +325,26 @@ internal data class DeepSeekHarnessConfig(
         "DSH_PROVIDER" to "deepseek-official",
         "NODE_NO_WARNINGS" to "1"
     )
+}
+
+/**
+ * Web owns the built-in `web` profile. Keep its profile/home separate from
+ * the headless ACP overlay while reusing the same Dispatch Provider values.
+ */
+internal fun buildDeepSeekHarnessWebEnvironment(
+    provider: AgentProviderCredentials?,
+    model: String?,
+): Map<String, String> {
+    val config = syncAgentProviderCredentials(
+        config = DeepSeekHarnessConfig(),
+        sharedProvider = provider,
+        sharedModel = model,
+    )
+    return config.toEnvironment().toMutableMap().apply {
+        remove("DSH_ACP_HOME")
+        put("DSH_HOME", DEEPSEEK_HARNESS_WEB_HOME)
+        put("DSH_SESSION_ROOT", "$DEEPSEEK_HARNESS_WEB_HOME/sessions")
+    }
 }
 
 internal fun parseDeepSeekHarnessConfig(source: String): DeepSeekHarnessConfig {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdapters.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdapters.kt
@@ -53,6 +53,8 @@ internal data class AgentProviderMappingInput(
     val agentId: String,
     val provider: AgentProviderCredentials?,
     val model: String?,
+    /** ACP/Web request-level thinking selection, when the caller supplied one. */
+    val reasoningEffort: String? = null,
     val harnessAdapter: AcpHarnessAdapter = AcpHarnessAdapters.standard,
     val deepSeekConfig: DeepSeekHarnessConfig = DeepSeekHarnessConfig(),
 )
@@ -141,6 +143,7 @@ internal object AgentConfigAdapterRegistry {
 private fun AgentProviderMappingInput.normalized(): AgentProviderMappingInput = copy(
     provider = provider?.normalized(),
     model = model?.trim()?.takeIf { it.isNotEmpty() },
+    reasoningEffort = reasoningEffort?.trim()?.takeIf { it.isNotEmpty() },
 )
 
 private object DeepSeekHarnessConfigAdapter : AgentConfigAdapter {
@@ -305,7 +308,43 @@ private object OpenCodeConfigAdapter : AgentConfigAdapter {
 private object KimiCodeConfigAdapter : AgentConfigAdapter {
     override fun map(input: AgentProviderMappingInput): AgentProviderMapping {
         return AgentProviderMapping(
-            environment = buildKimiCodeModelEnvironment(input.provider, input.model),
+            environment = buildKimiCodeModelEnvironment(
+                provider = input.provider,
+                model = input.model,
+                reasoningEffort = input.reasoningEffort,
+            ),
+            launchConfigPath = input.reasoningEffort
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { KIMI_CODE_CONFIG_PATH },
+            launchConfigExecutorKey = input.reasoningEffort
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { "kimi-code-config-read" },
+        )
+    }
+
+    override fun launchConfigWrites(
+        input: AgentProviderMappingInput,
+        mapping: AgentProviderMapping,
+        providerModels: List<ProviderModelOption>,
+        existingConfig: String,
+    ): List<AgentConfigWrite> {
+        // KIMI_MODEL_THINKING_EFFORT is intentionally limited to Kimi's
+        // native provider by Kimi Code.  A shared custom Provider is exposed
+        // as OpenAI-compatible, so its concrete effort must be written to
+        // the documented global [thinking] section instead.
+        val effort = input.reasoningEffort?.trim()?.takeIf { it.isNotEmpty() }
+            ?: return emptyList()
+        return listOf(
+            AgentConfigWrite(
+                path = KIMI_CODE_CONFIG_PATH,
+                content = buildKimiCodeThinkingConfigToml(
+                    existingConfig = existingConfig,
+                    reasoningEffort = effort,
+                ),
+                executorKey = "kimi-code-config-write",
+            ),
         )
     }
 }
@@ -319,6 +358,7 @@ private object KimiCodeConfigAdapter : AgentConfigAdapter {
 internal fun buildKimiCodeModelEnvironment(
     provider: AgentProviderCredentials?,
     model: String?,
+    reasoningEffort: String? = null,
 ): Map<String, String> {
     val credentials = requireNotNull(provider) {
         "Dispatch Model Provider is required for Kimi Code."
@@ -351,7 +391,24 @@ internal fun buildKimiCodeModelEnvironment(
         "KIMI_MODEL_API_KEY" to credentials.apiKey,
         "KIMI_MODEL_BASE_URL" to baseUrl,
         "KIMI_MODEL_PROVIDER_TYPE" to providerType,
+        // The synthetic model defaults to these capabilities, but publishing
+        // them explicitly prevents a stale Kimi home/config from hiding the
+        // Thinking option after a Provider switch.
+        "KIMI_MODEL_CAPABILITIES" to "image_in,thinking",
     ).apply {
+        val normalizedEffort = normalizeKimiCodeThinkingEffort(reasoningEffort)
+        if (
+            providerType == "kimi" &&
+            normalizedEffort != null &&
+            normalizedEffort != "off" &&
+            normalizedEffort != "on" &&
+            normalizedEffort in KIMI_CODE_THINKING_EFFORTS
+        ) {
+            // Kimi's native trait consumes this forced value. Do not send it
+            // for custom OpenAI-compatible/Anthropic routes: Kimi Code's
+            // generic providers use the [thinking] config instead.
+            put("KIMI_MODEL_THINKING_EFFORT", normalizedEffort)
+        }
         if (credentials.customHeaders.isNotEmpty()) {
             put(
                 "KIMI_CODE_CUSTOM_HEADERS",
@@ -364,6 +421,93 @@ internal fun buildKimiCodeModelEnvironment(
 }
 
 internal const val KIMI_CODE_HOME = "/root/.kimi-code/omnibot"
+internal const val KIMI_CODE_CONFIG_PATH = "$KIMI_CODE_HOME/config.toml"
+
+private val KIMI_CODE_THINKING_EFFORTS = setOf(
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+)
+
+/** Normalize common UI aliases while preserving provider-specific levels. */
+internal fun normalizeKimiCodeThinkingEffort(value: String?): String? {
+    val normalized = value?.trim()?.lowercase()?.replace('_', '-')
+        ?.takeIf { it.isNotEmpty() }
+        ?: return null
+    return when (normalized) {
+        "no", "none", "off" -> "off"
+        "on" -> "on"
+        "minimal", "min" -> "minimal"
+        "med" -> "medium"
+        "extra-high", "very-high", "x-high" -> "xhigh"
+        else -> normalized
+    }
+}
+
+/**
+ * Update only Kimi Code's documented [thinking] table, preserving the rest of
+ * the app-owned Kimi config (MCP, permissions, and user settings).
+ */
+internal fun buildKimiCodeThinkingConfigToml(
+    existingConfig: String,
+    reasoningEffort: String?,
+): String {
+    val normalized = normalizeKimiCodeThinkingEffort(reasoningEffort)
+        ?: return existingConfig
+    val enabled = normalized != "off"
+    val lines = existingConfig.replace("\r\n", "\n").split('\n').toMutableList()
+    val sectionHeader = Regex("^\\s*\\[thinking]\\s*$")
+    val anySectionHeader = Regex("^\\s*\\[\\[?[^]]+]\\]\\]?\\s*$")
+    val sectionStart = lines.indexOfFirst { sectionHeader.matches(it) }
+    val sectionEnd = if (sectionStart >= 0) {
+        (sectionStart + 1 until lines.size)
+            .firstOrNull { anySectionHeader.matches(lines[it]) }
+            ?: lines.size
+    } else {
+        -1
+    }
+
+    fun updateKey(start: Int, endExclusive: Int, key: String, value: String): Boolean {
+        val keyRegex = Regex("^\\s*${Regex.escape(key)}\\s*=")
+        val existingIndex = (start + 1 until endExclusive)
+            .firstOrNull { keyRegex.containsMatchIn(lines[it]) }
+        if (existingIndex != null) {
+            lines[existingIndex] = "$key = $value"
+            return false
+        } else {
+            lines.add(endExclusive.coerceAtMost(lines.size), "$key = $value")
+            return true
+        }
+    }
+
+    fun removeKey(start: Int, endExclusive: Int, key: String) {
+        val keyRegex = Regex("^\\s*${Regex.escape(key)}\\s*=")
+        for (index in endExclusive - 1 downTo start + 1) {
+            if (keyRegex.containsMatchIn(lines[index])) lines.removeAt(index)
+        }
+    }
+
+    if (sectionStart < 0) {
+        while (lines.lastOrNull()?.isBlank() == true) lines.removeAt(lines.lastIndex)
+        if (lines.isNotEmpty()) lines += ""
+        lines += "[thinking]"
+        lines += "enabled = $enabled"
+        if (enabled && normalized != "on") {
+            lines += "effort = \"$normalized\""
+        }
+    } else {
+        var end = sectionEnd
+        if (updateKey(sectionStart, end, "enabled", enabled.toString())) end += 1
+        if (enabled && normalized != "on") {
+            updateKey(sectionStart, end, "effort", "\"$normalized\"")
+        } else {
+            removeKey(sectionStart, end, "effort")
+        }
+    }
+    return lines.joinToString("\n").trimEnd() + "\n"
+}
 
 /** Kimi expects an API root, while legacy Provider entries may store an endpoint. */
 internal fun normalizeKimiCodeBaseUrl(baseUrl: String): String {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdapters.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdapters.kt
@@ -93,7 +93,8 @@ internal object AgentConfigAdapterRegistry {
         DeepSeekHarnessConfigAdapter,
         CodexConfigAdapter,
         ClaudeCodeConfigAdapter,
-        OpenCodeConfigAdapter
+        OpenCodeConfigAdapter,
+        KimiCodeConfigAdapter,
     )
 
     fun map(input: AgentProviderMappingInput): AgentProviderMapping {
@@ -131,6 +132,8 @@ internal object AgentConfigAdapterRegistry {
             AcpHarnessProviderConfigKind.OPEN_CODE ->
                 this === OpenCodeConfigAdapter
             AcpHarnessProviderConfigKind.STANDARD -> false
+            AcpHarnessProviderConfigKind.KIMI_CODE ->
+                this === KimiCodeConfigAdapter
         }
     }
 }
@@ -297,6 +300,87 @@ private object OpenCodeConfigAdapter : AgentConfigAdapter {
             )
         )
     }
+}
+
+private object KimiCodeConfigAdapter : AgentConfigAdapter {
+    override fun map(input: AgentProviderMappingInput): AgentProviderMapping {
+        return AgentProviderMapping(
+            environment = buildKimiCodeModelEnvironment(input.provider, input.model),
+        )
+    }
+}
+
+/**
+ * Kimi's documented KIMI_MODEL_* channel creates an in-memory provider/model
+ * for one process. Use it for both ACP and Web so the shared Dispatch
+ * Provider remains the source of truth without writing an API key into
+ * Kimi's own config.toml.
+ */
+internal fun buildKimiCodeModelEnvironment(
+    provider: AgentProviderCredentials?,
+    model: String?,
+): Map<String, String> {
+    val credentials = requireNotNull(provider) {
+        "Dispatch Model Provider is required for Kimi Code."
+    }.normalized()
+    val modelId = model?.trim().orEmpty()
+    require(modelId.isNotEmpty()) {
+        "Dispatch Model is required for Kimi Code."
+    }
+
+    val protocol = credentials.protocolType.trim().lowercase()
+    val host = runCatching {
+        java.net.URI(credentials.baseUrl).host?.lowercase()
+    }.getOrNull().orEmpty()
+    val providerType = when {
+        protocol == "anthropic" -> "anthropic"
+        host == "api.kimi.com" ||
+            host == "api.moonshot.ai" ||
+            host == "api.moonshot.cn" -> "kimi"
+        else -> "openai"
+    }
+    val baseUrl = if (providerType == "anthropic") {
+        credentials.baseUrl
+    } else {
+        normalizeKimiCodeBaseUrl(credentials.baseUrl)
+    }
+    return linkedMapOf(
+        "KIMI_CODE_HOME" to KIMI_CODE_HOME,
+        "KIMI_CODE_NO_AUTO_UPDATE" to "1",
+        "KIMI_MODEL_NAME" to modelId,
+        "KIMI_MODEL_API_KEY" to credentials.apiKey,
+        "KIMI_MODEL_BASE_URL" to baseUrl,
+        "KIMI_MODEL_PROVIDER_TYPE" to providerType,
+    ).apply {
+        if (credentials.customHeaders.isNotEmpty()) {
+            put(
+                "KIMI_CODE_CUSTOM_HEADERS",
+                credentials.customHeaders.entries.joinToString("\n") { (key, value) ->
+                    "$key: $value"
+                },
+            )
+        }
+    }
+}
+
+internal const val KIMI_CODE_HOME = "/root/.kimi-code/omnibot"
+
+/** Kimi expects an API root, while legacy Provider entries may store an endpoint. */
+internal fun normalizeKimiCodeBaseUrl(baseUrl: String): String {
+    var normalized = baseUrl.trim().trimEnd('/')
+    listOf(
+        "/v1/chat/completions",
+        "/chat/completions",
+        "/v1/responses",
+        "/responses",
+    ).firstOrNull { normalized.endsWith(it, ignoreCase = true) }?.let {
+        normalized = normalized.dropLast(it.length).trimEnd('/')
+    }
+    if (normalized.isEmpty() || normalized.endsWith("#")) return normalized
+    if (normalized.endsWith("/v1") || normalized.endsWith("/compatible-mode/v1")) {
+        return normalized
+    }
+    return "$normalized/v1"
 }
 
 internal fun syncAgentProviderCredentials(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
@@ -237,6 +237,7 @@ class AgentRuntimeManager private constructor(
     private val historyRepository = AgentConversationHistoryRepository(appContext)
     private val remoteConfigStore = CodexRemoteBridgeConfigStore(appContext)
     private val acpAgentProfileStore = AcpAgentProfileStore(appContext)
+    private val agentWebLauncher = AgentWebLauncher(appContext)
     private val scheduledTaskScheduler by lazy {
         WorkspaceScheduledTaskScheduler(appContext)
     }
@@ -717,6 +718,9 @@ class AgentRuntimeManager private constructor(
         }
         if (method == "agent/config/write") {
             return writeAgentConfig(canonicalArgs)
+        }
+        if (method == "agent/web/launch") {
+            return launchAgentWeb(canonicalArgs)
         }
         if (method.startsWith("agent/")) {
             val requestedAgentId = canonicalArgs.stringValue("agentId")
@@ -1753,6 +1757,43 @@ class AgentRuntimeManager private constructor(
                 "kind" to "profile"
             )
         }
+    }
+
+    private suspend fun launchAgentWeb(args: Map<String, Any?>): Map<String, Any?> {
+        val agentId = args.stringValue("agentId")
+            ?: throw IllegalArgumentException("agentId is required.")
+        val service = AgentWebService.forAgentId(agentId)
+            ?: return AgentWebLaunchResult(
+                ok = false,
+                code = "UNSUPPORTED_AGENT",
+                packageId = "",
+                error = "This Agent does not expose a Web surface.",
+            ).toPayload()
+        val provider = currentAgentProviderCredentials()
+            ?: return AgentWebLaunchResult(
+                ok = false,
+                code = "PROVIDER_REQUIRED",
+                packageId = service.packageId,
+                error = "Configure the shared Dispatch Provider first.",
+            ).toPayload()
+        val model = currentAgentBoundModel()
+            ?: return AgentWebLaunchResult(
+                ok = false,
+                code = "MODEL_REQUIRED",
+                packageId = service.packageId,
+                error = "Select a shared Dispatch model first.",
+            ).toPayload()
+        val environment = when (service) {
+            AgentWebService.KIMI -> buildKimiCodeModelEnvironment(provider, model)
+            AgentWebService.DEEPSEEK_HARNESS ->
+                buildDeepSeekHarnessWebEnvironment(provider, model)
+        }
+        return agentWebLauncher.launch(
+            AgentWebLaunchRequest(
+                service = service,
+                environment = environment,
+            )
+        ).toPayload()
     }
 
     private suspend fun readRawAgentConfig(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
@@ -1783,8 +1783,33 @@ class AgentRuntimeManager private constructor(
                 packageId = service.packageId,
                 error = "Select a shared Dispatch model first.",
             ).toPayload()
+        val requestedReasoningEffort = args.stringValue("effort")
+            ?: args.stringValue("reasoningEffort")
         val environment = when (service) {
-            AgentWebService.KIMI -> buildKimiCodeModelEnvironment(provider, model)
+            AgentWebService.KIMI -> {
+                if (!requestedReasoningEffort.isNullOrBlank()) {
+                    val existingConfig = readTerminalTextFile(
+                        path = KIMI_CODE_CONFIG_PATH,
+                        executorKey = "kimi-code-config-read",
+                    )
+                    val updatedConfig = buildKimiCodeThinkingConfigToml(
+                        existingConfig = existingConfig,
+                        reasoningEffort = requestedReasoningEffort,
+                    )
+                    if (updatedConfig != existingConfig) {
+                        writeTerminalTextFile(
+                            path = KIMI_CODE_CONFIG_PATH,
+                            content = updatedConfig,
+                            executorKey = "kimi-code-config-write",
+                        )
+                    }
+                }
+                buildKimiCodeModelEnvironment(
+                    provider = provider,
+                    model = model,
+                    reasoningEffort = requestedReasoningEffort,
+                )
+            }
             AgentWebService.DEEPSEEK_HARNESS ->
                 buildDeepSeekHarnessWebEnvironment(provider, model)
         }
@@ -2212,15 +2237,17 @@ class AgentRuntimeManager private constructor(
     private suspend fun connectLocalAcp(
         profile: AcpAgentProfile = acpAgentProfileStore.selected(),
         runtime: LocalAcpRuntime = localRuntimeFor(profile.id),
+        reasoningEffort: String? = null,
     ) {
         require(profile.enabled) {
             "No enabled ACP Agent is selected. Enable one in Agent mode settings."
         }
-        runtime.connect(profile = profile)
+        runtime.connect(profile = profile, reasoningEffort = reasoningEffort)
     }
 
     private suspend fun prepareLocalAcpLaunch(
-        profile: AcpAgentProfile
+        profile: AcpAgentProfile,
+        reasoningEffort: String? = null,
     ): Map<String, String> {
         val usesSharedProvider = AcpAgentProfileStore
             .officialRuntime(profile)
@@ -2287,6 +2314,8 @@ class AgentRuntimeManager private constructor(
             append('|')
             append(resolvedModel.orEmpty())
             append('|')
+            append(normalizeKimiCodeThinkingEffort(reasoningEffort).orEmpty())
+            append('|')
             // Credentials are never logged; the hash only invalidates the
             // in-memory environment when a Provider/API key changes.
             append(sharedProvider?.hashCode() ?: 0)
@@ -2306,6 +2335,7 @@ class AgentRuntimeManager private constructor(
                 agentId = profile.id,
                 provider = sharedProvider,
                 model = resolvedModel,
+                reasoningEffort = reasoningEffort,
                 harnessAdapter = harnessAdapter,
             )
         )
@@ -2345,6 +2375,7 @@ class AgentRuntimeManager private constructor(
                 agentId = profile.id,
                 provider = sharedProvider,
                 model = resolvedModel,
+                reasoningEffort = reasoningEffort,
                 harnessAdapter = harnessAdapter,
             ),
             mapping = mapping,
@@ -2827,7 +2858,12 @@ class AgentRuntimeManager private constructor(
         // runtime, or lazily start one, without touching other profiles.
         val targetRuntime = localRuntimeFor(targetProfile.id)
         if (!targetRuntime.isConnected) {
-            connectLocalAcp(profile = targetProfile, runtime = targetRuntime)
+            connectLocalAcp(
+                profile = targetProfile,
+                runtime = targetRuntime,
+                reasoningEffort = args.stringValue("effort")
+                    ?: args.stringValue("reasoningEffort"),
+            )
         }
         if (conversationId != null) {
             if (normalConversation && conversationAgentId != targetProfile.id) {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentWebLauncher.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentWebLauncher.kt
@@ -1,0 +1,221 @@
+package cn.com.omnimind.bot.agent.runtime
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import cn.com.omnimind.bot.terminal.EmbeddedTerminalRuntime
+import cn.com.omnimind.bot.terminal.ReTerminalSessionBridge
+import com.ai.assistance.operit.terminal.TerminalManager
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/** Web surfaces that are backed by an installed local Agent runtime. */
+internal enum class AgentWebService(
+    val agentId: String,
+    val packageId: String,
+    val commandName: String,
+    val command: String,
+    val sessionId: String,
+    val urlKind: AgentWebUrlKind,
+) {
+    KIMI(
+        agentId = AcpAgentProfileStore.KIMI_CODE_AGENT_ID,
+        packageId = "kimi",
+        commandName = "kimi",
+        command = "kimi web --no-open",
+        sessionId = "omnibot-web-kimi",
+        urlKind = AgentWebUrlKind.KIMI,
+    ),
+    DEEPSEEK_HARNESS(
+        agentId = AcpAgentProfileStore.DEEPSEEK_HARNESS_AGENT_ID,
+        packageId = "deepseek_harness",
+        commandName = "dsh",
+        command = "dsh web --no-open",
+        sessionId = "omnibot-web-dsh",
+        urlKind = AgentWebUrlKind.DEEPSEEK_HARNESS,
+    );
+
+    companion object {
+        fun forAgentId(agentId: String): AgentWebService? {
+            val normalized = agentId.trim()
+            return entries.firstOrNull { it.agentId == normalized }
+        }
+    }
+}
+
+internal enum class AgentWebUrlKind {
+    KIMI,
+    DEEPSEEK_HARNESS,
+}
+
+internal data class AgentWebLaunchRequest(
+    val service: AgentWebService,
+    val environment: Map<String, String>,
+)
+
+internal data class AgentWebLaunchResult(
+    val ok: Boolean,
+    val code: String,
+    val packageId: String,
+    val reused: Boolean = false,
+    val error: String? = null,
+) {
+    fun toPayload(): Map<String, Any?> = linkedMapOf(
+        "ok" to ok,
+        "code" to code,
+        "packageId" to packageId,
+        "reused" to reused,
+        "error" to error,
+    ).filterValues { it != null }
+}
+
+/**
+ * Starts a vendor Web UI in a named ReTerminal background session and opens
+ * only the vendor-published loopback URL in the system browser.
+ *
+ * The browser URL is deliberately never returned through Flutter: Kimi's
+ * URL contains a bearer token and the DSH URL is still a privileged local
+ * filesystem/shell surface.
+ */
+internal class AgentWebLauncher(
+    private val context: Context,
+) {
+    private val launchMutexes = AgentWebService.entries.associateWith { Mutex() }
+
+    suspend fun launch(request: AgentWebLaunchRequest): AgentWebLaunchResult =
+        launchMutexes.getValue(request.service).withLock {
+            withContext(Dispatchers.IO) {
+                val service = request.service
+                if (!isCommandAvailable(service.commandName)) {
+                    return@withContext AgentWebLaunchResult(
+                        ok = false,
+                        code = CODE_RUNTIME_MISSING,
+                        packageId = service.packageId,
+                        error = "Web runtime is not installed.",
+                    )
+                }
+
+                val launch = try {
+                    EmbeddedTerminalRuntime.launchBackgroundServiceSession(
+                        context = context,
+                        sessionId = service.sessionId,
+                        command = "$MANAGED_NPM_PATH_PREFIX exec ${service.command}",
+                        workingDirectory = AgentWorkspaceManager.SHELL_ROOT_PATH,
+                        environment = request.environment,
+                    )
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    return@withContext AgentWebLaunchResult(
+                        ok = false,
+                        code = CODE_START_FAILED,
+                        packageId = service.packageId,
+                        error = "Unable to start the Web service.",
+                    )
+                }
+                if (!launch.started && !launch.alreadyRunning) {
+                    return@withContext AgentWebLaunchResult(
+                        ok = false,
+                        code = CODE_START_FAILED,
+                        packageId = service.packageId,
+                        error = "Unable to start the Web service.",
+                    )
+                }
+
+                val url = awaitUrl(service)
+                    ?: return@withContext AgentWebLaunchResult(
+                        ok = false,
+                        code = CODE_URL_TIMEOUT,
+                        packageId = service.packageId,
+                        reused = launch.alreadyRunning,
+                        error = "The Web service did not publish a local URL.",
+                    )
+
+                val opened = runCatching {
+                    context.startActivity(
+                        Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        },
+                    )
+                }.isSuccess
+                if (!opened) {
+                    AgentWebLaunchResult(
+                        ok = false,
+                        code = CODE_BROWSER_UNAVAILABLE,
+                        packageId = service.packageId,
+                        reused = launch.alreadyRunning,
+                        error = "No system browser is available.",
+                    )
+                } else {
+                    AgentWebLaunchResult(
+                        ok = true,
+                        code = CODE_OPENED,
+                        packageId = service.packageId,
+                        reused = launch.alreadyRunning,
+                    )
+                }
+            }
+        }
+
+    private suspend fun isCommandAvailable(commandName: String): Boolean {
+        val result = TerminalManager.getInstance(context).executeHiddenCommand(
+            command = "$MANAGED_NPM_PATH_PREFIX command -v ${shellQuote(commandName)}",
+            executorKey = "agent-web-command-probe-$commandName",
+            timeoutMs = COMMAND_PROBE_TIMEOUT_MS,
+        )
+        return result.isOk && result.exitCode == 0
+    }
+
+    private suspend fun awaitUrl(service: AgentWebService): String? {
+        repeat(URL_WAIT_ATTEMPTS) { attempt ->
+            val session = ReTerminalSessionBridge.getSession(context, service.sessionId)
+            val transcript = session?.getTranscriptText().orEmpty()
+            AgentWebUrlParser.find(service.urlKind, transcript)?.let { return it }
+            if (attempt > 1 && session != null && !session.isRunning) {
+                return null
+            }
+            delay(URL_WAIT_INTERVAL_MS)
+        }
+        return null
+    }
+
+    private companion object {
+        const val CODE_OPENED = "OPENED"
+        const val CODE_RUNTIME_MISSING = "RUNTIME_MISSING"
+        const val CODE_START_FAILED = "START_FAILED"
+        const val CODE_URL_TIMEOUT = "URL_TIMEOUT"
+        const val CODE_BROWSER_UNAVAILABLE = "BROWSER_UNAVAILABLE"
+        const val COMMAND_PROBE_TIMEOUT_MS = 15_000L
+        const val URL_WAIT_ATTEMPTS = 60
+        const val URL_WAIT_INTERVAL_MS = 500L
+        const val MANAGED_NPM_PATH_PREFIX =
+            "PATH=\"/root/.npm-global/bin:\$PATH\"; export PATH;"
+
+        fun shellQuote(value: String): String =
+            "'${value.replace("'", "'\"'\"'")}'"
+    }
+}
+
+internal object AgentWebUrlParser {
+    private val ansiEscapeRegex = Regex("\\u001B\\[[0-?]*[ -/]*[@-~]")
+    private val kimiUrlRegex = Regex(
+        "https?://(?:127\\.0\\.0\\.1|localhost):\\d+/#token=[A-Za-z0-9_-]+",
+    )
+    private val deepSeekUrlRegex = Regex(
+        "https?://(?:127\\.0\\.0\\.1|localhost):\\d+",
+    )
+
+    fun find(kind: AgentWebUrlKind, transcript: String): String? {
+        val clean = ansiEscapeRegex.replace(transcript, "")
+        val regex = when (kind) {
+            AgentWebUrlKind.KIMI -> kimiUrlRegex
+            AgentWebUrlKind.DEEPSEEK_HARNESS -> deepSeekUrlRegex
+        }
+        return regex.findAll(clean).lastOrNull()?.value
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/LocalAcpRuntime.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/LocalAcpRuntime.kt
@@ -501,7 +501,8 @@ internal class LocalAcpRuntime(
     private val scope: CoroutineScope,
     private val bindingRepository: AgentSessionBindingRepository,
     private val profileStore: AcpAgentProfileStore,
-    private val prepareLaunchEnvironment: suspend (AcpAgentProfile) -> Map<String, String>,
+    private val prepareLaunchEnvironment:
+        suspend (AcpAgentProfile, String?) -> Map<String, String>,
     private val resolveSessionMcpEnabled: suspend (AcpAgentProfile) -> Boolean = { true },
     private val prepareSharedProviderBinding: suspend () -> Unit = {},
     private val buildHandoffContext: suspend (Long, String?) -> String?,
@@ -642,7 +643,8 @@ internal class LocalAcpRuntime(
     fun agentVersion(): String? = agentInfo?.implementation?.version
 
     suspend fun connect(
-        profile: AcpAgentProfile = profileStore.selected()
+        profile: AcpAgentProfile = profileStore.selected(),
+        reasoningEffort: String? = null,
     ) {
         val callerJob = coroutineContext[Job]
         callerJob?.let(pendingConnectJobs::add)
@@ -661,7 +663,7 @@ internal class LocalAcpRuntime(
                 sessionMcpEnabled = true
                 emptyMap()
             } else {
-                prepareLaunchEnvironment(profile).also {
+                prepareLaunchEnvironment(profile, reasoningEffort).also {
                     val officialRuntime = AcpAgentProfileStore.officialRuntime(profile)
                     val health = profileStore.health(profile.id)
                     if (shouldProbeManagedAcpLaunchCommand(
@@ -1770,7 +1772,7 @@ internal class LocalAcpRuntime(
             // command in place; the normal agent/select path performs the ACP
             // handshake when the user actually switches to that Harness.
             return runCatching {
-                prepareLaunchEnvironment(profile)
+                prepareLaunchEnvironment(profile, null)
                 requireLaunchCommand(profile)
                 val health = managedAgentPreparationHealth(
                     preparationRevision = AcpAgentProfileStore

--- a/app/src/main/java/com/ai/assistance/operit/terminal/setup/EnvironmentSetupLogic.kt
+++ b/app/src/main/java/com/ai/assistance/operit/terminal/setup/EnvironmentSetupLogic.kt
@@ -2,6 +2,8 @@ package com.ai.assistance.operit.terminal.setup
 
 import cn.com.omnimind.bot.agent.runtime.DEEPSEEK_HARNESS_NPM_INSTALL_COMMAND
 import cn.com.omnimind.bot.agent.runtime.DEEPSEEK_HARNESS_NATIVE_HEALTH_COMMAND
+import cn.com.omnimind.bot.agent.runtime.KIMI_CODE_NATIVE_HEALTH_COMMAND
+import cn.com.omnimind.bot.agent.runtime.KIMI_CODE_NPM_INSTALL_COMMAND
 import com.ai.assistance.operit.terminal.utils.SourceManager
 import com.rk.terminal.runtime.UbuntuRepositoryManager
 import com.rk.terminal.ui.screens.settings.WorkingMode
@@ -23,6 +25,7 @@ object EnvironmentSetupLogic {
             DEEPSEEK_HARNESS_NATIVE_HEALTH_COMMAND
     private const val DEEPSEEK_HARNESS_VERSION_COMMAND =
         "node -p \"require('/root/.npm-global/lib/node_modules/@deepseek-ai/dsh/package.json').version\""
+    private const val KIMI_CODE_VERSION_COMMAND = "kimi --version"
 
     val packageDefinitions: List<PackageDefinition> = listOf(
         PackageDefinition("nodejs", "node --version", "dev"),
@@ -39,6 +42,7 @@ object EnvironmentSetupLogic {
         PackageDefinition("claude_code", "command -v claude-agent-acp", "ai"),
         PackageDefinition("opencode", "opencode --version", "ai"),
         PackageDefinition("deepseek_harness", DEEPSEEK_HARNESS_CHECK_COMMAND, "ai"),
+        PackageDefinition("kimi", KIMI_CODE_NATIVE_HEALTH_COMMAND, "ai"),
         PackageDefinition("ssh_client", "ssh -V 2>&1", "ssh"),
         PackageDefinition("sshpass", "sshpass -V 2>&1", "ssh"),
         PackageDefinition("openssh_server", "sshd -V 2>&1", "ssh")
@@ -78,6 +82,7 @@ object EnvironmentSetupLogic {
             "linux-headers",
             "util-linux-dev"
         ),
+        "kimi" to listOf("nodejs", "npm", "git", "bash", "curl", "ripgrep"),
         "python" to listOf("python3"),
         "pip" to listOf("py3-pip"),
         "uv" to listOf("python3", "py3-pip"),
@@ -107,6 +112,7 @@ object EnvironmentSetupLogic {
             "build-essential",
             "python3"
         ),
+        "kimi" to listOf("nodejs", "git", "bash", "curl", "ripgrep"),
         "python" to listOf("python3"),
         "pip" to listOf("python3-pip"),
         "uv" to listOf("python3", "python3-pip"),
@@ -208,6 +214,10 @@ object EnvironmentSetupLogic {
         if ("deepseek_harness" in requested) {
             commands += DEEPSEEK_HARNESS_NPM_INSTALL_COMMAND
             commands += "ln -sf /root/.npm-global/bin/dsh /usr/local/bin/dsh || true"
+        }
+        if ("kimi" in requested) {
+            commands += KIMI_CODE_NPM_INSTALL_COMMAND
+            commands += "ln -sf /root/.npm-global/bin/kimi /usr/local/bin/kimi || true"
         }
         if ("openssh_server" in requested) {
             commands += "mkdir -p /var/run/sshd /etc/ssh"
@@ -334,6 +344,11 @@ object EnvironmentSetupLogic {
                     commandCheck = DEEPSEEK_HARNESS_CHECK_COMMAND,
                     versionCommand = DEEPSEEK_HARNESS_VERSION_COMMAND
                 )
+                "kimi" -> buildProbeSnippet(
+                    packageId = packageId,
+                    commandCheck = KIMI_CODE_NATIVE_HEALTH_COMMAND,
+                    versionCommand = KIMI_CODE_VERSION_COMMAND
+                )
                 "ssh_client" -> buildProbeSnippet(
                     packageId = packageId,
                     commandCheck = "command -v ssh >/dev/null 2>&1",
@@ -389,6 +404,7 @@ object EnvironmentSetupLogic {
             "claude_code" -> "PATH=\"/root/.npm-global/bin:${'$'}PATH\"; export PATH; command -v claude-agent-acp"
             "opencode" -> "PATH=\"/root/.npm-global/bin:${'$'}PATH\"; export PATH; command -v opencode && opencode --version"
             "deepseek_harness" -> DEEPSEEK_HARNESS_CHECK_COMMAND
+            "kimi" -> KIMI_CODE_NATIVE_HEALTH_COMMAND
             "ripgrep" -> "command -v rg"
             "tmux" -> "command -v tmux"
             "xz" -> "command -v xz"
@@ -440,7 +456,12 @@ object EnvironmentSetupLogic {
             checks.putIfAbsent(label, command)
         }
 
-        if (
+        if ("kimi" in requested) {
+            add(
+                "Kimi Code Node.js 22.19+",
+                "node -e 'const [major, minor] = process.versions.node.split(\".\").map(Number); if (major < 22 || (major === 22 && minor < 19)) process.exit(1)' >/dev/null 2>&1"
+            )
+        } else if (
             requested.any {
                 it == "nodejs" || it == "npm" || it in NPM_AGENT_PACKAGE_IDS
             }
@@ -485,6 +506,9 @@ object EnvironmentSetupLogic {
         }
         if ("deepseek_harness" in requested) {
             add("DeepSeek Harness", DEEPSEEK_HARNESS_CHECK_COMMAND)
+        }
+        if ("kimi" in requested) {
+            add("Kimi Code", KIMI_CODE_NATIVE_HEALTH_COMMAND)
         }
         if ("ssh_client" in requested) {
             add("SSH client", "ssh -V >/dev/null 2>&1")
@@ -531,6 +555,7 @@ object EnvironmentSetupLogic {
         "codex",
         "claude_code",
         "opencode",
-        "deepseek_harness"
+        "deepseek_harness",
+        "kimi"
     )
 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdaptersTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdaptersTest.kt
@@ -119,6 +119,67 @@ class AgentConfigAdaptersTest {
     }
 
     @Test
+    fun kimiCodeUsesTheSharedProviderThroughItsEphemeralModelChannel() {
+        val mapping = AgentConfigAdapterRegistry.map(
+            AgentProviderMappingInput(
+                agentId = AcpAgentProfileStore.KIMI_CODE_AGENT_ID,
+                provider = provider.copy(
+                    customHeaders = mapOf(" X-Trace " to " request-1 "),
+                ),
+                model = "GLM-5.1",
+                harnessAdapter = AcpHarnessAdapters.kimiCode,
+            ),
+        )
+
+        assertEquals("GLM-5.1", mapping.environment["KIMI_MODEL_NAME"])
+        assertEquals("secret", mapping.environment["KIMI_MODEL_API_KEY"])
+        assertEquals("https://llmapi.paratera.com/v1", mapping.environment["KIMI_MODEL_BASE_URL"])
+        assertEquals("openai", mapping.environment["KIMI_MODEL_PROVIDER_TYPE"])
+        assertEquals("/root/.kimi-code/omnibot", mapping.environment["KIMI_CODE_HOME"])
+        assertEquals("X-Trace: request-1", mapping.environment["KIMI_CODE_CUSTOM_HEADERS"])
+        assertEquals("1", mapping.environment["KIMI_CODE_NO_AUTO_UPDATE"])
+    }
+
+    @Test
+    fun kimiCodeRecognizesMoonshotAndAnthropicProviderTypes() {
+        val kimi = buildKimiCodeModelEnvironment(
+            provider = AgentProviderCredentials(
+                baseUrl = "https://api.moonshot.cn",
+                apiKey = "secret",
+            ),
+            model = "kimi-k2.6",
+        )
+        assertEquals("kimi", kimi["KIMI_MODEL_PROVIDER_TYPE"])
+        assertEquals("https://api.moonshot.cn/v1", kimi["KIMI_MODEL_BASE_URL"])
+
+        val anthropic = buildKimiCodeModelEnvironment(
+            provider = AgentProviderCredentials(
+                baseUrl = "https://provider.example/v1",
+                apiKey = "secret",
+                protocolType = "anthropic",
+            ),
+            model = "claude-sonnet",
+        )
+        assertEquals("anthropic", anthropic["KIMI_MODEL_PROVIDER_TYPE"])
+        assertEquals("https://provider.example/v1", anthropic["KIMI_MODEL_BASE_URL"])
+    }
+
+    @Test
+    fun deepSeekWebEnvironmentDoesNotReuseTheHeadlessAcpHome() {
+        val environment = buildDeepSeekHarnessWebEnvironment(
+            provider = provider,
+            model = "GLM-5.1",
+        )
+
+        assertEquals("https://llmapi.paratera.com/v1", environment["DEEPSEEK_BASE_URL"])
+        assertEquals("secret", environment["DEEPSEEK_API_KEY"])
+        assertEquals("GLM-5.1", environment["DSH_MODEL"])
+        assertEquals("/root/.dsh/omnibot-web", environment["DSH_HOME"])
+        assertEquals("/root/.dsh/omnibot-web/sessions", environment["DSH_SESSION_ROOT"])
+        assertTrue(!environment.containsKey("DSH_ACP_HOME"))
+    }
+
+    @Test
     fun providerMappingUsesHarnessCapabilityInsteadOfAdapterObjectIdentity() {
         val decoratedCodex = object : AcpHarnessAdapter by AcpHarnessAdapters.codex {}
         val mapping = AgentConfigAdapterRegistry.map(

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdaptersTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdaptersTest.kt
@@ -136,8 +136,90 @@ class AgentConfigAdaptersTest {
         assertEquals("https://llmapi.paratera.com/v1", mapping.environment["KIMI_MODEL_BASE_URL"])
         assertEquals("openai", mapping.environment["KIMI_MODEL_PROVIDER_TYPE"])
         assertEquals("/root/.kimi-code/omnibot", mapping.environment["KIMI_CODE_HOME"])
+        assertEquals("image_in,thinking", mapping.environment["KIMI_MODEL_CAPABILITIES"])
         assertEquals("X-Trace: request-1", mapping.environment["KIMI_CODE_CUSTOM_HEADERS"])
         assertEquals("1", mapping.environment["KIMI_CODE_NO_AUTO_UPDATE"])
+        assertEquals(null, mapping.launchConfigPath)
+    }
+
+    @Test
+    fun kimiCodePublishesExplicitEffortForCustomOpenAiProvidersThroughConfig() {
+        val input = AgentProviderMappingInput(
+            agentId = AcpAgentProfileStore.KIMI_CODE_AGENT_ID,
+            provider = provider,
+            model = "GLM-5.1",
+            reasoningEffort = "high",
+            harnessAdapter = AcpHarnessAdapters.kimiCode,
+        )
+        val mapping = AgentConfigAdapterRegistry.map(input)
+        assertEquals(KIMI_CODE_CONFIG_PATH, mapping.launchConfigPath)
+        val writes = AgentConfigAdapterRegistry.launchConfigWrites(
+            input = input,
+            mapping = mapping,
+            providerModels = emptyList(),
+            existingConfig = "[permissions]\nmode = \"manual\"\n",
+        )
+
+        assertEquals(1, writes.size)
+        assertEquals(KIMI_CODE_CONFIG_PATH, writes.single().path)
+        assertTrue(writes.single().content.contains("[permissions]"))
+        assertTrue(writes.single().content.contains("enabled = true"))
+        assertTrue(writes.single().content.contains("effort = \"high\""))
+        // Kimi's forced-effort environment override is not valid for the
+        // generic OpenAI provider and must not be emitted accidentally.
+        assertTrue(!mapping.environment.containsKey("KIMI_MODEL_THINKING_EFFORT"))
+    }
+
+    @Test
+    fun kimiCodeUsesForcedEffortOnlyForTheNativeKimiProvider() {
+        val environment = buildKimiCodeModelEnvironment(
+            provider = AgentProviderCredentials(
+                baseUrl = "https://api.moonshot.cn/v1",
+                apiKey = "secret",
+            ),
+            model = "kimi-k2.6",
+            reasoningEffort = "xhigh",
+        )
+
+        assertEquals("xhigh", environment["KIMI_MODEL_THINKING_EFFORT"])
+    }
+
+    @Test
+    fun kimiCodeThinkingConfigCanTurnThinkingOffWithoutDroppingOtherSettings() {
+        val config = buildKimiCodeThinkingConfigToml(
+            existingConfig = """
+                [thinking]
+                enabled = true
+                effort = "high"
+                keep = "all"
+
+                [permissions]
+                mode = "manual"
+            """.trimIndent(),
+            reasoningEffort = "none",
+        )
+
+        assertTrue(config.contains("enabled = false"))
+        assertTrue(!config.contains("effort = \"high\""))
+        assertTrue(config.contains("keep = \"all\""))
+        assertTrue(config.contains("[permissions]"))
+    }
+
+    @Test
+    fun kimiCodeThinkingConfigStopsBeforeArrayTables() {
+        val config = buildKimiCodeThinkingConfigToml(
+            existingConfig = """
+                [thinking]
+                enabled = true
+
+                [[hooks]]
+                event = "PreToolUse"
+            """.trimIndent(),
+            reasoningEffort = "medium",
+        )
+
+        assertTrue(config.indexOf("effort = \"medium\"") < config.indexOf("[[hooks]]"))
+        assertTrue(config.contains("event = \"PreToolUse\""))
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeProtocolPayloadTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeProtocolPayloadTest.kt
@@ -459,7 +459,7 @@ class AgentRuntimeProtocolPayloadTest {
     @Test
     fun managedAcpCatalogIncludesSupportedAgentsWithoutGemini() {
         assertEquals(
-            listOf("小万", "Codex", "Claude Code", "OpenCode", "DeepSeek Harness"),
+            listOf("小万", "Codex", "Claude Code", "OpenCode", "Kimi Code", "DeepSeek Harness"),
             AcpAgentProfileStore.OFFICIAL_AGENTS.map { it.name }
         )
         assertTrue(AcpAgentProfileStore.OFFICIAL_AGENTS.all { it.builtIn })
@@ -813,6 +813,22 @@ class AgentRuntimeProtocolPayloadTest {
             managedAgentTerminalPackageId(AcpAgentProfileStore.OFFICIAL_AGENTS.first {
                 it.id == AcpAgentProfileStore.XIAOWAN_AGENT_ID
             })
+        )
+    }
+
+    @Test
+    fun kimiCodeIsRegisteredAsAnOfficialSharedProviderAgent() {
+        val profile = AcpAgentProfileStore.OFFICIAL_AGENTS.first {
+            it.id == AcpAgentProfileStore.KIMI_CODE_AGENT_ID
+        }
+
+        assertEquals("kimi", profile.command)
+        assertEquals(listOf("acp"), profile.arguments)
+        assertEquals("kimi", managedAgentTerminalPackageId(profile))
+        assertTrue(AcpAgentProfileStore.usesSharedProvider(profile))
+        assertEquals(
+            AcpHarnessProviderConfigKind.KIMI_CODE,
+            AcpHarnessAdapters.forProfile(profile).providerConfigKind,
         )
     }
 

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentWebLauncherTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentWebLauncherTest.kt
@@ -1,0 +1,75 @@
+package cn.com.omnimind.bot.agent.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AgentWebLauncherTest {
+    @Test
+    fun webServicesUseDedicatedCommandsAndSessions() {
+        assertEquals(
+            AgentWebService.KIMI,
+            AgentWebService.forAgentId(AcpAgentProfileStore.KIMI_CODE_AGENT_ID),
+        )
+        assertEquals("kimi", AgentWebService.KIMI.commandName)
+        assertEquals("kimi web --no-open", AgentWebService.KIMI.command)
+        assertEquals("omnibot-web-kimi", AgentWebService.KIMI.sessionId)
+
+        assertEquals(
+            AgentWebService.DEEPSEEK_HARNESS,
+            AgentWebService.forAgentId(AcpAgentProfileStore.DEEPSEEK_HARNESS_AGENT_ID),
+        )
+        assertEquals("dsh", AgentWebService.DEEPSEEK_HARNESS.commandName)
+        assertEquals("dsh web --no-open", AgentWebService.DEEPSEEK_HARNESS.command)
+        assertEquals("omnibot-web-dsh", AgentWebService.DEEPSEEK_HARNESS.sessionId)
+        assertNull(AgentWebService.forAgentId("codex-acp"))
+    }
+
+    @Test
+    fun kimiParserKeepsOnlyLoopbackTokenUrlAndStripsAnsi() {
+        val url = AgentWebUrlParser.find(
+            kind = AgentWebUrlKind.KIMI,
+            transcript = "\u001B[32mready\u001B[0m http://127.0.0.1:58627/#token=abc_DEF-123\n",
+        )
+
+        assertEquals("http://127.0.0.1:58627/#token=abc_DEF-123", url)
+        assertNull(
+            AgentWebUrlParser.find(
+                kind = AgentWebUrlKind.KIMI,
+                transcript = "https://example.com:58627/#token=abc",
+            ),
+        )
+    }
+
+    @Test
+    fun deepSeekParserAcceptsOnlyLoopbackOrigin() {
+        assertEquals(
+            "http://localhost:3080",
+            AgentWebUrlParser.find(
+                kind = AgentWebUrlKind.DEEPSEEK_HARNESS,
+                transcript = "dsh web: http://localhost:3080\n",
+            ),
+        )
+        assertNull(
+            AgentWebUrlParser.find(
+                kind = AgentWebUrlKind.DEEPSEEK_HARNESS,
+                transcript = "http://192.168.1.20:3080",
+            ),
+        )
+    }
+
+    @Test
+    fun launchPayloadDoesNotExposeTheBrowserUrl() {
+        val payload = AgentWebLaunchResult(
+            ok = true,
+            code = "OPENED",
+            packageId = "kimi",
+        ).toPayload()
+
+        assertTrue(payload["ok"] == true)
+        assertFalse(payload.containsKey("url"))
+        assertFalse(payload.containsValue("#token=secret"))
+    }
+}

--- a/app/src/test/java/com/ai/assistance/operit/terminal/setup/EnvironmentSetupLogicTest.kt
+++ b/app/src/test/java/com/ai/assistance/operit/terminal/setup/EnvironmentSetupLogicTest.kt
@@ -108,6 +108,34 @@ class EnvironmentSetupLogicTest {
     }
 
     @Test
+    fun buildInstallCommands_installsKimiCodeInManagedNpmPath() {
+        val commands = EnvironmentSetupLogic.buildInstallCommands(
+            selectedPackageIds = listOf("kimi"),
+            repositorySetupCommand = "",
+        )
+
+        val apkAdd = commands.first { it.contains("omnibot_apk_add") }
+        assertTrue(apkAdd.contains("nodejs"))
+        assertTrue(apkAdd.contains("npm"))
+        assertTrue(commands.any { it.contains("@moonshot-ai/kimi-code@latest") })
+        assertTrue(commands.any { it.contains("registry.npmmirror.com") })
+        assertTrue(
+            commands.contains(
+                "ln -sf /root/.npm-global/bin/kimi /usr/local/bin/kimi || true",
+            ),
+        )
+    }
+
+    @Test
+    fun buildInventoryProbeCommand_requiresSupportedKimiNodeVersion() {
+        val command = EnvironmentSetupLogic.buildInventoryProbeCommand(listOf("kimi"))
+
+        assertTrue(command.contains("command -v kimi"))
+        assertTrue(command.contains("major === 22 && minor < 19"))
+        assertTrue(command.contains("kimi --version"))
+    }
+
+    @Test
     fun buildInstallCommands_installsClaudeCodeAndOpenCodeInManagedNpmPath() {
         val commands = EnvironmentSetupLogic.buildInstallCommands(
             selectedPackageIds = listOf("claude_code", "opencode"),

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 05 19:05:46 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/lib/features/home/pages/agent/agent_mode_setting_page.dart
+++ b/ui/lib/features/home/pages/agent/agent_mode_setting_page.dart
@@ -179,6 +179,17 @@ class _AgentModeSettingPageState extends State<AgentModeSettingPage> {
         managedAdapter: true,
       ),
       AcpAgentProfile(
+        id: 'kimi-code-acp',
+        name: 'Kimi Code',
+        command: 'kimi',
+        description: 'Kimi Code official ACP profile',
+        arguments: <String>['acp'],
+        builtIn: true,
+        source: 'official',
+        status: 'unchecked',
+        managedAdapter: true,
+      ),
+      AcpAgentProfile(
         id: 'deepseek-harness-acp',
         name: 'DeepSeek Harness',
         // Keep the fallback catalog identical to the native official
@@ -362,6 +373,64 @@ class _AgentModeSettingPageState extends State<AgentModeSettingPage> {
     );
     if (changed == true && mounted) {
       await _load();
+    }
+  }
+
+  bool _supportsWeb(String agentId) {
+    return agentId == 'kimi-code-acp' || agentId == 'deepseek-harness-acp';
+  }
+
+  String _webPackageId(String agentId) {
+    return agentId == 'kimi-code-acp' ? 'kimi' : 'deepseek_harness';
+  }
+
+  Future<void> _launchWeb(AcpAgentProfile agent) async {
+    try {
+      final response = await AgentRuntimeService.launchAgentWeb(agent.id);
+      if (!mounted) return;
+      final code = response['code']?.toString().trim() ?? '';
+      switch (code) {
+        case 'OPENED':
+          showToast(_text('${agent.name} Web 已打开', '${agent.name} Web opened'));
+          return;
+        case 'RUNTIME_MISSING':
+          GoRouterManager.push(
+            '/home/termux_setting?focus=${Uri.encodeComponent(_webPackageId(agent.id))}',
+          );
+          return;
+        case 'PROVIDER_REQUIRED':
+          showToast(
+            _text(
+              '请先配置统一 Dispatch Provider',
+              'Configure the shared Dispatch Provider first',
+            ),
+            type: ToastType.warning,
+          );
+          return;
+        case 'MODEL_REQUIRED':
+          showToast(
+            _text('请先选择统一 Dispatch 模型', 'Select a shared Dispatch model first'),
+            type: ToastType.warning,
+          );
+          return;
+        default:
+          showToast(
+            _text(
+              '启动 ${agent.name} Web 失败',
+              'Failed to start ${agent.name} Web',
+            ),
+            type: ToastType.error,
+          );
+      }
+    } catch (error) {
+      if (!mounted) return;
+      showToast(
+        _text(
+          '启动 ${agent.name} Web 失败：$error',
+          'Failed to start ${agent.name} Web: $error',
+        ),
+        type: ToastType.error,
+      );
     }
   }
 
@@ -671,6 +740,7 @@ class _AgentModeSettingPageState extends State<AgentModeSettingPage> {
     final installEntry = agent.managedAdapter && agent.status != 'online';
     final action = needsManagedPreparation ? _prepare : _test;
     final capabilitySubtitle = _capabilitySubtitle(agent);
+    final supportsWeb = agent.builtIn && _supportsWeb(agent.id);
     return _FlatTile(
       tileKey: Key('agent-config-${agent.id}'),
       leading: AgentBrandIcon(
@@ -696,6 +766,9 @@ class _AgentModeSettingPageState extends State<AgentModeSettingPage> {
       actionLabel: canTest ? testLabel : null,
       actionKey: Key('agent-check-${agent.id}'),
       onAction: canTest ? () => action(agent) : null,
+      secondaryActionLabel: supportsWeb ? _text('打开 Web', 'Open Web') : null,
+      secondaryActionKey: supportsWeb ? Key('agent-web-${agent.id}') : null,
+      onSecondaryAction: supportsWeb && !busy ? () => _launchWeb(agent) : null,
       navigationLabel: installEntry
           ? _text('安装', 'Install')
           : _text('配置', 'Configure'),
@@ -865,6 +938,9 @@ class _FlatTile extends StatelessWidget {
     this.actionLabel,
     this.actionKey,
     this.onAction,
+    this.secondaryActionLabel,
+    this.secondaryActionKey,
+    this.onSecondaryAction,
     this.navigationLabel,
     this.navigationKey,
     this.busy = false,
@@ -882,6 +958,9 @@ class _FlatTile extends StatelessWidget {
   final String? actionLabel;
   final Key? actionKey;
   final VoidCallback? onAction;
+  final String? secondaryActionLabel;
+  final Key? secondaryActionKey;
+  final VoidCallback? onSecondaryAction;
   final String? navigationLabel;
   final Key? navigationKey;
   final bool busy;
@@ -1024,6 +1103,35 @@ class _FlatTile extends StatelessWidget {
                           constraints: const BoxConstraints(maxWidth: 150),
                           child: Text(
                             actionLabel!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: palette.accentPrimary,
+                              fontFamily: 'PingFang SC',
+                            ),
+                          ),
+                        ),
+                      ),
+                    if (secondaryActionLabel != null &&
+                        onSecondaryAction != null)
+                      TextButton(
+                        key: secondaryActionKey,
+                        onPressed: onSecondaryAction,
+                        style: TextButton.styleFrom(
+                          minimumSize: Size.zero,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 4,
+                            vertical: 3,
+                          ),
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          visualDensity: VisualDensity.compact,
+                        ),
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 150),
+                          child: Text(
+                            secondaryActionLabel!,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -2087,6 +2087,8 @@ abstract class _ChatPageStateBase extends State<ChatPage>
 
   void _showSnackBar(String message);
 
+  Future<void> _launchAgentWeb(String agentId);
+
   Future<bool> _ensureNormalChatModelConfigurationForSend();
 
   Future<void> _startManualRecordingCommand(String messageText);

--- a/ui/lib/features/home/pages/chat/chat_page.dart
+++ b/ui/lib/features/home/pages/chat/chat_page.dart
@@ -2087,7 +2087,7 @@ abstract class _ChatPageStateBase extends State<ChatPage>
 
   void _showSnackBar(String message);
 
-  Future<void> _launchAgentWeb(String agentId);
+  Future<void> _launchAgentWeb(String agentId, {String? reasoningEffort});
 
   Future<bool> _ensureNormalChatModelConfigurationForSend();
 

--- a/ui/lib/features/home/pages/chat/chat_page_agent.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_agent.dart
@@ -1187,25 +1187,41 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
   @override
   Future<void> _selectAgentReasoningEffort(String effort) async {
     final normalized = _normalizeAgentReasoningEffort(effort);
-    if (normalized == null ||
-        !_agentReasoningEffortOptions.contains(normalized)) {
+    final isBuiltInXiaowan =
+        _activeAcpAgentId == _kXiaowanAcpAgentId ||
+        _agentRuntimeStatus.activeAgentId == _kXiaowanAcpAgentId;
+    final advertisedOptions = _agentReasoningEffortOptions.isNotEmpty
+        ? _agentReasoningEffortOptions
+        : (isBuiltInXiaowan ? _kAgentReasoningEffortOptions : const <String>[]);
+    final normalizedOptions = advertisedOptions
+        .map(_normalizeAgentReasoningEffort)
+        .whereType<String>()
+        .toSet();
+    if (normalized == null || !normalizedOptions.contains(normalized)) {
       return;
     }
-    try {
-      await _setAgentConfigOption(
-        configId: 'reasoning_effort',
-        value: normalized,
-      );
-    } catch (error) {
-      if (mounted) {
-        showToast(
-          LegacyTextLocalizer.isEnglish
-              ? 'Failed to change reasoning effort: $error'
-              : '修改思考强度失败：$error',
-          type: ToastType.error,
+    // Xiaowan receives the selected effort through the canonical ACP prompt
+    // metadata. It has no mutable Harness-side `reasoning_effort` option, so
+    // attempting session/set_config_option here would make a valid local
+    // selection look like a failed request. Other Harnesses can still apply
+    // their advertised ACP config option immediately.
+    if (!isBuiltInXiaowan) {
+      try {
+        await _setAgentConfigOption(
+          configId: 'reasoning_effort',
+          value: normalized,
         );
+      } catch (error) {
+        if (mounted) {
+          showToast(
+            LegacyTextLocalizer.isEnglish
+                ? 'Failed to change reasoning effort: $error'
+                : '修改思考强度失败：$error',
+            type: ToastType.error,
+          );
+        }
+        return;
       }
-      return;
     }
     if (!mounted) return;
     setState(() {
@@ -1365,6 +1381,19 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
     if (command.isEmpty) {
       return;
     }
+    if ((cardData['controlType'] ?? '').toString() == 'effortSlider') {
+      if (command.startsWith('/')) {
+        _messageController.value = const TextEditingValue(
+          text: '/effort ',
+          selection: TextSelection.collapsed(offset: 8),
+        );
+        _requestComposerFocus();
+        _handleSlashCommandInput();
+      } else {
+        await _selectAgentReasoningEffort(command);
+      }
+      return;
+    }
     if (cardData['acpCommand'] == true) {
       final value = command.endsWith(' ') ? command : '$command ';
       _messageController.value = TextEditingValue(
@@ -1430,6 +1459,14 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
         return true;
       case AgentSlashSubmitKind.selectModel:
         await _selectAgentModel(intent.value ?? '');
+        return true;
+      case AgentSlashSubmitKind.openReasoningEffortPicker:
+        _triggerSlashCommandPanel();
+        return true;
+      case AgentSlashSubmitKind.selectReasoningEffort:
+        await _selectAgentReasoningEffort(intent.value ?? '');
+        _messageController.clear();
+        _hideSlashCommandPanel();
         return true;
       case AgentSlashSubmitKind.startReview:
         _messageController.clear();

--- a/ui/lib/features/home/pages/chat/chat_page_agent.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_agent.dart
@@ -356,6 +356,46 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
     }
   }
 
+  @override
+  Future<void> _launchAgentWeb(String agentId) async {
+    final normalized = agentId.trim();
+    if (normalized.isEmpty) return;
+    try {
+      final response = await AgentRuntimeService.launchAgentWeb(normalized);
+      if (!mounted) return;
+      final code = response['code']?.toString().trim() ?? '';
+      final packageId = response['packageId']?.toString().trim() ?? '';
+      final displayName = normalized == 'kimi-code-acp'
+          ? 'Kimi Web'
+          : 'DSH Web';
+      switch (code) {
+        case 'OPENED':
+          _showSnackBar('$displayName 已打开');
+          return;
+        case 'RUNTIME_MISSING':
+          if (packageId.isNotEmpty) {
+            GoRouterManager.push(
+              '/home/termux_setting?focus=${Uri.encodeComponent(packageId)}',
+            );
+          }
+          return;
+        case 'PROVIDER_REQUIRED':
+          _showSnackBar('请先配置统一 Dispatch Provider');
+          GoRouterManager.push('/home/agent_mode_setting');
+          return;
+        case 'MODEL_REQUIRED':
+          _showSnackBar('请先选择统一 Dispatch 模型');
+          GoRouterManager.push('/home/agent_mode_setting');
+          return;
+        default:
+          _showSnackBar('$displayName 启动失败');
+      }
+    } catch (error) {
+      if (!mounted) return;
+      _showSnackBar('$agentId Web 启动失败：$error');
+    }
+  }
+
   /// A local ACP adapter is only an execution harness. Its Provider and model
   /// come from the shared Agent scene binding. Check that binding before
   /// stopping the currently visible harness; otherwise a missing Provider

--- a/ui/lib/features/home/pages/chat/chat_page_agent.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_agent.dart
@@ -138,6 +138,17 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
     return modelIds;
   }
 
+  ProviderModelOption? _findSharedProviderModelOption(String modelId) {
+    final providerProfileId = _activeDispatchSceneSelection?.providerProfileId;
+    if (providerProfileId == null || providerProfileId.trim().isEmpty) {
+      return null;
+    }
+    return (_modelOptionsByProfileId[providerProfileId] ??
+            const <ProviderModelOption>[])
+        .where((item) => item.id.trim().toLowerCase() == modelId.toLowerCase())
+        .firstOrNull;
+  }
+
   @override
   Future<void> _refreshAgentRuntimeStatus() async {
     if (!mounted || _isAgentRuntimeStatusLoading) return;
@@ -357,11 +368,17 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
   }
 
   @override
-  Future<void> _launchAgentWeb(String agentId) async {
+  Future<void> _launchAgentWeb(
+    String agentId, {
+    String? reasoningEffort,
+  }) async {
     final normalized = agentId.trim();
     if (normalized.isEmpty) return;
     try {
-      final response = await AgentRuntimeService.launchAgentWeb(normalized);
+      final response = await AgentRuntimeService.launchAgentWeb(
+        normalized,
+        effort: reasoningEffort ?? _activeAgentReasoningEffort,
+      );
       if (!mounted) return;
       final code = response['code']?.toString().trim() ?? '';
       final packageId = response['packageId']?.toString().trim() ?? '';
@@ -814,6 +831,9 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
               )
           ? activeModel
           : preferredModel;
+      final sharedProviderModel = sharedAgent && effectiveModel != null
+          ? _findSharedProviderModelOption(effectiveModel)
+          : null;
       final modelOptions = modelConfigSupported
           ? _mergeAgentOptionIds(
               current: effectiveModel,
@@ -825,7 +845,23 @@ mixin _ChatPageAgentMixin on _ChatPageStateBase {
         response,
         effectiveModel,
       );
-      final serverEffort = configSettings.reasoningEffort ?? modelDefaultEffort;
+      // The shared Provider catalog already tells us whether this model is a
+      // reasoning model, but its OpenAI-compatible /models response usually
+      // has no effort list. Kimi Code would otherwise resolve this to the
+      // boolean `on` value and omit `reasoning_effort` on the wire. Use the
+      // interoperable medium level as the default only for catalog-confirmed
+      // reasoning models; users can still choose another advertised effort.
+      final isKimiCodeAgent =
+          _activeAcpAgentId == 'kimi-code-acp' ||
+          _agentRuntimeStatus.activeAgentId == 'kimi-code-acp';
+      final sharedProviderDefaultEffort =
+          isKimiCodeAgent && sharedProviderModel?.reasoning == true
+          ? 'medium'
+          : null;
+      final serverEffort =
+          configSettings.reasoningEffort ??
+          modelDefaultEffort ??
+          sharedProviderDefaultEffort;
       final storedPermissionMode = _parseAgentPermissionMode(
         _readAgentPreference(
           _kAgentPermissionModePreferenceKey,

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -1747,6 +1747,14 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                               ),
                               onThreadTargetSelected:
                                   _handleEmbeddedDrawerThreadTargetSelected,
+                              onLaunchKimiWeb: () {
+                                unawaited(_launchAgentWeb('kimi-code-acp'));
+                              },
+                              onLaunchDeepSeekWeb: () {
+                                unawaited(
+                                  _launchAgentWeb('deepseek-harness-acp'),
+                                );
+                              },
                             ),
                           ),
                         ),
@@ -2018,6 +2026,12 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
                         onSearchFocusChanged:
                             _handleHomeDrawerSearchFocusChanged,
                         searchFieldKey: _drawerSearchFieldKey,
+                        onLaunchKimiWeb: () {
+                          unawaited(_launchAgentWeb('kimi-code-acp'));
+                        },
+                        onLaunchDeepSeekWeb: () {
+                          unawaited(_launchAgentWeb('deepseek-harness-acp'));
+                        },
                       ),
                 onDrawerChanged: isHdPadLandscape
                     ? null

--- a/ui/lib/features/home/pages/chat/chat_page_ui.dart
+++ b/ui/lib/features/home/pages/chat/chat_page_ui.dart
@@ -279,6 +279,18 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
     if (route == _SlashCommandPanelRoute.agentModel) {
       return _buildAgentModelCards();
     }
+    if (route == _SlashCommandPanelRoute.effort) {
+      final query = _slashCommandRouteQuery(route).toLowerCase();
+      final card = _buildAgentReasoningEffortCommandCard();
+      final options =
+          (card['effortOptions'] as List<dynamic>? ?? const <dynamic>[]).map(
+            (option) => option.toString().toLowerCase(),
+          );
+      if (query.isEmpty || options.any((option) => option.startsWith(query))) {
+        return <Map<String, dynamic>>[card];
+      }
+      return const <Map<String, dynamic>>[];
+    }
     return _buildAgentRootCommandCards();
   }
 
@@ -373,6 +385,17 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
         toggleValue: planModeEnabled,
       ),
     ];
+    // Xiaowan's original /effort control belongs to the Agent conversation
+    // now, but it must remain visible when the built-in ACP profile is active.
+    // External Harnesses advertise their own effort options; only show this
+    // card for them after those options have been negotiated.
+    final showAgentReasoningEffort =
+        _activeAcpAgentId == _kXiaowanAcpAgentId ||
+        _agentRuntimeStatus.activeAgentId == _kXiaowanAcpAgentId ||
+        _agentReasoningEffortOptions.isNotEmpty;
+    if (showAgentReasoningEffort) {
+      commands.insert(1, _buildAgentReasoningEffortCommandCard());
+    }
     commands.addAll(_buildAgentAcpCommandCards());
     if (query.isEmpty) {
       return commands;
@@ -385,11 +408,40 @@ mixin _ChatPageUiMixin on _ChatPageStateBase {
         .toList(growable: false);
   }
 
+  Map<String, dynamic> _buildAgentReasoningEffortCommandCard() {
+    final options = _agentReasoningEffortOptions.isNotEmpty
+        ? _agentReasoningEffortOptions
+        : _kAgentReasoningEffortOptions;
+    final activeEffort = _activeAgentReasoningEffort;
+    final selectedEffort = activeEffort == 'none' && options.contains('no')
+        ? 'no'
+        : activeEffort;
+    return <String, dynamic>{
+      'cardId': 'slash-command-agent-effort',
+      'toolName': '/effort',
+      'toolTitle': '/effort',
+      'displayName': '/effort',
+      'toolType': 'command',
+      'toolTypeLabel': LegacyTextLocalizer.isEnglish ? 'Thinking' : '思考',
+      'status': activeEffort == null ? 'running' : 'success',
+      'statusLabel':
+          activeEffort ?? (LegacyTextLocalizer.isEnglish ? 'Default' : '默认'),
+      'summary': LegacyTextLocalizer.isEnglish
+          ? 'Choose the thinking effort for the active Agent'
+          : '设置当前 Agent 的思考强度',
+      'progress': '',
+      'controlType': 'effortSlider',
+      'effortOptions': options,
+      if (selectedEffort != null && options.contains(selectedEffort))
+        'selectedEffort': selectedEffort,
+    };
+  }
+
   List<Map<String, dynamic>> _buildAgentAcpCommandCards() {
     final runtime = _runtimeForMode(ChatPageMode.agent);
     final commands =
         runtime?.availableAcpCommands ?? const <Map<String, dynamic>>[];
-    final seen = <String>{'/model', '/review', '/init', '/plan'};
+    final seen = <String>{'/model', '/review', '/init', '/plan', '/effort'};
     return commands
         .map((command) {
           final name = (command['name'] ?? '').toString().trim();

--- a/ui/lib/features/home/pages/chat/utils/agent_slash_commands.dart
+++ b/ui/lib/features/home/pages/chat/utils/agent_slash_commands.dart
@@ -2,6 +2,8 @@ enum AgentSlashSubmitKind {
   none,
   openModelPicker,
   selectModel,
+  openReasoningEffortPicker,
+  selectReasoningEffort,
   startReview,
   startInit,
   togglePlan,
@@ -34,6 +36,24 @@ AgentSlashSubmitIntent resolveAgentSlashSubmitIntent(String messageText) {
     return AgentSlashSubmitIntent(
       AgentSlashSubmitKind.selectModel,
       value: modelId,
+    );
+  }
+
+  if (normalized == '/effort') {
+    return const AgentSlashSubmitIntent(
+      AgentSlashSubmitKind.openReasoningEffortPicker,
+    );
+  }
+  if (normalized.startsWith('/effort ')) {
+    final effort = trimmed.substring('/effort'.length).trim();
+    if (effort.isEmpty) {
+      return const AgentSlashSubmitIntent(
+        AgentSlashSubmitKind.openReasoningEffortPicker,
+      );
+    }
+    return AgentSlashSubmitIntent(
+      AgentSlashSubmitKind.selectReasoningEffort,
+      value: effort,
     );
   }
 

--- a/ui/lib/features/home/pages/termux_setting/termux_setting_page.dart
+++ b/ui/lib/features/home/pages/termux_setting/termux_setting_page.dart
@@ -103,6 +103,12 @@ const List<_EnvironmentDefinition> _environmentDefinitions =
         groupKey: 'alpineAiAgent',
       ),
       _EnvironmentDefinition(
+        id: 'kimi',
+        title: 'Kimi Code',
+        descriptionKey: 'alpineKimiCode',
+        groupKey: 'alpineAiAgent',
+      ),
+      _EnvironmentDefinition(
         id: 'ssh_client',
         title: 'ssh',
         descriptionKey: 'alpineSshClient',
@@ -253,6 +259,8 @@ class _TermuxSettingPageState extends State<TermuxSettingPage>
         return l10n.alpineOpenCode;
       case 'alpineDeepSeekHarness':
         return l10n.alpineDeepSeekHarness;
+      case 'alpineKimiCode':
+        return l10n.alpineKimiCode;
       case 'alpineSshClient':
         return l10n.alpineSshClient;
       case 'alpineSshpass':

--- a/ui/lib/features/home/widgets/home_drawer.dart
+++ b/ui/lib/features/home/widgets/home_drawer.dart
@@ -103,6 +103,8 @@ class HomeDrawer extends ConsumerStatefulWidget {
     this.onThreadTargetSelected,
     this.onSearchFocusChanged,
     this.searchFieldKey,
+    this.onLaunchKimiWeb,
+    this.onLaunchDeepSeekWeb,
   });
 
   final int? memoryCount;
@@ -112,6 +114,8 @@ class HomeDrawer extends ConsumerStatefulWidget {
   final ValueChanged<ConversationThreadTarget>? onThreadTargetSelected;
   final ValueChanged<bool>? onSearchFocusChanged;
   final GlobalKey? searchFieldKey;
+  final VoidCallback? onLaunchKimiWeb;
+  final VoidCallback? onLaunchDeepSeekWeb;
 
   @override
   ConsumerState<HomeDrawer> createState() => HomeDrawerState();
@@ -267,6 +271,9 @@ class HomeDrawerState extends ConsumerState<HomeDrawer> {
           children: [
             const SizedBox(height: 16),
             Expanded(child: _buildConversationSection()),
+            if (widget.onLaunchKimiWeb != null ||
+                widget.onLaunchDeepSeekWeb != null)
+              _buildWebAgentShortcutBar(),
             _buildFooterShortcutBar(),
             // Aligns this row's bottom edge with the chat composer's bottom
             // edge (both sit this far above the shared SafeArea bottom).

--- a/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
+++ b/ui/lib/features/home/widgets/home_drawer_conversation_list.dart
@@ -1158,6 +1158,7 @@ extension _HomeDrawerConversationList on HomeDrawerState {
       'claude-code-acp' => 'Claude Code',
       'opencode-acp' => 'OpenCode',
       'deepseek-harness-acp' => 'DeepSeek',
+      'kimi-code-acp' => 'Kimi Code',
       _ => _humanizeAgentId(agentId),
     };
   }

--- a/ui/lib/features/home/widgets/home_drawer_header_footer.dart
+++ b/ui/lib/features/home/widgets/home_drawer_header_footer.dart
@@ -22,6 +22,76 @@ extension _HomeDrawerHeaderFooter on HomeDrawerState {
     return context.omniPalette.textSecondary;
   }
 
+  Widget _buildWebAgentShortcutBar() {
+    final items = <_DrawerWebShortcut>[
+      if (widget.onLaunchKimiWeb != null)
+        _DrawerWebShortcut(
+          label: 'Kimi Web',
+          agentId: 'kimi-code-acp',
+          onTap: widget.onLaunchKimiWeb!,
+        ),
+      if (widget.onLaunchDeepSeekWeb != null)
+        _DrawerWebShortcut(
+          label: 'DSH Web',
+          agentId: 'deepseek-harness-acp',
+          onTap: widget.onLaunchDeepSeekWeb!,
+        ),
+    ];
+    final surface = context.isDarkTheme
+        ? context.omniPalette.surfaceSecondary
+        : Colors.white;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+      child: Row(
+        children: [
+          for (int index = 0; index < items.length; index++) ...[
+            if (index > 0) const SizedBox(width: 8),
+            Expanded(
+              child: Material(
+                color: surface,
+                borderRadius: BorderRadius.circular(12),
+                child: InkWell(
+                  key: ValueKey('home-drawer-web-${items[index].agentId}'),
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: () {
+                    _maybeCloseDrawer();
+                    items[index].onTap();
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 9,
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        AgentBrandIcon(agentId: items[index].agentId, size: 18),
+                        const SizedBox(width: 7),
+                        Flexible(
+                          child: Text(
+                            items[index].label,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: _drawerTextColor,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              fontFamily: 'PingFang SC',
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   Widget _buildFooterShortcutBar() {
     final items = <_DrawerShortcutAction>[
       _DrawerShortcutAction(
@@ -120,4 +190,16 @@ extension _HomeDrawerHeaderFooter on HomeDrawerState {
       ),
     );
   }
+}
+
+class _DrawerWebShortcut {
+  const _DrawerWebShortcut({
+    required this.label,
+    required this.agentId,
+    required this.onTap,
+  });
+
+  final String label;
+  final String agentId;
+  final VoidCallback onTap;
 }

--- a/ui/lib/l10n/app_en.arb
+++ b/ui/lib/l10n/app_en.arb
@@ -504,6 +504,7 @@
   "alpineClaudeCode": "Anthropic Claude Code CLI for ACP Agents",
   "alpineOpenCode": "OpenCode CLI with built-in ACP support",
   "alpineDeepSeekHarness": "DeepSeek Harness (dsh) official ACP runtime",
+  "alpineKimiCode": "Kimi Code CLI for ACP and Web",
   "alpineSshClient": "SSH Client",
   "alpineSshpass": "SSH Password Helper",
   "alpineOpenSshServer": "OpenSSH Server",

--- a/ui/lib/l10n/app_zh.arb
+++ b/ui/lib/l10n/app_zh.arb
@@ -504,6 +504,7 @@
   "alpineClaudeCode": "Anthropic Claude Code CLI（供 ACP Agent 使用）",
   "alpineOpenCode": "OpenCode CLI（内置 ACP 支持）",
   "alpineDeepSeekHarness": "DeepSeek Harness（dsh）官方 ACP 运行组件",
+  "alpineKimiCode": "Kimi Code CLI（供 ACP 与 Web 使用）",
   "alpineSshClient": "SSH 客户端",
   "alpineSshpass": "SSH 密码辅助工具",
   "alpineOpenSshServer": "OpenSSH 服务器",

--- a/ui/lib/l10n/generated/app_localizations.dart
+++ b/ui/lib/l10n/generated/app_localizations.dart
@@ -2774,6 +2774,12 @@ abstract class AppLocalizations {
   /// **'DeepSeek Harness（dsh）官方 ACP 运行组件'**
   String get alpineDeepSeekHarness;
 
+  /// No description provided for @alpineKimiCode.
+  ///
+  /// In zh, this message translates to:
+  /// **'Kimi Code CLI（供 ACP 与 Web 使用）'**
+  String get alpineKimiCode;
+
   /// No description provided for @alpineSshClient.
   ///
   /// In zh, this message translates to:

--- a/ui/lib/l10n/generated/app_localizations_en.dart
+++ b/ui/lib/l10n/generated/app_localizations_en.dart
@@ -1545,6 +1545,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'DeepSeek Harness (dsh) official ACP runtime';
 
   @override
+  String get alpineKimiCode => 'Kimi Code CLI for ACP and Web';
+
+  @override
   String get alpineSshClient => 'SSH Client';
 
   @override

--- a/ui/lib/l10n/generated/app_localizations_zh.dart
+++ b/ui/lib/l10n/generated/app_localizations_zh.dart
@@ -1446,6 +1446,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get alpineDeepSeekHarness => 'DeepSeek Harness（dsh）官方 ACP 运行组件';
 
   @override
+  String get alpineKimiCode => 'Kimi Code CLI（供 ACP 与 Web 使用）';
+
+  @override
   String get alpineSshClient => 'SSH 客户端';
 
   @override

--- a/ui/lib/services/agent_runtime_service.dart
+++ b/ui/lib/services/agent_runtime_service.dart
@@ -844,8 +844,14 @@ class AgentRuntimeService {
     return _invokeMap('agent/prepare', {'agentId': agentId.trim()});
   }
 
-  static Future<Map<String, dynamic>> launchAgentWeb(String agentId) {
-    return _invokeMap('agent/web/launch', {'agentId': agentId.trim()});
+  static Future<Map<String, dynamic>> launchAgentWeb(
+    String agentId, {
+    String? effort,
+  }) {
+    return _invokeMap('agent/web/launch', {
+      'agentId': agentId.trim(),
+      if (effort != null && effort.trim().isNotEmpty) 'effort': effort.trim(),
+    });
   }
 
   static Future<Map<String, dynamic>> prepareAgentInBackground(String agentId) {

--- a/ui/lib/services/agent_runtime_service.dart
+++ b/ui/lib/services/agent_runtime_service.dart
@@ -844,6 +844,10 @@ class AgentRuntimeService {
     return _invokeMap('agent/prepare', {'agentId': agentId.trim()});
   }
 
+  static Future<Map<String, dynamic>> launchAgentWeb(String agentId) {
+    return _invokeMap('agent/web/launch', {'agentId': agentId.trim()});
+  }
+
   static Future<Map<String, dynamic>> prepareAgentInBackground(String agentId) {
     final normalizedId = agentId.trim();
     final existing = _agentPreparationTasks[normalizedId];

--- a/ui/lib/widgets/agent_brand_icon.dart
+++ b/ui/lib/widgets/agent_brand_icon.dart
@@ -6,7 +6,7 @@ import 'package:ui/widgets/agent_avatar.dart';
 
 /// ACP Agent 品牌图标。
 ///
-/// 已知的内置 Agent（Codex / Claude Code / OpenCode / DeepSeek Harness）渲染各自来自 Lobe Icons
+/// 已知的内置 Agent（Codex / Claude Code / OpenCode / DeepSeek Harness / Kimi Code）渲染各自来自 Lobe Icons
 /// (https://icons.lobehub.com) 的原始品牌 SVG。小万沿用可编辑的 AgentAvatarService，
 /// 让头像选择器同时影响 ACP 顶部、运行头和旧兼容卡片；未识别的自定义 Agent
 /// 回退到默认机器人图标 [Icons.smart_toy_outlined]。
@@ -47,6 +47,10 @@ class AgentBrandIcon extends StatelessWidget {
       'assets/provider_icons/deepseek.svg',
       brandColor: Color(0xFF4D6BFE),
     ),
+    'kimi-code-acp': _AgentBrand(
+      'assets/provider_icons/moonshot.svg',
+      brandColor: Color(0xFF4A90E2),
+    ),
   };
 
   /// Keep persisted/remote aliases on the same visual identity. An empty id
@@ -65,6 +69,7 @@ class AgentBrandIcon extends StatelessWidget {
       'deepseek-harness' ||
       'deepseek_harness' ||
       'deepseek-harness-acp' => 'deepseek-harness-acp',
+      'kimi' || 'kimi-code' || 'kimi-code-acp' => 'kimi-code-acp',
       _ => normalized,
     };
   }

--- a/ui/test/features/home/pages/agent/agent_mode_setting_page_test.dart
+++ b/ui/test/features/home/pages/agent/agent_mode_setting_page_test.dart
@@ -93,6 +93,7 @@ void main() {
     expect(find.text('初始化检测'), findsNothing);
     expect(find.text('重新检测'), findsNWidgets(2));
     expect(find.text('安装官方 Harness'), findsOneWidget);
+    expect(find.text('打开 Web'), findsOneWidget);
     expect(find.text('配置'), findsNWidgets(3));
     expect(find.text('安装'), findsOneWidget);
     // 3 Agent 配置入口 + 1 安装入口 + 1 远程 PC Bridge 入口。

--- a/ui/test/features/home/pages/chat/utils/agent_slash_commands_test.dart
+++ b/ui/test/features/home/pages/chat/utils/agent_slash_commands_test.dart
@@ -41,13 +41,19 @@ void main() {
     );
   });
 
-  test('rejects agent-only slash commands in codex mode', () {
+  test('routes agent reasoning effort commands', () {
+    expect(
+      resolveAgentSlashSubmitIntent('/effort').kind,
+      AgentSlashSubmitKind.openReasoningEffortPicker,
+    );
+    final effortIntent = resolveAgentSlashSubmitIntent('/effort high');
+    expect(effortIntent.kind, AgentSlashSubmitKind.selectReasoningEffort);
+    expect(effortIntent.value, 'high');
+  });
+
+  test('rejects unsupported agent-only slash commands', () {
     expect(
       resolveAgentSlashSubmitIntent('/compact').kind,
-      AgentSlashSubmitKind.unsupported,
-    );
-    expect(
-      resolveAgentSlashSubmitIntent('/effort high').kind,
       AgentSlashSubmitKind.unsupported,
     );
     expect(

--- a/ui/test/features/home/widgets/home_drawer_test.dart
+++ b/ui/test/features/home/widgets/home_drawer_test.dart
@@ -154,6 +154,46 @@ void main() {
     expect(find.byTooltip('轨迹'), findsOneWidget);
   });
 
+  testWidgets('shows Kimi and DSH Web shortcuts when provided', (tester) async {
+    var kimiTaps = 0;
+    var deepSeekTaps = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DefaultAssetBundle(
+          bundle: _SvgTestAssetBundle(),
+          child: _buildProviderScope(
+            child: Scaffold(
+              body: SizedBox(
+                width: 360,
+                height: 720,
+                child: HomeDrawer(
+                  embedded: true,
+                  closeOnNavigate: false,
+                  onLaunchKimiWeb: () => kimiTaps += 1,
+                  onLaunchDeepSeekWeb: () => deepSeekTaps += 1,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final kimi = find.byKey(const ValueKey('home-drawer-web-kimi-code-acp'));
+    final deepSeek = find.byKey(
+      const ValueKey('home-drawer-web-deepseek-harness-acp'),
+    );
+    expect(kimi, findsOneWidget);
+    expect(deepSeek, findsOneWidget);
+
+    await tester.tap(kimi);
+    await tester.tap(deepSeek);
+    expect(kimiTaps, 1);
+    expect(deepSeekTaps, 1);
+  });
+
   testWidgets(
     'embedded mode creates new chat_only conversation when requested',
     (tester) async {

--- a/ui/test/services/agent_runtime_service_test.dart
+++ b/ui/test/services/agent_runtime_service_test.dart
@@ -63,6 +63,21 @@ void main() {
     expect(result['code'], 'OPENED');
   });
 
+  test('launchAgentWeb forwards the selected thinking effort', () async {
+    MethodCall? capturedCall;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      capturedCall = call;
+      return <String, dynamic>{'ok': true, 'code': 'OPENED'};
+    });
+
+    await AgentRuntimeService.launchAgentWeb('kimi-code-acp', effort: 'high');
+
+    expect(capturedCall?.arguments, {
+      'agentId': 'kimi-code-acp',
+      'effort': 'high',
+    });
+  });
+
   test('ensureSession reserves a session before a new prompt', () async {
     final calls = <MethodCall>[];
     messenger.setMockMethodCallHandler(channel, (call) async {

--- a/ui/test/services/agent_runtime_service_test.dart
+++ b/ui/test/services/agent_runtime_service_test.dart
@@ -45,6 +45,24 @@ void main() {
     expect(capturedCall?.arguments, {'agentId': 'xiaowan-acp'});
   });
 
+  test('launchAgentWeb uses the native Web surface boundary', () async {
+    MethodCall? capturedCall;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      capturedCall = call;
+      return <String, dynamic>{
+        'ok': true,
+        'code': 'OPENED',
+        'packageId': 'kimi',
+      };
+    });
+
+    final result = await AgentRuntimeService.launchAgentWeb('kimi-code-acp');
+
+    expect(capturedCall?.method, 'agent/web/launch');
+    expect(capturedCall?.arguments, {'agentId': 'kimi-code-acp'});
+    expect(result['code'], 'OPENED');
+  });
+
   test('ensureSession reserves a session before a new prompt', () async {
     final calls = <MethodCall>[];
     messenger.setMockMethodCallHandler(channel, (call) async {


### PR DESCRIPTION
## 变更摘要

为 Agent 模式接入 Kimi Code 与 Kimi/DSH Web UI。用户可以通过系统浏览器直接使用运行时自带的 Web 界面，获得接近桌面端的完整 Agent 体验，包括会话管理、工具调用、思考过程展示和交互反馈。

对于 Web 入口，OmniBot 不再依赖主体 TUI 到 Flutter UI 的转换链路，而是由 Web UI 自身负责渲染和交互。这样可以减少 ANSI 文本、终端布局、流式状态以及键盘交互转换带来的适配成本，避免 TUI 转换过程中出现显示错乱、状态丢失和交互异常等问题。

同时保留 OmniBot 对本地运行时、Provider 和模型配置的统一管理，Web UI 作为现有 TUI/ACP 入口的补充。

## 主要改动

- 新增 Kimi Code 官方 ACP Profile、运行时安装、健康检查及 Harness 适配。
- 增加 Kimi Web、DSH Web 后台启动流程。
- 通过系统浏览器打开对应的 Web UI。
- 为 Kimi Web 和 DSH Web 配置独立的运行目录与会话目录。
- 在 Agent 模式页和首页菜单增加 Web UI 快捷入口。
- 复用 OmniBot 当前配置的 Provider 和模型信息。
- 升级 Gradle Wrapper 至 8.14.4。

## 配置与兼容性

- 完善 Agent Provider、模型和思考强度配置向 ACP/Web 运行时的传递。
- 区分原生 Kimi 与自定义 OpenAI Provider 的思考配置方式。
- 补充 Agent 命令面板的思考强度选项、命令解析及持久化支持。
- 外部 ACP Harness 继续使用协商出的可用配置选项。
- 小万 Agent 不发送其不支持的动态配置请求。

## 验证情况

- [x] Android Agent 配置与 Web 启动定向单元测试通过
- [x] Flutter Agent 命令解析与运行时服务定向测试通过
- [x] `dart analyze lib/features/home/pages/chat/chat_page.dart`
- [x] `git diff --check`
- [x] 全量 Flutter Analyze 无新增编译错误
- [x] 已在 `RMX5200` 真机完成基础功能测试

当前真机验证主要覆盖基本使用流程，不代表功能已经完全健壮或覆盖所有场景。后续仍需补充更多设备、Provider、登录状态、异常流程及长时间运行测试，并持续迭代。

## 风险与回滚

- Web UI 需要本地安装对应的 Node/npm 运行时，并可能依赖网络下载。
- Kimi Code 运行时需要满足官方 Node.js 版本要求。
- Web 服务通过本地 loopback 地址运行，由系统浏览器打开。
- Web UI 是新增入口，不替换现有 TUI/ACP 使用方式。
- 新增的 Agent Profile、Web 会话目录与现有运行时隔离，不修改已有会话数据。
- 如需回滚，撤销本 PR 包含的三个提交即可。