### PR TITLE
fix(acp): 修复 Codex 图片输入能力

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdapters.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdapters.kt
@@ -272,7 +272,10 @@ private object CodexConfigAdapter : AgentConfigAdapter {
             ),
             AgentConfigWrite(
                 path = CODEX_MODEL_CATALOG_JSON_PATH,
-                content = buildCodexModelCatalogJson(providerModels),
+                content = buildCodexModelCatalogJson(
+                    providerModels = providerModels,
+                    provider = provider,
+                ),
                 executorKey = "codex-agent-config-write",
             ),
         )
@@ -450,7 +453,8 @@ internal fun resolveAcpLaunchModelForDispatch(
 }
 
 internal fun buildCodexModelCatalogJson(
-    providerModels: List<ProviderModelOption>
+    providerModels: List<ProviderModelOption>,
+    provider: AgentProviderCredentials? = null,
 ): String {
     val models = JsonArray()
     providerModels
@@ -469,12 +473,10 @@ internal fun buildCodexModelCatalogJson(
             // the shared gateway rejects. Keep the adapter's default explicit
             // and conservative; it does not change the Provider model ID.
             val reasoningLevels = listOf("medium")
-            val inputModalities = providerModel.inputModalities
-                .map { it.trim().lowercase() }
-                .filter { it in CODEX_SUPPORTED_INPUT_MODALITIES }
-                .distinct()
-                .toMutableList()
-            if ("text" !in inputModalities) inputModalities += "text"
+            val inputModalities = resolveCodexInputModalities(
+                providerModel = providerModel,
+                provider = provider,
+            )
 
             val model = JsonObject().apply {
                 addProperty("slug", modelId)
@@ -548,8 +550,57 @@ internal fun buildCodexModelCatalogJson(
         .toJson(JsonObject().apply { add("models", models) }) + "\n"
 }
 
+/**
+ * Resolve the image capability written to Codex's model catalog.
+ *
+ * An omitted `input_modalities` field means "unknown" in a Provider
+ * `/models` response. Writing `text` for that case is not neutral: Codex
+ * treats the catalog value as an explicit capability and rejects image input
+ * before the request reaches the upstream model. Keep explicit model
+ * metadata authoritative, then use the resolved Provider route capability,
+ * and finally preserve Codex's text-plus-image default for unknown routes.
+ */
+internal fun resolveCodexInputModalities(
+    providerModel: ProviderModelOption,
+    provider: AgentProviderCredentials? = null,
+): List<String> {
+    val declaredModalities = providerModel.inputModalities
+        .map { it.trim().lowercase() }
+        .filter { it in CODEX_SUPPORTED_INPUT_MODALITIES }
+        .distinct()
+    if (declaredModalities.isNotEmpty()) {
+        return declaredModalities.toMutableList().apply {
+            if ("text" !in this) add("text")
+        }
+    }
+
+    // Some compatible /models endpoints expose this as `attachment` or
+    // `vision` instead of an input modality list. Treat an explicit boolean
+    // as a model declaration, but do not let it override a modality list.
+    providerModel.attachment?.let { supportsImage ->
+        return if (supportsImage) {
+            CODEX_DEFAULT_INPUT_MODALITIES
+        } else {
+            listOf("text")
+        }
+    }
+
+    val routeSupportsImage = provider?.let {
+        DeepSeekProvider.requestCapabilities(
+            protocolType = it.protocolType,
+            apiBase = it.baseUrl,
+            model = providerModel.id,
+        ).supportsVisionInput
+    }
+    return when (routeSupportsImage) {
+        false -> listOf("text")
+        true, null -> CODEX_DEFAULT_INPUT_MODALITIES
+    }
+}
+
 private const val CODEX_DEFAULT_CONTEXT_WINDOW = 272000
 private val CODEX_SUPPORTED_INPUT_MODALITIES = setOf("text", "image", "audio")
+private val CODEX_DEFAULT_INPUT_MODALITIES = listOf("text", "image")
 private const val CODEX_PROVIDER_BASE_INSTRUCTIONS =
     "You are a coding agent. Follow the user's instructions, inspect the workspace, and make safe, precise changes."
 

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
@@ -1760,8 +1760,9 @@ class AgentRuntimeManager private constructor(
                     ?: throw IllegalArgumentException("Model ID is required.")
                 val apiKey = args.stringValue("apiKey")
                     ?: throw IllegalArgumentException("API Key is required.")
+                val providerProfile = currentAgentProviderProfile()
                 val providerModelResolution = resolveCurrentProviderModelIds(
-                    currentAgentProviderProfile()
+                    providerProfile
                 )
                 val providerModels = providerModelResolution
                     ?.takeIf { it.authoritative }
@@ -1780,11 +1781,20 @@ class AgentRuntimeManager private constructor(
                         wireApi = args.stringValue("wireApi") ?: OpenAiWireApi.RESPONSES,
                         modelCatalogPath = CODEX_MODEL_CATALOG_JSON_PATH,
                         envHttpHeaders = buildAcpHeaderBindings(
-                            currentAgentProviderProfile()?.customHeaders.orEmpty()
+                            providerProfile?.customHeaders.orEmpty()
                         ).envHttpHeaders,
                     ),
                     authJson = buildCodexAuthJson(apiKey),
-                    modelCatalogJson = buildCodexModelCatalogJson(providerModels)
+                    modelCatalogJson = buildCodexModelCatalogJson(
+                        providerModels = providerModels,
+                        provider = AgentProviderCredentials(
+                            baseUrl = baseUrl,
+                            apiKey = apiKey,
+                            wireApi = args.stringValue("wireApi") ?: OpenAiWireApi.RESPONSES,
+                            customHeaders = providerProfile?.customHeaders.orEmpty(),
+                            protocolType = providerProfile?.protocolType ?: "openai_compatible",
+                        ),
+                    )
                 )
             }
             CLAUDE_CODE_AGENT_ID -> {

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdaptersTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentConfigAdaptersTest.kt
@@ -1,5 +1,6 @@
 package cn.com.omnimind.bot.agent.runtime
 
+import cn.com.omnimind.baselib.llm.DeepSeekProvider
 import cn.com.omnimind.baselib.llm.ProviderModelOption
 import cn.com.omnimind.baselib.llm.OpenAiWireApi
 import com.google.gson.JsonParser
@@ -564,12 +565,71 @@ class AgentConfigAdaptersTest {
         assertTrue(model["base_instructions"].asString.isNotBlank())
         assertEquals("list", model["visibility"].asString)
         assertEquals(false, model["supports_parallel_tool_calls"].asBoolean)
+        assertEquals(
+            listOf("text", "image"),
+            model["input_modalities"].asJsonArray.map { it.asString },
+        )
         assertEquals("medium", model["default_reasoning_level"].asString)
         assertEquals(
             listOf("medium"),
             model["supported_reasoning_levels"].asJsonArray.map {
                 it.asJsonObject["effort"].asString
             },
+        )
+    }
+
+    @Test
+    fun codexCatalogUsesResolvedProviderVisionCapabilityWhenMetadataIsMissing() {
+        val catalog = JsonParser.parseString(
+            buildCodexModelCatalogJson(
+                providerModels = listOf(
+                    ProviderModelOption(id = "deepseek-v4-pro"),
+                    ProviderModelOption(id = "deepseek-v4-flash-vision-exp"),
+                ),
+                provider = AgentProviderCredentials(
+                    baseUrl = DeepSeekProvider.OFFICIAL_BASE_URL,
+                    apiKey = "secret",
+                    protocolType = DeepSeekProvider.PROTOCOL_TYPE,
+                ),
+            ),
+        ).asJsonObject
+        val models = catalog.getAsJsonArray("models")
+            .associateBy { it.asJsonObject["slug"].asString }
+
+        assertEquals(
+            listOf("text"),
+            models.getValue("deepseek-v4-pro")
+                .asJsonObject["input_modalities"].asJsonArray.map { it.asString },
+        )
+        assertEquals(
+            listOf("text", "image"),
+            models.getValue("deepseek-v4-flash-vision-exp")
+                .asJsonObject["input_modalities"].asJsonArray.map { it.asString },
+        )
+    }
+
+    @Test
+    fun codexCatalogKeepsExplicitModalitiesAheadOfRouteFallback() {
+        val catalog = JsonParser.parseString(
+            buildCodexModelCatalogJson(
+                providerModels = listOf(
+                    ProviderModelOption(
+                        id = "deepseek-v4-flash-vision-exp",
+                        inputModalities = listOf("text"),
+                    ),
+                ),
+                provider = AgentProviderCredentials(
+                    baseUrl = DeepSeekProvider.OFFICIAL_BASE_URL,
+                    apiKey = "secret",
+                    protocolType = DeepSeekProvider.PROTOCOL_TYPE,
+                ),
+            ),
+        ).asJsonObject
+        val model = catalog.getAsJsonArray("models").single().asJsonObject
+
+        assertEquals(
+            listOf("text"),
+            model["input_modalities"].asJsonArray.map { it.asString },
         )
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Sep 05 19:05:46 CST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 背景

PR #515 先于堆叠 PR #516 合并到 `main`，因此 #516 的修复只进入了原 PR 的源分支。本 PR 将这两个修复提交正式补充到 `main`。

## 问题

Provider `/models` 未返回 `input_modalities` 时，Codex 模型目录会被写成仅支持 text，导致支持图片的模型在请求发出前被 Codex 判定为不支持图片输入。

## 修复

- 保留 Provider 显式声明的模型模态能力。
- 兼容 `attachment` / `vision` 能力标记。
- 复用 Provider 路由能力区分 DeepSeek 文本模型和视觉模型。
- 未知能力保持 Codex 默认的 text + image 输入能力。
- 同时覆盖启动配置和运行时配置写入路径。
- 将 Gradle Wrapper 升级至 8.14.4，满足当前 AGP 构建要求。

## 验证

- `:app:testDevelopStandardDebugUnitTest --tests cn.com.omnimind.bot.agent.runtime.AgentConfigAdaptersTest` 通过。
- `:app:assembleDevelopStandardDebug -Ptarget=lib/main_standard.dart` 通过。

关联：#515、#516。