### PR TITLE
fix(mcp): 修复 MCP 能力声明与历史协议兼容

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -399,6 +399,7 @@ dependencies {
     implementation(libs.ktor.server.call.logging)
     implementation(libs.mcp.kotlin.sdk.server)
     testImplementation(libs.junit)
+    testImplementation(libs.okhttp.mockwebserver)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest )
 }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/XiaowanAcpConnection.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/XiaowanAcpConnection.kt
@@ -36,10 +36,12 @@ import com.agentclientprotocol.common.Event
 import com.agentclientprotocol.common.SessionCreationParameters
 import com.agentclientprotocol.model.AgentCapabilities
 import com.agentclientprotocol.model.ContentBlock
+import com.agentclientprotocol.model.CloseSessionResponse
 import com.agentclientprotocol.model.DeleteSessionResponse
 import com.agentclientprotocol.model.EmbeddedResourceResource
 import com.agentclientprotocol.model.Implementation
 import com.agentclientprotocol.model.MessageId
+import com.agentclientprotocol.model.McpCapabilities
 import com.agentclientprotocol.model.ModelId
 import com.agentclientprotocol.model.ModelInfo
 import com.agentclientprotocol.model.PromptResponse
@@ -47,7 +49,6 @@ import com.agentclientprotocol.model.PromptCapabilities
 import com.agentclientprotocol.model.SessionCapabilities
 import com.agentclientprotocol.model.SessionCloseCapabilities
 import com.agentclientprotocol.model.SessionDeleteCapabilities
-import com.agentclientprotocol.model.SessionForkCapabilities
 import com.agentclientprotocol.model.SessionInfo
 import com.agentclientprotocol.model.SessionListCapabilities
 import com.agentclientprotocol.model.SessionResumeCapabilities
@@ -75,6 +76,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
@@ -92,6 +94,8 @@ import java.util.UUID
 import java.time.Instant
 import java.nio.charset.StandardCharsets
 import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -113,6 +117,7 @@ internal class XiaowanAcpConnection(
     private lateinit var serverTransport: LoopbackTransport
     private lateinit var serverProtocol: Protocol
     private lateinit var serverProtocolScope: CoroutineScope
+    private lateinit var agentSupport: XiaowanAgentSupport
 
     override val exitSignal = CompletableDeferred<Int?>()
     override val isRunning: Boolean
@@ -138,9 +143,7 @@ internal class XiaowanAcpConnection(
                 }
         )
         serverProtocol = Protocol(serverProtocolScope, serverTransport)
-        Agent(
-            serverProtocol,
-            XiaowanAgentSupport(
+        agentSupport = XiaowanAgentSupport(
                 context = context,
                 scope = scope,
                 scheduleToolBridge = scheduleToolBridge,
@@ -158,7 +161,7 @@ internal class XiaowanAcpConnection(
                     )
                 },
             )
-        )
+        Agent(serverProtocol, agentSupport)
         return clientTransport
     }
 
@@ -187,6 +190,7 @@ internal class XiaowanAcpConnection(
         "Built-in Xiaowan ACP Agent closed before initialize completed"
 
     override suspend fun close() {
+        if (::agentSupport.isInitialized) agentSupport.closeAllSessions()
         if (::serverProtocol.isInitialized) serverProtocol.close()
         if (::serverProtocolScope.isInitialized) serverProtocolScope.cancel()
         if (::clientTransport.isInitialized) clientTransport.close()
@@ -281,6 +285,7 @@ private class XiaowanAgentSupport(
 
     @Volatile
     private var cachedModels: XiaowanModels? = null
+    private val activeSessions = ConcurrentHashMap<String, XiaowanAgentSession>()
 
     override suspend fun initialize(clientInfo: ClientInfo): AgentInfo {
         // Provider/model resolution is owned by Dispatch Model. A persisted
@@ -298,29 +303,7 @@ private class XiaowanAgentSupport(
         }
         return AgentInfo(
                 protocolVersion = 1,
-                capabilities = AgentCapabilities(
-                    loadSession = true,
-                    promptCapabilities = PromptCapabilities(
-                    // The shared Chat Completions executor currently accepts
-                    // image parts and workspace file references, but it does
-                    // not send ACP audio blocks to an audio-capable model.
-                    // Advertising audio here made clients believe Xiaowan
-                    // could transcribe/play prompt audio, while the adapter
-                    // silently reduced it to a workspace attachment. Keep
-                    // the capability truthful until an audio input route is
-                    // implemented end-to-end.
-                    audio = false,
-                    image = true,
-                    embeddedContext = true,
-                ),
-                sessionCapabilities = SessionCapabilities(
-                    list = SessionListCapabilities(),
-                    fork = SessionForkCapabilities(),
-                    resume = SessionResumeCapabilities(),
-                    delete = SessionDeleteCapabilities(),
-                    close = SessionCloseCapabilities(),
-                )
-            ),
+                capabilities = xiaowanAgentCapabilities(),
             authMethods = emptyList(),
             implementation = Implementation(
                 name = "xiaowan",
@@ -335,11 +318,15 @@ private class XiaowanAgentSupport(
         sessionParameters: SessionCreationParameters,
     ): AgentSession {
         validateXiaowanSessionParameters(sessionParameters)
-        return createXiaowanSession(SessionId(UUID.randomUUID().toString()))
+        return createXiaowanSession(
+            sessionId = SessionId(UUID.randomUUID().toString()),
+            sessionParameters = sessionParameters,
+        )
     }
 
     private suspend fun createXiaowanSession(
         sessionId: SessionId,
+        sessionParameters: SessionCreationParameters,
         requirePersistedSession: Boolean = false,
     ): AgentSession {
         if (requirePersistedSession) {
@@ -349,7 +336,15 @@ private class XiaowanAgentSupport(
             }
         }
         val models = loadXiaowanModels()
-        return XiaowanAgentSession(
+        val mcpSession = XiaowanMcpSession.open(
+            context = context,
+            scope = scope,
+            sessionId = sessionId.value,
+            cwd = sessionParameters.cwd,
+            servers = sessionParameters.mcpServers,
+        )
+        lateinit var session: XiaowanAgentSession
+        session = XiaowanAgentSession(
             context = context,
             scope = scope,
             scheduleToolBridge = scheduleToolBridge,
@@ -359,7 +354,14 @@ private class XiaowanAgentSupport(
             providerProfile = models.providerProfile,
             sessionId = sessionId,
             requestPermission = requestPermission,
+            mcpSession = mcpSession,
+            onClosed = { closedSessionId ->
+                activeSessions.remove(closedSessionId, session)
+            },
         )
+        activeSessions.remove(sessionId.value)?.close(JsonNull)
+        activeSessions[sessionId.value] = session
+        return session
     }
 
     override suspend fun listSessions(
@@ -399,10 +401,12 @@ private class XiaowanAgentSupport(
         sessionId: SessionId,
         _meta: JsonElement?
     ): DeleteSessionResponse {
-        require(isXiaowanSession(sessionId.value)) {
-            "Xiaowan ACP session does not exist: ${sessionId.value}"
+        activeSessions.remove(sessionId.value)?.close(JsonNull)
+        if (isXiaowanSession(sessionId.value)) {
+            deleteSessionCallback(sessionId.value)
         }
-        deleteSessionCallback(sessionId.value)
+        // ACP deletion is intentionally idempotent: deleting an unknown or
+        // already-deleted session succeeds without fabricating history.
         return DeleteSessionResponse(JsonNull)
     }
 
@@ -411,7 +415,11 @@ private class XiaowanAgentSupport(
         sessionParameters: SessionCreationParameters
     ): AgentSession {
         validateXiaowanSessionParameters(sessionParameters)
-        return createXiaowanSession(sessionId, requirePersistedSession = true)
+        return createXiaowanSession(
+            sessionId = sessionId,
+            sessionParameters = sessionParameters,
+            requirePersistedSession = true,
+        )
     }
 
     override suspend fun resumeSession(
@@ -419,7 +427,11 @@ private class XiaowanAgentSupport(
         sessionParameters: SessionCreationParameters
     ): AgentSession {
         validateXiaowanSessionParameters(sessionParameters)
-        return createXiaowanSession(sessionId, requirePersistedSession = true)
+        return createXiaowanSession(
+            sessionId = sessionId,
+            sessionParameters = sessionParameters,
+            requirePersistedSession = true,
+        )
     }
 
     override suspend fun forkSession(
@@ -427,7 +439,18 @@ private class XiaowanAgentSupport(
         sessionParameters: SessionCreationParameters
     ): AgentSession {
         validateXiaowanSessionParameters(sessionParameters)
-        return createXiaowanSession(SessionId(UUID.randomUUID().toString()))
+        return createXiaowanSession(
+            sessionId = SessionId(UUID.randomUUID().toString()),
+            sessionParameters = sessionParameters,
+        )
+    }
+
+    suspend fun closeAllSessions() {
+        val sessions = activeSessions.values.toList()
+        activeSessions.clear()
+        sessions.forEach { session ->
+            runCatching { session.close(JsonNull) }
+        }
     }
 
     private fun validateXiaowanSessionParameters(parameters: SessionCreationParameters) {
@@ -624,6 +647,8 @@ private class XiaowanAgentSession(
     private val providerProfile: ModelProviderProfile,
     override val sessionId: SessionId,
     private val requestPermission: suspend (String, String, String, String) -> Boolean,
+    private val mcpSession: XiaowanMcpSession,
+    private val onClosed: (String) -> Unit,
 ) : AgentSession {
     private companion object {
         private const val TAG = "XiaowanAcpConnection"
@@ -633,6 +658,7 @@ private class XiaowanAgentSession(
     private val promptMutex = Mutex()
     @Volatile
     private var activePromptJob: Job? = null
+    private val closed = AtomicBoolean(false)
     private var selectedModelId: String = configuredModelId
     private val executor = OmniAgentExecutor(
         context = context,
@@ -663,12 +689,14 @@ private class XiaowanAgentSession(
                 )
             }
         },
+        sessionCapabilityModules = listOfNotNull(mcpSession.capabilityModule),
     )
 
     override suspend fun prompt(
         content: List<ContentBlock>,
         _meta: JsonElement?,
     ): Flow<Event> = channelFlow {
+        check(!closed.get()) { "Xiaowan ACP session is closed: ${sessionId.value}" }
         var promptJob: Job? = null
         try {
             promptMutex.withLock {
@@ -851,7 +879,16 @@ private class XiaowanAgentSession(
         // projects the official cancel result through the existing lifecycle.
         // Propagating a CancellationException from this callback can abort the
         // Android process while the JSON-RPC request is being handled.
-        activePromptJob?.cancel()
+        activePromptJob?.cancelAndJoin()
+    }
+
+    override suspend fun close(_meta: JsonElement?): CloseSessionResponse {
+        if (closed.compareAndSet(false, true)) {
+            cancel()
+            mcpSession.close()
+            onClosed(sessionId.value)
+        }
+        return CloseSessionResponse(JsonNull)
     }
 
     /**
@@ -919,6 +956,33 @@ internal fun AgentResult.Success.toAcpUsage(): Usage? {
         _meta = JsonNull,
     )
 }
+
+internal fun xiaowanAgentCapabilities(): AgentCapabilities = AgentCapabilities(
+    // ACP v1 session/load requires history replay before its response settles.
+    // Xiaowan restores durable context through resume but does not yet provide
+    // that replay boundary, so load must not be advertised.
+    loadSession = false,
+    promptCapabilities = PromptCapabilities(
+        // The shared executor accepts image and workspace resources, but it
+        // has no ACP audio route.
+        audio = false,
+        image = true,
+        embeddedContext = true,
+    ),
+    mcpCapabilities = McpCapabilities(
+        http = true,
+        sse = true,
+    ),
+    sessionCapabilities = SessionCapabilities(
+        list = SessionListCapabilities(),
+        // The local app can copy its Conversation after a fork, but the Agent
+        // itself does not clone context for arbitrary ACP clients yet.
+        fork = null,
+        resume = SessionResumeCapabilities(),
+        delete = SessionDeleteCapabilities(),
+        close = SessionCloseCapabilities(),
+    ),
+)
 
 /**
  * Maps the shared ACP vocabulary at the Xiaowan adapter boundary. Keeping

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeManager.kt
@@ -710,6 +710,29 @@ class AgentRuntimeManager private constructor(
         }
     }
 
+    /**
+     * ACP MCP declarations are immutable session setup inputs. Once the user
+     * edits the remote MCP set, no live local Agent may keep serving the old
+     * definitions or connections. The next request reconnects/resumes through
+     * the canonical ACP lifecycle with a fresh SessionCreationParameters list.
+     */
+    suspend fun invalidateMcpConfiguration() {
+        sessionMutex.withLock {
+            invalidateLocalProbeCache()
+            val connectedProfiles = acpAgentProfileStore.list().filter { profile ->
+                localRuntimeFor(profile.id).isConnected
+            }
+            connectedProfiles.forEach { profile ->
+                localRuntimeFor(profile.id).disconnect()
+                clearActiveTurnsForAgent(profile.id)
+            }
+            if (connectedProfiles.isNotEmpty() && activeRuntime == AgentRuntimeKind.LOCAL) {
+                activeRuntime = null
+                activeLocalDistributionId = null
+            }
+        }
+    }
+
     suspend fun handleMethod(method: String, args: Map<String, Any?>): Any? {
         val canonicalArgs = AcpSessionCompatibility.canonicalize(method, args)
         if (method == "initialize") {

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeMcp.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeMcp.kt
@@ -5,6 +5,7 @@ package cn.com.omnimind.bot.agent.runtime
 import cn.com.omnimind.bot.mcp.McpServerState
 import cn.com.omnimind.bot.mcp.RemoteMcpConfigStore
 import cn.com.omnimind.bot.mcp.RemoteMcpServerConfig
+import cn.com.omnimind.bot.mcp.RemoteMcpTransport
 import com.agentclientprotocol.model.HttpHeader
 import com.agentclientprotocol.model.McpServer
 
@@ -50,13 +51,14 @@ internal fun buildLocalAgentAcpMcpServers(
  * session; they are not reimplemented by OmniBot and their tool names are
  * therefore left untouched for the Harness to namespace.
  *
- * ACP 0.26 only has a typed HTTP server in the JVM SDK.  Streamable HTTP is
- * supported by the official adapters; legacy `/sse` entries remain available
- * to OmniBot's native MCP client but are deliberately not sent as an invalid
- * ACP HTTP declaration.
+ * Preserve the transport type negotiated through ACP. A legacy SSE endpoint
+ * must never be mislabeled as Streamable HTTP, and neither optional transport
+ * may be sent to an Agent that omitted the corresponding capability.
  */
 internal fun buildConfiguredRemoteAcpMcpServers(
     configured: List<RemoteMcpServerConfig> = RemoteMcpConfigStore.listEnabledServers(),
+    supportsHttp: Boolean,
+    supportsSse: Boolean,
 ): List<McpServer> {
     val usedNames = linkedSetOf<String>()
     return configured.mapNotNull { server ->
@@ -66,9 +68,14 @@ internal fun buildConfiguredRemoteAcpMcpServers(
         ) {
             return@mapNotNull null
         }
-        if (endpoint.substringBefore('?').trimEnd('/').endsWith("/sse", ignoreCase = true)) {
-            return@mapNotNull null
-        }
+        val legacySse = server.transport == RemoteMcpTransport.SSE ||
+            (
+                server.transport == RemoteMcpTransport.AUTO &&
+                    endpoint.substringBefore('?').trimEnd('/')
+                        .endsWith("/sse", ignoreCase = true)
+                )
+        if (legacySse && !supportsSse) return@mapNotNull null
+        if (!legacySse && !supportsHttp) return@mapNotNull null
         val baseName = server.name.trim().ifBlank {
             "remote-${server.id.take(8)}"
         }
@@ -78,17 +85,33 @@ internal fun buildConfiguredRemoteAcpMcpServers(
             name = "$baseName-$suffix"
             suffix += 1
         }
-        val headers = server.bearerToken.trim()
-            .takeIf(String::isNotEmpty)
-            ?.let {
-                listOf(HttpHeader(name = "Authorization", value = "Bearer $it"))
-            }
-            .orEmpty()
-        McpServer.Http(
-            name = name,
-            url = endpoint,
-            headers = headers,
-        )
+        val configuredHeaders = server.headers.entries
+            .filter { (headerName, _) -> headerName.isNotBlank() }
+            .map { (headerName, value) -> HttpHeader(name = headerName, value = value) }
+            .toMutableList()
+        val hasAuthorization = configuredHeaders.any {
+            it.name.equals("Authorization", ignoreCase = true)
+        }
+        if (!hasAuthorization && server.bearerToken.isNotBlank()) {
+            configuredHeaders += HttpHeader(
+                name = "Authorization",
+                value = "Bearer ${server.bearerToken.trim()}",
+            )
+        }
+        val headers = configuredHeaders.toList()
+        if (legacySse) {
+            McpServer.Sse(
+                name = name,
+                url = endpoint,
+                headers = headers,
+            )
+        } else {
+            McpServer.Http(
+                name = name,
+                url = endpoint,
+                headers = headers,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/LocalAcpRuntime.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/LocalAcpRuntime.kt
@@ -3225,30 +3225,42 @@ internal class LocalAcpRuntime(
         args: Map<String, Any?> = emptyMap()
     ): SessionCreationParameters {
         val profile = activeProfile ?: profileStore.selected()
-        val supportsHttp = requireAgentInfo().capabilities.mcpCapabilities.http
+        val agentCapabilities = requireAgentInfo().capabilities
+        val supportsHttp = agentCapabilities.mcpCapabilities.http
+        val supportsSse = agentCapabilities.mcpCapabilities.sse
         val requestedAdditionalDirectories = (args["additionalDirectories"] as? List<*>)
             .orEmpty()
             .mapNotNull { it?.toString()?.trim()?.takeIf(String::isNotEmpty) }
             .distinct()
-        val supportsAdditionalDirectories = requireAgentInfo()
-            .capabilities.sessionCapabilities.additionalDirectories != null
+        val supportsAdditionalDirectories =
+            agentCapabilities.sessionCapabilities.additionalDirectories != null
         if (requestedAdditionalDirectories.isNotEmpty() && !supportsAdditionalDirectories) {
             throw IllegalArgumentException(
                 "${profile.name} ACP does not support additionalDirectories; " +
                     "use a path under ${AgentWorkspaceManager.SHELL_ROOT_PATH}."
             )
         }
-        val mcpState = if (sessionMcpEnabled && supportsHttp) {
+        // Xiaowan already owns the native OmniBot capability modules. Feeding
+        // the app's own loopback MCP server back into that built-in Agent would
+        // duplicate tools and create an unnecessary self-call path. External
+        // Harnesses still receive the local device MCP surface.
+        val shouldDeclareLocalServer = sessionMcpEnabled &&
+            supportsHttp &&
+            profile.id != AcpAgentProfileStore.XIAOWAN_AGENT_ID
+        val mcpState = if (shouldDeclareLocalServer) {
             McpServerManager.ensureRunning(appContext)
         } else {
             McpServerManager.currentState()
         }
-        val declaredServers = if (sessionMcpEnabled && supportsHttp) {
+        val declaredServers = if (sessionMcpEnabled) {
             buildLocalAgentAcpMcpServers(
                 harnessAdapter = AcpHarnessAdapters.forProfile(profile),
-                supportsHttp = supportsHttp,
+                supportsHttp = shouldDeclareLocalServer,
                 state = mcpState
-            ) + buildConfiguredRemoteAcpMcpServers()
+            ) + buildConfiguredRemoteAcpMcpServers(
+                supportsHttp = supportsHttp,
+                supportsSse = supportsSse,
+            )
         } else {
             emptyList()
         }

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/OmniAgentExecutor.kt
@@ -6,6 +6,7 @@ import cn.com.omnimind.baselib.i18n.AppLocaleManager
 import cn.com.omnimind.baselib.llm.ChatCompletionMessage
 import cn.com.omnimind.bot.agent.workspace.memory.LongTermMemoryIndex
 import cn.com.omnimind.bot.agent.workspace.memory.TurnMemoryLoadTracker
+import cn.com.omnimind.bot.agent.tool.AgentCapabilityModule
 import cn.com.omnimind.bot.agent.tool.AgentToolHandlerModule
 import cn.com.omnimind.bot.plugin.OmniPluginHost
 import cn.com.omnimind.bot.plugin.OmniPluginSession
@@ -28,7 +29,8 @@ import java.util.UUID
 class OmniAgentExecutor(
     private val context: Context,
     private val scope: CoroutineScope,
-    private val scheduleToolBridge: AgentScheduleToolBridge
+    private val scheduleToolBridge: AgentScheduleToolBridge,
+    private val sessionCapabilityModules: List<AgentCapabilityModule> = emptyList(),
 ) {
     internal data class TimeContextSnapshot(
         val locale: cn.com.omnimind.baselib.i18n.PromptLocale,
@@ -251,6 +253,9 @@ class OmniAgentExecutor(
                 conversationMode = conversationMode,
                 terminalDistribution = terminalDistribution,
                 pluginToolDefinitions = activePluginSession?.toolDefinitions.orEmpty(),
+                capabilityToolDefinitions = sessionCapabilityModules.flatMap {
+                    it.toolDefinitions
+                },
                 userMessage = userMessage,
                 toolRoutingMode = AgentToolRoutingMode.fromSkillFrontmatter(
                     resolvedSkills.map(ResolvedSkillContext::frontmatter),
@@ -329,10 +334,11 @@ class OmniAgentExecutor(
                 subagentDispatcher = subagentDispatcher,
                 toolCatalog = toolRegistry,
                 terminalDistribution = terminalDistribution,
-                capabilityModules = if (activePluginSession != null) {
-                    listOf(AgentToolHandlerModule(activePluginSession.toolHandlers))
-                } else {
-                    emptyList()
+                capabilityModules = buildList {
+                    addAll(sessionCapabilityModules)
+                    if (activePluginSession != null) {
+                        add(AgentToolHandlerModule(activePluginSession.toolHandlers))
+                    }
                 }
             )
             pluginSession = null

--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/XiaowanMcpSession.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/XiaowanMcpSession.kt
@@ -1,0 +1,576 @@
+package cn.com.omnimind.bot.agent.runtime
+
+import android.content.Context
+import android.util.Log
+import cn.com.omnimind.baselib.llm.AssistantToolCall
+import cn.com.omnimind.bot.agent.AgentCallback
+import cn.com.omnimind.bot.agent.AgentExecutionEnvironment
+import cn.com.omnimind.bot.agent.AgentToolExecutionHandle
+import cn.com.omnimind.bot.agent.AgentToolRegistry
+import cn.com.omnimind.bot.agent.ToolExecutionResult
+import cn.com.omnimind.bot.agent.tool.AgentCapabilityModule
+import cn.com.omnimind.bot.agent.tool.AgentCapabilityToolDefinition
+import cn.com.omnimind.bot.agent.tool.handlers.ToolHandler
+import cn.com.omnimind.bot.mcp.RemoteMcpCallResult
+import cn.com.omnimind.bot.mcp.RemoteMcpClient
+import cn.com.omnimind.bot.mcp.RemoteMcpServerConfig
+import cn.com.omnimind.bot.mcp.RemoteMcpToolDescriptor
+import cn.com.omnimind.bot.mcp.RemoteMcpTransport
+import com.agentclientprotocol.model.McpServer
+import com.ai.assistance.operit.terminal.TerminalManager
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * MCP resources supplied by one ACP session.
+ *
+ * This object owns every connection and one capability module. Definitions
+ * and handlers therefore share the same ACP Session lifetime instead of using
+ * the process-global remote MCP discovery cache.
+ */
+internal class XiaowanMcpSession private constructor(
+    val capabilityModule: AgentCapabilityModule?,
+    private val connections: List<XiaowanMcpServerConnection>,
+) {
+    suspend fun close() {
+        connections.forEach { connection ->
+            runCatching { connection.close() }
+        }
+    }
+
+    companion object {
+        suspend fun open(
+            context: Context,
+            scope: CoroutineScope,
+            sessionId: String,
+            cwd: String,
+            servers: List<McpServer>,
+        ): XiaowanMcpSession {
+            if (servers.isEmpty()) return XiaowanMcpSession(null, emptyList())
+
+            val ready = coroutineScope {
+                servers.mapIndexed { index, server ->
+                    async {
+                        val connection = createXiaowanMcpConnection(
+                            context = context,
+                            scope = scope,
+                            sessionId = sessionId,
+                            cwd = cwd,
+                            index = index,
+                            server = server,
+                        )
+                        try {
+                            connection.start()
+                            connection to connection.listTools()
+                        } catch (error: CancellationException) {
+                            runCatching { connection.close() }
+                            throw error
+                        } catch (error: Throwable) {
+                            runCatching { connection.close() }
+                            // One unavailable optional server must not make the
+                            // Agent session unusable. Other supplied servers still
+                            // contribute tools, while the failure remains visible
+                            // in diagnostics and can be retried in a new session.
+                            Log.w(
+                                TAG,
+                                "MCP connect failed session=$sessionId server=${server.name}",
+                                error,
+                            )
+                            null
+                        }
+                    }
+                }.awaitAll().filterNotNull()
+            }
+            val opened = ready.map { (connection, _) -> connection }
+            val discovered = ready.flatMap { (connection, tools) ->
+                tools.map { tool -> XiaowanMcpDiscoveredTool(connection, tool) }
+            }
+
+            val bindings = buildXiaowanMcpToolBindings(discovered)
+            val module = bindings.takeIf(List<*>::isNotEmpty)?.let {
+                XiaowanMcpCapabilityModule(it)
+            }
+            return XiaowanMcpSession(module, opened)
+        }
+
+        private const val TAG = "XiaowanMcpSession"
+    }
+}
+
+internal interface XiaowanMcpServerConnection {
+    val connectionId: String
+    val serverName: String
+
+    suspend fun start()
+    suspend fun listTools(): List<RemoteMcpToolDescriptor>
+    suspend fun callTool(
+        toolName: String,
+        arguments: Map<String, Any?>,
+    ): RemoteMcpCallResult
+    suspend fun close()
+}
+
+internal data class XiaowanMcpDiscoveredTool(
+    val connection: XiaowanMcpServerConnection,
+    val descriptor: RemoteMcpToolDescriptor,
+)
+
+internal data class XiaowanMcpToolBinding(
+    val modelToolName: String,
+    val connection: XiaowanMcpServerConnection,
+    val descriptor: RemoteMcpToolDescriptor,
+)
+
+internal fun buildXiaowanMcpToolBindings(
+    discovered: List<XiaowanMcpDiscoveredTool>,
+): List<XiaowanMcpToolBinding> {
+    val occupied = linkedSetOf<String>()
+    return discovered.map { item ->
+        val server = sanitizeMcpToolSegment(item.connection.serverName, maxLength = 16)
+        val tool = sanitizeMcpToolSegment(item.descriptor.toolName, maxLength = 25)
+        val hash = stableMcpNameHash(
+            "${item.connection.connectionId}\u0000${item.descriptor.toolName}"
+        )
+        val base = "mcp__${server}__${tool}__$hash"
+        var candidate = base
+        var suffix = 2
+        while (!occupied.add(candidate)) {
+            candidate = "${base.take(61)}_$suffix"
+            suffix += 1
+        }
+        XiaowanMcpToolBinding(candidate, item.connection, item.descriptor)
+    }
+}
+
+internal class XiaowanMcpCapabilityModule(
+    bindings: List<XiaowanMcpToolBinding>,
+) : AgentCapabilityModule {
+    private val handler = XiaowanMcpToolHandler(bindings.associateBy { it.modelToolName })
+
+    override val handlers: List<ToolHandler> = listOf(handler)
+
+    override val toolDefinitions: List<AgentCapabilityToolDefinition> = bindings.map { binding ->
+        AgentCapabilityToolDefinition(
+            name = binding.modelToolName,
+            displayName = binding.descriptor.toolName,
+            description = binding.descriptor.description,
+            parameters = mapToJsonObject(binding.descriptor.inputSchema),
+            toolType = "mcp",
+            serverName = binding.connection.serverName,
+        )
+    }
+}
+
+private class XiaowanMcpToolHandler(
+    private val bindings: Map<String, XiaowanMcpToolBinding>,
+) : ToolHandler {
+    override val toolNames: Set<String> = bindings.keys
+
+    override suspend fun execute(
+        toolCall: AssistantToolCall,
+        args: JsonObject,
+        runtimeDescriptor: AgentToolRegistry.RuntimeToolDescriptor,
+        env: AgentExecutionEnvironment,
+        callback: AgentCallback,
+        toolHandle: AgentToolExecutionHandle,
+    ): ToolExecutionResult {
+        val toolName = toolCall.function.name
+        val binding = bindings[toolName]
+            ?: return ToolExecutionResult.Error(toolName, "Unknown MCP tool: $toolName")
+        return try {
+            val title = args["tool_title"]
+                ?.let { it as? JsonPrimitive }
+                ?.contentOrNull
+                ?.trim()
+                .orEmpty()
+            callback.onToolCallProgress(
+                toolName,
+                title.ifBlank {
+                    "Calling ${binding.connection.serverName}/${binding.descriptor.toolName}"
+                },
+            )
+            val result = binding.connection.callTool(
+                toolName = binding.descriptor.toolName,
+                arguments = jsonObjectToMap(args).filterKeys { it != "tool_title" },
+            )
+            ToolExecutionResult.McpResult(
+                toolName = toolName,
+                serverName = binding.connection.serverName,
+                summaryText = result.summaryText,
+                previewJson = result.previewJson,
+                rawResultJson = result.rawResultJson,
+                success = result.success,
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Throwable) {
+            ToolExecutionResult.Error(
+                toolName,
+                error.message ?: "MCP tool call failed",
+            )
+        }
+    }
+
+    // Connections belong to XiaowanMcpSession, not to the per-turn router.
+    override suspend fun dispose() = Unit
+}
+
+private fun createXiaowanMcpConnection(
+    context: Context,
+    scope: CoroutineScope,
+    sessionId: String,
+    cwd: String,
+    index: Int,
+    server: McpServer,
+): XiaowanMcpServerConnection {
+    val connectionId = "xiaowan-${stableMcpNameHash(sessionId)}-$index-${UUID.randomUUID()}"
+    return when (server) {
+        is McpServer.Http -> XiaowanHttpMcpConnection(
+            RemoteMcpServerConfig(
+                id = connectionId,
+                name = server.name,
+                endpointUrl = server.url,
+                headers = server.headers.associate { it.name to it.value },
+                transport = RemoteMcpTransport.HTTP,
+            )
+        )
+        is McpServer.Sse -> XiaowanHttpMcpConnection(
+            RemoteMcpServerConfig(
+                id = connectionId,
+                name = server.name,
+                endpointUrl = server.url,
+                headers = server.headers.associate { it.name to it.value },
+                transport = RemoteMcpTransport.SSE,
+            )
+        )
+        is McpServer.Stdio -> XiaowanStdioMcpConnection(
+            context = context,
+            scope = scope,
+            connectionId = connectionId,
+            cwd = cwd,
+            server = server,
+        )
+    }
+}
+
+private class XiaowanHttpMcpConnection(
+    private val config: RemoteMcpServerConfig,
+) : XiaowanMcpServerConnection {
+    override val connectionId: String = config.id
+    override val serverName: String = config.name
+
+    override suspend fun start() = Unit
+
+    override suspend fun listTools(): List<RemoteMcpToolDescriptor> =
+        RemoteMcpClient.listTools(config)
+
+    override suspend fun callTool(
+        toolName: String,
+        arguments: Map<String, Any?>,
+    ): RemoteMcpCallResult = RemoteMcpClient.callTool(config, toolName, arguments)
+
+    override suspend fun close() {
+        RemoteMcpClient.close(config)
+    }
+}
+
+private class XiaowanStdioMcpConnection(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    override val connectionId: String,
+    private val cwd: String,
+    private val server: McpServer.Stdio,
+) : XiaowanMcpServerConnection {
+    override val serverName: String = server.name
+
+    private val requestMutex = Mutex()
+    private var process: Process? = null
+    private var reader: BufferedReader? = null
+    private var writer: BufferedWriter? = null
+    private var stdoutJob: Job? = null
+    private var stderrJob: Job? = null
+    private var stdoutLines: Channel<String>? = null
+
+    override suspend fun start() {
+        if (process != null) return
+        val command = buildString {
+            append("cd -- ")
+            append(shellQuoteMcp(cwd))
+            append(" && exec ")
+            append(shellQuoteMcp(server.command))
+            server.args.forEach { argument ->
+                append(' ')
+                append(shellQuoteMcp(argument))
+            }
+        }
+        val started = TerminalManager.getInstance(context).startLongLivedProcess(
+            command = command,
+            executorKey = connectionId,
+            extraEnvironment = server.env
+                .filter { it.name.isNotBlank() }
+                .associate { it.name to it.value },
+            redirectErrorStream = false,
+        )
+        process = started
+        reader = started.inputStream.bufferedReader(StandardCharsets.UTF_8)
+        writer = started.outputStream.bufferedWriter(StandardCharsets.UTF_8)
+        val lines = Channel<String>(Channel.UNLIMITED)
+        stdoutLines = lines
+        stdoutJob = scope.launch(Dispatchers.IO) {
+            try {
+                reader?.useLines { output ->
+                    output.forEach { line -> lines.send(line) }
+                }
+            } finally {
+                lines.close()
+            }
+        }
+        stderrJob = scope.launch(Dispatchers.IO) {
+            started.errorStream.bufferedReader(StandardCharsets.UTF_8).useLines { lines ->
+                lines.forEach { line ->
+                    if (line.isNotBlank()) {
+                        Log.d(TAG, "stdio server=$serverName: ${line.take(500)}")
+                    }
+                }
+            }
+        }
+
+        request(
+            method = "initialize",
+            params = buildJsonObject {
+                put("protocolVersion", RemoteMcpClient.DEFAULT_PROTOCOL_VERSION)
+                put("capabilities", buildJsonObject {
+                    put("tools", buildJsonObject {})
+                })
+                put("clientInfo", buildJsonObject {
+                    put("name", "omnibot-android")
+                    put("version", "1.0")
+                })
+            },
+        )
+        notify("notifications/initialized", buildJsonObject {})
+    }
+
+    override suspend fun listTools(): List<RemoteMcpToolDescriptor> {
+        val result = request("tools/list", buildJsonObject {})
+        val tools = (result as? JsonObject)?.get("tools") as? JsonArray ?: JsonArray(emptyList())
+        return tools.mapNotNull { element ->
+            val raw = element as? JsonObject ?: return@mapNotNull null
+            val name = raw["name"]?.jsonPrimitive?.contentOrNull?.trim().orEmpty()
+            if (name.isBlank()) return@mapNotNull null
+            RemoteMcpToolDescriptor(
+                serverId = connectionId,
+                serverName = serverName,
+                toolName = name,
+                description = raw["description"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+                inputSchema = jsonObjectToMap(
+                    raw["inputSchema"] as? JsonObject ?: buildJsonObject {}
+                ),
+            )
+        }
+    }
+
+    override suspend fun callTool(
+        toolName: String,
+        arguments: Map<String, Any?>,
+    ): RemoteMcpCallResult {
+        val result = request(
+            "tools/call",
+            buildJsonObject {
+                put("name", toolName)
+                put("arguments", mapToJsonObject(arguments))
+            },
+        )
+        return remoteMcpCallResult(result)
+    }
+
+    override suspend fun close() {
+        requestMutex.withLock {
+            stdoutJob?.cancel()
+            stdoutJob = null
+            stderrJob?.cancel()
+            stderrJob = null
+            stdoutLines?.close()
+            stdoutLines = null
+            val active = process
+            process = null
+            runCatching { writer?.close() }
+            runCatching { reader?.close() }
+            writer = null
+            reader = null
+            if (active != null) {
+                runCatching { active.destroy() }
+                val exited = runCatching { active.waitFor(500, TimeUnit.MILLISECONDS) }
+                    .getOrDefault(false)
+                if (!exited) runCatching { active.destroyForcibly() }
+            }
+        }
+    }
+
+    private suspend fun request(method: String, params: JsonObject): JsonElement {
+        val requestId = UUID.randomUUID().toString()
+        val payload = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("id", requestId)
+            put("method", method)
+            put("params", params)
+        }
+        return requestMutex.withLock {
+            withTimeout<JsonElement>(RPC_TIMEOUT_MS) {
+                val activeWriter = writer ?: error("MCP stdio writer is closed")
+                val activeLines = stdoutLines ?: error("MCP stdio reader is closed")
+                withContext(Dispatchers.IO) {
+                    activeWriter.write(payload.toString())
+                    activeWriter.newLine()
+                    activeWriter.flush()
+                }
+                var matchedResult: JsonElement? = null
+                while (matchedResult == null) {
+                    val line = activeLines.receiveCatching().getOrNull()
+                        ?: error("MCP stdio server exited before responding to $method")
+                    val response = runCatching {
+                        MCP_JSON.parseToJsonElement(line) as? JsonObject
+                    }.getOrNull() ?: continue
+                    val responseId = response["id"]
+                        ?.jsonPrimitive
+                        ?.contentOrNull
+                    if (responseId != requestId) continue
+                    val error = response["error"] as? JsonObject
+                    if (error != null) {
+                        val message = error["message"]
+                            ?.jsonPrimitive
+                            ?.contentOrNull
+                            ?: "Unknown MCP stdio error"
+                        throw IllegalStateException(message)
+                    }
+                    matchedResult = response["result"] ?: JsonNull
+                }
+                checkNotNull(matchedResult)
+            }
+        }
+    }
+
+    private suspend fun notify(method: String, params: JsonObject) {
+        val payload = buildJsonObject {
+            put("jsonrpc", "2.0")
+            put("method", method)
+            put("params", params)
+        }
+        requestMutex.withLock {
+            withContext(Dispatchers.IO) {
+                val activeWriter = writer ?: error("MCP stdio writer is closed")
+                activeWriter.write(payload.toString())
+                activeWriter.newLine()
+                activeWriter.flush()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "XiaowanStdioMcp"
+        private const val RPC_TIMEOUT_MS = 40_000L
+        private val MCP_JSON = Json { ignoreUnknownKeys = true }
+    }
+}
+
+private fun remoteMcpCallResult(result: JsonElement): RemoteMcpCallResult {
+    val raw = result.toString()
+    val resultObject = result as? JsonObject
+    val content = resultObject?.get("content") as? JsonArray
+    val summary = content
+        ?.mapNotNull { item ->
+            val block = item as? JsonObject ?: return@mapNotNull null
+            if (block["type"]?.jsonPrimitive?.contentOrNull != "text") return@mapNotNull null
+            block["text"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf(String::isNotEmpty)
+        }
+        ?.joinToString("\n")
+        ?.takeIf(String::isNotBlank)
+        ?: raw.take(600)
+    return RemoteMcpCallResult(
+        summaryText = summary,
+        previewJson = if (raw.length <= 1200) raw else raw.take(1200) + "...",
+        rawResultJson = raw,
+        success = (resultObject?.get("isError") as? JsonPrimitive)?.contentOrNull != "true",
+    )
+}
+
+private fun sanitizeMcpToolSegment(value: String, maxLength: Int): String {
+    return value
+        .trim()
+        .map { char ->
+            if (char.isAsciiLetterOrDigit() || char == '_' || char == '-') char else '_'
+        }
+        .joinToString("")
+        .trim('_')
+        .ifBlank { "unnamed" }
+        .take(maxLength)
+}
+
+private fun Char.isAsciiLetterOrDigit(): Boolean =
+    this in 'a'..'z' || this in 'A'..'Z' || this in '0'..'9'
+
+private fun stableMcpNameHash(value: String): String =
+    value.hashCode().toUInt().toString(16).padStart(8, '0')
+
+private fun shellQuoteMcp(value: String): String =
+    "'${value.replace("'", "'\"'\"'")}'"
+
+private fun mapToJsonObject(value: Map<String, Any?>): JsonObject = JsonObject(
+    value.mapValues { (_, child) -> anyToJson(child) }
+)
+
+private fun anyToJson(value: Any?): JsonElement = when (value) {
+    null -> JsonNull
+    is JsonElement -> value
+    is Map<*, *> -> JsonObject(
+        value.entries.associate { (key, child) -> key.toString() to anyToJson(child) }
+    )
+    is Iterable<*> -> JsonArray(value.map(::anyToJson))
+    is Array<*> -> JsonArray(value.map(::anyToJson))
+    is Boolean -> JsonPrimitive(value)
+    is Number -> JsonPrimitive(value)
+    else -> JsonPrimitive(value.toString())
+}
+
+private fun jsonObjectToMap(value: JsonObject): Map<String, Any?> =
+    value.mapValues { (_, child) -> jsonToAny(child) }
+
+private fun jsonToAny(value: JsonElement): Any? = when (value) {
+    JsonNull -> null
+    is JsonObject -> jsonObjectToMap(value)
+    is JsonArray -> value.map(::jsonToAny)
+    is JsonPrimitive -> when {
+        value.isString -> value.content
+        value.contentOrNull == "true" -> true
+        value.contentOrNull == "false" -> false
+        value.contentOrNull?.toLongOrNull() != null -> value.content.toLong()
+        value.contentOrNull?.toDoubleOrNull() != null -> value.content.toDouble()
+        else -> value.contentOrNull
+    }
+}

--- a/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentCapabilityModule.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentCapabilityModule.kt
@@ -19,9 +19,29 @@ import cn.com.omnimind.bot.agent.tool.handlers.TerminalToolHandler
 import cn.com.omnimind.bot.agent.tool.handlers.ToolHandler
 import cn.com.omnimind.bot.agent.tool.handlers.VlmToolHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.serialization.json.JsonObject
+
+data class AgentCapabilityToolDefinition(
+    val name: String,
+    val displayName: String,
+    val description: String,
+    val parameters: JsonObject,
+    val toolType: String,
+    val serverName: String? = null,
+)
 
 interface AgentCapabilityModule {
     val handlers: List<ToolHandler>
+
+    /**
+     * Model-facing definitions owned by the same lifecycle as [handlers].
+     *
+     * Session-scoped capabilities such as ACP-provided MCP servers must enter
+     * the canonical Agent catalog here. Keeping definitions and execution in
+     * one module prevents a stale definition from outliving its handler.
+     */
+    val toolDefinitions: List<AgentCapabilityToolDefinition>
+        get() = emptyList()
 }
 
 class AgentToolHandlerModule(

--- a/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentToolRegistry.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/tool/AgentToolRegistry.kt
@@ -6,6 +6,7 @@ import cn.com.omnimind.baselib.shizuku.PrivilegedActionPolicy
 import cn.com.omnimind.baselib.shizuku.ShizukuBackend
 import cn.com.omnimind.baselib.shizuku.ShizukuCapabilityManager
 import cn.com.omnimind.baselib.util.OmniLog
+import cn.com.omnimind.bot.agent.tool.AgentCapabilityToolDefinition
 import cn.com.omnimind.bot.plugin.OmniPluginToolDefinition
 import com.rk.terminal.runtime.TerminalDistribution
 import kotlinx.serialization.json.JsonArray
@@ -25,6 +26,7 @@ class AgentToolRegistry(
     private val conversationMode: String = AgentConversationModePolicy.AGENT_MODE,
     terminalDistribution: TerminalDistribution.Spec = TerminalDistribution.alpine,
     pluginToolDefinitions: List<OmniPluginToolDefinition> = emptyList(),
+    capabilityToolDefinitions: List<AgentCapabilityToolDefinition> = emptyList(),
     userMessage: String? = null,
     toolRoutingMode: AgentToolRoutingMode = AgentToolRoutingMode.DEFAULT,
     // Keep the visual-operation entry visible so the Agent can explain how
@@ -108,7 +110,7 @@ class AgentToolRegistry(
         }
         runtimeDefinitions.addAll(AgentToolDefinitions.memoryTools(locale))
         runtimeDefinitions.addAll(AgentToolDefinitions.subagentTools(locale))
-        if (pluginToolDefinitions.isNotEmpty()) {
+        if (pluginToolDefinitions.isNotEmpty() || capabilityToolDefinitions.isNotEmpty()) {
             val occupiedNames = runtimeDefinitions.mapNotNullTo(linkedSetOf()) { definition ->
                 (definition["function"] as? JsonObject)
                     ?.get("name")
@@ -132,6 +134,29 @@ class AgentToolRegistry(
                             }
                             put("description", JsonPrimitive(pluginTool.description))
                             put("parameters", pluginTool.parameters)
+                        })
+                    },
+                    locale,
+                    terminalDistribution
+                )
+            }
+            capabilityToolDefinitions.forEach { capabilityTool ->
+                require(capabilityTool.name !in occupiedNames) {
+                    "Capability tool conflicts with an existing tool: ${capabilityTool.name}"
+                }
+                occupiedNames += capabilityTool.name
+                runtimeDefinitions += AgentToolDefinitions.decorateToolDefinition(
+                    buildJsonObject {
+                        put("type", JsonPrimitive("function"))
+                        put("function", buildJsonObject {
+                            put("name", JsonPrimitive(capabilityTool.name))
+                            put("displayName", JsonPrimitive(capabilityTool.displayName))
+                            put("toolType", JsonPrimitive(capabilityTool.toolType))
+                            capabilityTool.serverName?.let {
+                                put("serverName", JsonPrimitive(it))
+                            }
+                            put("description", JsonPrimitive(capabilityTool.description))
+                            put("parameters", capabilityTool.parameters)
                         })
                     },
                     locale,

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/McpServerManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/McpServerManager.kt
@@ -48,6 +48,7 @@ import java.io.File
 import java.net.BindException
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import java.net.URI
 import java.security.MessageDigest
 import java.security.SecureRandom
 import java.util.UUID
@@ -124,7 +125,8 @@ object McpServerManager {
      * second private protocol or a second server lifecycle.
      */
     fun ensureRunning(context: Context): McpServerState {
-        currentState().takeIf { it.running }?.let { return it }
+        val currentHost = resolveLanIp() ?: LOOPBACK_HOST
+        if (isRunning && activeHost == currentHost) return currentState()
         val port = mmkv.decodeInt(PREF_PORT, DEFAULT_PORT).takeIf { it > 0 } ?: DEFAULT_PORT
         return startServer(context, port)
     }
@@ -294,9 +296,7 @@ object McpServerManager {
             val lanIp = resolveLanIp() ?: LOOPBACK_HOST
             if (isRunning) {
                 val currentPort = mmkv.decodeInt(PREF_PORT, DEFAULT_PORT).takeIf { it > 0 } ?: DEFAULT_PORT
-                if (currentPort == port) {
-                    activeHost = lanIp
-                    mmkv.encode(PREF_HOST, lanIp)
+                if (currentPort == port && activeHost == lanIp) {
                     return currentState()
                 }
                 stopServerLocked()
@@ -321,7 +321,7 @@ object McpServerManager {
                             .getOrNull()
                     }
                     ?: return@repeat
-                val engine = buildServer(context, resolvedPort)
+                val engine = buildServer(context, resolvedPort, lanIp)
                 try {
                     engine.start(wait = false)
                     server = engine
@@ -397,7 +397,8 @@ object McpServerManager {
 
     private fun buildServer(
         context: Context,
-        port: Int
+        port: Int,
+        lanHost: String,
     ): EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration> {
         val token = ensureToken()
         val appContext = context.applicationContext
@@ -406,6 +407,16 @@ object McpServerManager {
         val browserMirrorService = BrowserMirrorService(appContext)
         val agentRunService = AgentRunService(appContext)
         val webChatAvatarService = WebChatAvatarService(appContext)
+        val allowedMcpHosts = listOf(
+            lanHost,
+            LOOPBACK_HOST,
+            "localhost",
+            "[::1]",
+        ).distinct()
+        // The SDK parses allowedOrigins as URLs before comparing only their
+        // host component. Supplying bare hostnames would make server startup
+        // fail even though allowedHosts intentionally uses bare host values.
+        val allowedMcpOrigins = allowedMcpHosts.map { host -> "http://$host" }
 
         return embeddedServer(CIO, host = "0.0.0.0", port = port) {
             install(CallLogging)
@@ -424,6 +435,16 @@ object McpServerManager {
             }
             intercept(ApplicationCallPipeline.Plugins) {
                 if (call.request.path() == "/mcp") {
+                    if (!isAllowedMcpRequestAuthority(
+                            host = call.request.headers[HttpHeaders.Host].orEmpty(),
+                            origin = call.request.headers[HttpHeaders.Origin],
+                            allowedHosts = allowedMcpHosts,
+                        )
+                    ) {
+                        call.respond(HttpStatusCode.Forbidden, mapOf("error" to "Invalid MCP origin"))
+                        finish()
+                        return@intercept
+                    }
                     val bearerToken = call.request.headers[HttpHeaders.Authorization]
                         ?.removePrefix("Bearer ")
                         ?.trim()
@@ -444,7 +465,9 @@ object McpServerManager {
             }
             mcpStreamableHttp(
                 path = "/mcp",
-                enableDnsRebindingProtection = false,
+                enableDnsRebindingProtection = true,
+                allowedHosts = allowedMcpHosts,
+                allowedOrigins = allowedMcpOrigins,
             ) {
                 // This endpoint is the narrow ACP bridge: it intentionally
                 // publishes only AndroidDeviceMcpServer tools.  OmniBot's
@@ -485,6 +508,49 @@ object McpServerManager {
         }
     }
 
+    internal fun isAllowedMcpRequestAuthority(
+        host: String,
+        origin: String?,
+        allowedHosts: List<String>,
+    ): Boolean {
+        val allowed = allowedHosts.mapNotNull(::extractMcpHost).toSet()
+        if (extractMcpHost(host) !in allowed) return false
+        if (origin.isNullOrBlank()) return true
+        if (origin.equals("null", ignoreCase = true)) return false
+        val originHost = runCatching { URI(origin).host }
+            .getOrNull()
+            ?.let(::extractMcpHost)
+            ?: return false
+        return originHost in allowed
+    }
+
+    private fun extractMcpHost(value: String): String? {
+        val raw = value.trim()
+        if (raw.isEmpty() || raw.any { it.isWhitespace() || it in "/@?#" }) return null
+        val host = if (raw.startsWith("[")) {
+            val closingBracket = raw.indexOf(']')
+            if (closingBracket <= 1) return null
+            val suffix = raw.substring(closingBracket + 1)
+            if (suffix.isNotEmpty() &&
+                (!suffix.startsWith(":") || suffix.drop(1).any { !it.isDigit() })
+            ) {
+                return null
+            }
+            raw.substring(1, closingBracket)
+        } else {
+            val colon = raw.indexOf(':')
+            if (colon < 0) {
+                raw
+            } else {
+                if (colon == 0 || raw.indexOf(':', colon + 1) >= 0) return null
+                val port = raw.substring(colon + 1)
+                if (port.any { !it.isDigit() }) return null
+                raw.substring(0, colon)
+            }
+        }
+        return host.lowercase().takeIf(String::isNotBlank)
+    }
+
     private fun stopServerLocked() {
         runCatching {
             server?.stop(500, 1_500)
@@ -507,19 +573,10 @@ object McpServerManager {
 
     private fun resolveAdvertisedHost(): String? {
         val currentHost = resolveLanIp()
-        if (currentHost != null && isRunning) {
-            synchronized(serverLock) {
-                if (isRunning && activeHost != currentHost) {
-                    activeHost = currentHost
-                    mmkv.encode(PREF_HOST, currentHost)
-                }
-            }
-        }
-        if (currentHost != null) return currentHost
         return if (isRunning) {
             activeHost ?: mmkv.decodeString(PREF_HOST)
         } else {
-            null
+            currentHost
         }
     }
 

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/ModernMcpProtocol.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/ModernMcpProtocol.kt
@@ -18,10 +18,13 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+import java.util.Base64
 
 /**
  * Thin protocol boundary for MCP 2026-07-28.
@@ -51,7 +54,10 @@ internal object ModernMcpProtocol {
 
     internal fun isModernRequest(call: ApplicationCall): Boolean =
         call.request.path() == "/mcp" &&
-            call.request.headers[PROTOCOL_VERSION_HEADER] == PROTOCOL_VERSION
+            (
+                call.request.headers[PROTOCOL_VERSION_HEADER] == PROTOCOL_VERSION ||
+                    call.request.headers[METHOD_HEADER] != null
+                )
 
     internal suspend fun handle(
         call: ApplicationCall,
@@ -67,8 +73,7 @@ internal object ModernMcpProtocol {
         }
         val id = request["id"] ?: JsonNull
         val method = call.request.headers[METHOD_HEADER]
-            ?: request["method"]?.jsonPrimitive?.contentOrNull
-        val bodyMethod = request["method"]?.jsonPrimitive?.contentOrNull
+        val bodyMethod = (request["method"] as? JsonPrimitive)?.contentOrNull
         if (method.isNullOrBlank() || bodyMethod != method) {
             respondError(
                 call,
@@ -80,17 +85,27 @@ internal object ModernMcpProtocol {
             return
         }
         if (call.request.headers[PROTOCOL_VERSION_HEADER] != PROTOCOL_VERSION) {
+            val requested = call.request.headers[PROTOCOL_VERSION_HEADER]
+                ?.takeIf(String::isNotBlank)
+                ?: "unknown"
             respondError(
                 call,
                 id,
                 -32022,
                 "Unsupported MCP protocol version",
                 status = HttpStatusCode.BadRequest,
+                data = buildJsonObject {
+                    putJsonArray("supported") { add(JsonPrimitive(PROTOCOL_VERSION)) }
+                    put("requested", requested)
+                },
             )
             return
         }
-        val meta = request["_meta"]?.jsonObject
-        val metaVersion = meta?.get(META_PROTOCOL_VERSION)?.jsonPrimitive?.contentOrNull
+        val params = request["params"] as? JsonObject ?: JsonObject(emptyMap())
+        // MCP 2026 request metadata is scoped to params, matching RequestParams
+        // in the official schema. It is not a JSON-RPC envelope field.
+        val meta = params["_meta"] as? JsonObject
+        val metaVersion = (meta?.get(META_PROTOCOL_VERSION) as? JsonPrimitive)?.contentOrNull
         if (metaVersion != PROTOCOL_VERSION) {
             respondError(
                 call,
@@ -101,14 +116,25 @@ internal object ModernMcpProtocol {
             )
             return
         }
-        if (meta[META_CLIENT_INFO] !is JsonObject ||
-            meta[META_CLIENT_CAPABILITIES] !is JsonObject
-        ) {
+        // clientInfo is SHOULD/optional; clientCapabilities is required on
+        // every modern request and must not be inferred from an earlier call.
+        if (meta[META_CLIENT_CAPABILITIES] !is JsonObject) {
             respondError(
                 call,
                 id,
                 -32021,
                 "Modern MCP request metadata is incomplete",
+                status = HttpStatusCode.BadRequest,
+            )
+            return
+        }
+        val clientInfo = meta[META_CLIENT_INFO]
+        if (clientInfo != null && !isValidImplementation(clientInfo)) {
+            respondError(
+                call,
+                id,
+                -32602,
+                "Modern MCP clientInfo is invalid",
                 status = HttpStatusCode.BadRequest,
             )
             return
@@ -119,6 +145,9 @@ internal object ModernMcpProtocol {
                 call,
                 id,
                 buildJsonObject {
+                    put("resultType", "complete")
+                    put("ttlMs", 0)
+                    put("cacheScope", "private")
                     putJsonArray("supportedVersions") {
                         add(JsonPrimitive(PROTOCOL_VERSION))
                     }
@@ -141,6 +170,9 @@ internal object ModernMcpProtocol {
                     call,
                     id,
                     buildJsonObject {
+                        put("resultType", "complete")
+                        put("ttlMs", 0)
+                        put("cacheScope", "private")
                         putJsonArray("tools") {
                             tools.forEach { add(toolToJson(it)) }
                         }
@@ -150,9 +182,9 @@ internal object ModernMcpProtocol {
             }
 
             "tools/call" -> {
-                val params = request["params"]?.jsonObject.orEmpty()
-                val toolName = params["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
+                val toolName = (params["name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
                 val headerName = call.request.headers[NAME_HEADER]
+                    ?.let(::decodeMcpHeaderValue)
                 if (toolName.isBlank() || headerName != toolName) {
                     respondError(
                         call,
@@ -163,7 +195,7 @@ internal object ModernMcpProtocol {
                     )
                     return
                 }
-                val arguments = params["arguments"]?.jsonObject.orEmpty()
+                val arguments = params["arguments"] as? JsonObject ?: JsonObject(emptyMap())
                 val result = AndroidDeviceMcpServer.modernCallTool(
                     context = context,
                     scope = scope,
@@ -177,13 +209,25 @@ internal object ModernMcpProtocol {
                     call,
                     id,
                     buildJsonObject {
+                        put("resultType", "complete")
                         resultJson.forEach { (key, value) -> put(key, value) }
-                        putJsonObject("_meta") { put(META_SERVER_INFO, serverInfo) }
+                        putJsonObject("_meta") {
+                            (resultJson["_meta"] as? JsonObject)?.forEach { (key, value) ->
+                                put(key, value)
+                            }
+                            put(META_SERVER_INFO, serverInfo)
+                        }
                     },
                 )
             }
 
-            else -> respondError(call, id, -32601, "Method not found: $method")
+            else -> respondError(
+                call,
+                id,
+                -32601,
+                "Method not found: $method",
+                status = HttpStatusCode.NotFound,
+            )
         }
     }
 
@@ -201,6 +245,16 @@ internal object ModernMcpProtocol {
                 }
             }
         }
+
+    private fun isValidImplementation(value: JsonElement): Boolean {
+        val implementation = value as? JsonObject ?: return false
+        return (implementation["name"] as? JsonPrimitive)
+            ?.contentOrNull
+            ?.isNotBlank() == true &&
+            (implementation["version"] as? JsonPrimitive)
+                ?.contentOrNull
+                ?.isNotBlank() == true
+    }
 
     private suspend fun respondResult(
         call: ApplicationCall,
@@ -224,6 +278,7 @@ internal object ModernMcpProtocol {
         code: Int,
         message: String,
         status: HttpStatusCode = HttpStatusCode.OK,
+        data: JsonObject? = null,
     ) {
         call.respondText(
             text = buildJsonObject {
@@ -232,11 +287,37 @@ internal object ModernMcpProtocol {
                 putJsonObject("error") {
                     put("code", code)
                     put("message", message)
+                    data?.let { put("data", it) }
                 }
             }.toString(),
             contentType = ContentType.Application.Json,
             status = status,
         )
     }
+
+    /** Decode the header-safe sentinel required for non-ASCII MCP names. */
+    internal fun decodeMcpHeaderValue(value: String): String? {
+        if (!value.startsWith(BASE64_PREFIX) || !value.endsWith(BASE64_SUFFIX)) {
+            return value.takeIf { raw ->
+                raw == raw.trim() && raw.all { char -> char.code in 0x20..0x7e }
+            }
+        }
+        val encoded = value.substring(
+            BASE64_PREFIX.length,
+            value.length - BASE64_SUFFIX.length,
+        )
+        return runCatching {
+            val bytes = Base64.getDecoder().decode(encoded)
+            StandardCharsets.UTF_8
+                .newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString()
+        }.getOrNull()
+    }
+
+    private const val BASE64_PREFIX = "=?base64?"
+    private const val BASE64_SUFFIX = "?="
 
 }

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/RemoteMcpClient.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/RemoteMcpClient.kt
@@ -5,6 +5,8 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -20,11 +22,16 @@ import java.util.concurrent.TimeUnit
 object RemoteMcpClient {
     private const val TAG = "[RemoteMcpClient]"
     internal const val DEFAULT_PROTOCOL_VERSION = "2025-11-25"
+    internal const val MODERN_PROTOCOL_VERSION = "2026-07-28"
     private const val SESSION_ID_HEADER = "Mcp-Session-Id"
     private const val PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version"
     private val gson = Gson()
     private val mapType = object : TypeToken<Map<String, Any?>>() {}.type
     private val sessions = ConcurrentHashMap<String, RemoteMcpSession>()
+    private val initializationLocks = ConcurrentHashMap<String, Mutex>()
+    private val protocolProbeLocks = ConcurrentHashMap<String, Mutex>()
+    private val modernHeaderBindings =
+        ConcurrentHashMap<String, List<ModernHeaderBinding>>()
     private val client = OkHttpClient.Builder()
         .connectTimeout(20, TimeUnit.SECONDS)
         .readTimeout(40, TimeUnit.SECONDS)
@@ -41,54 +48,147 @@ object RemoteMcpClient {
     private data class RemoteMcpSession(
         val sessionId: String?,
         val protocolVersion: String = DEFAULT_PROTOCOL_VERSION,
+        val initialized: Boolean = false,
+        val initializeResult: Map<String, Any?> = emptyMap(),
+        val effectiveTransport: RemoteMcpTransport? = null,
+        val protocolEra: ProtocolEra = ProtocolEra.UNKNOWN,
+    )
+
+    private enum class ProtocolEra { UNKNOWN, MODERN, LEGACY }
+
+    private data class ModernHeaderBinding(
+        val name: String,
+        val path: List<String>,
+        val type: String,
     )
 
     private class HttpStatusException(
         val code: Int,
+        val responseBody: String = "",
+        override val message: String,
+    ) : IOException(message)
+
+    private class RpcErrorException(
+        val code: Int,
+        val data: Map<String, Any?>?,
         override val message: String,
     ) : IOException(message)
 
     suspend fun initialize(config: RemoteMcpServerConfig): Map<String, Any?> {
-        val result = callJsonRpc(
-            config = config,
-            method = "initialize",
-            params = mapOf(
-                "protocolVersion" to DEFAULT_PROTOCOL_VERSION,
-                "capabilities" to mapOf("tools" to emptyMap<String, Any>()),
-                "clientInfo" to mapOf("name" to "omnibot-android", "version" to "1.0")
-            )
-        )
-        if (!looksLikeSseEndpoint(config.endpointUrl)) {
-            runCatching {
-                callJsonRpc(config, "notifications/initialized", emptyMap())
-            }.onFailure {
-                OmniLog.w(TAG, "initialized notification failed: ${it.message}")
+        if (!usesSseTransport(config)) {
+            sessions[config.id]?.takeIf { it.initialized }?.let {
+                return it.initializeResult
             }
         }
-        return deepStringMap(result) ?: emptyMap()
+        val lock = initializationLocks.getOrPut(config.id) { Mutex() }
+        return lock.withLock {
+            if (!usesSseTransport(config)) {
+                sessions[config.id]?.takeIf { it.initialized }?.let {
+                    return@withLock it.initializeResult
+                }
+                // An initialize request starts a new legacy MCP lifecycle and
+                // must never carry a previously minted Mcp-Session-Id.
+                sessions.remove(config.id)
+            }
+            val result = callJsonRpc(
+                config = config,
+                method = "initialize",
+                params = mapOf(
+                    "protocolVersion" to DEFAULT_PROTOCOL_VERSION,
+                    "capabilities" to mapOf("tools" to emptyMap<String, Any>()),
+                    "clientInfo" to mapOf("name" to "omnibot-android", "version" to "1.0")
+                )
+            )
+            if (!usesSseTransport(config)) {
+                runCatching {
+                    callJsonRpc(config, "notifications/initialized", emptyMap())
+                }.onFailure {
+                    OmniLog.w(TAG, "initialized notification failed: ${it.message}")
+                }
+            }
+            val normalized = deepStringMap(result) ?: emptyMap()
+            updateSession(
+                serverId = config.id,
+                initialized = true,
+                initializeResult = normalized,
+                protocolEra = ProtocolEra.LEGACY,
+            )
+            normalized
+        }
     }
 
-    suspend fun listTools(config: RemoteMcpServerConfig): List<RemoteMcpToolDescriptor> {
-        val result = if (looksLikeSseEndpoint(config.endpointUrl)) {
+    suspend fun listTools(config: RemoteMcpServerConfig): List<RemoteMcpToolDescriptor> = try {
+        listToolsOnce(config)
+    } catch (error: HttpStatusException) {
+        val hasStatefulSession = sessions[config.id]?.sessionId != null
+        if (error.code != 404 || !hasStatefulSession) throw error
+        invalidateSession(config.id)
+        listToolsOnce(config)
+    }
+
+    private suspend fun listToolsOnce(
+        config: RemoteMcpServerConfig,
+    ): List<RemoteMcpToolDescriptor> {
+        val result = if (usesSseTransport(config)) {
             callSseMethodWithInitialize(config, "tools/list", emptyMap())
+        } else if (useModernProtocol(config)) {
+            callModernJsonRpc(config, "tools/list", emptyMap())
         } else {
             initialize(config)
-            callJsonRpc(config, "tools/list", emptyMap())
+            if (usesSseTransport(config)) {
+                callSseMethodWithInitialize(config, "tools/list", emptyMap())
+            } else {
+                callJsonRpc(config, "tools/list", emptyMap())
+            }
         }
+        return parseToolDescriptors(config, result)
+    }
+
+    suspend fun close(config: RemoteMcpServerConfig) {
+        try {
+            val session = sessions[config.id]
+            if (session?.sessionId != null &&
+                session.protocolEra == ProtocolEra.LEGACY &&
+                !usesSseTransport(config)
+            ) {
+                closeLegacyHttpSession(config)
+            }
+        } finally {
+            invalidateSession(config.id)
+        }
+    }
+
+    private fun parseToolDescriptors(
+        config: RemoteMcpServerConfig,
+        result: Any?,
+    ): List<RemoteMcpToolDescriptor> {
         val resultMap = deepStringMap(result) ?: emptyMap()
         val tools = (resultMap["tools"] as? List<*>) ?: emptyList<Any>()
         return tools.mapNotNull { raw ->
             val toolMap = deepStringMap(raw) ?: return@mapNotNull null
             val name = toolMap["name"]?.toString()?.trim().orEmpty()
             if (name.isBlank()) return@mapNotNull null
+            val inputSchema = deepStringMap(toolMap["inputSchema"])
+                ?: deepStringMap(toolMap["parameters"])
+                ?: emptyMap()
+            if (sessions[config.id]?.protocolEra == ProtocolEra.MODERN) {
+                val bindings = runCatching { collectModernHeaderBindings(inputSchema) }
+                    .onFailure { error ->
+                        OmniLog.w(
+                            TAG,
+                            "reject modern MCP tool ${config.name}/$name: ${error.message}",
+                        )
+                    }
+                    .getOrNull()
+                    ?: return@mapNotNull null
+                modernHeaderBindings[modernToolKey(config.id, name)] = bindings
+            }
             RemoteMcpToolDescriptor(
                 serverId = config.id,
                 serverName = config.name,
                 toolName = name,
                 description = toolMap["description"]?.toString()?.trim().orEmpty(),
-                inputSchema = deepStringMap(toolMap["inputSchema"])
-                    ?: deepStringMap(toolMap["parameters"])
-                    ?: emptyMap()
+                inputSchema = inputSchema,
             )
         }
     }
@@ -101,11 +201,32 @@ object RemoteMcpClient {
     ): RemoteMcpCallResult = try {
         callToolOnce(config, toolName, arguments, meta)
     } catch (error: HttpStatusException) {
-        if (error.code !in setOf(401, 403)) throw error
+        val hasStatefulSession = sessions[config.id]?.sessionId != null
+        if (error.code !in setOf(401, 403) && !(error.code == 404 && hasStatefulSession)) {
+            throw error
+        }
         // The local OmniLink gateway may restart independently of Omnibot.
         // Drop the stale MCP session and perform one bounded re-initialize so
         // background plugin polling recovers without user interaction.
         invalidateSession(config.id)
+        callToolOnce(config, toolName, arguments, meta)
+    } catch (error: RpcErrorException) {
+        if (error.code != HEADER_MISMATCH_ERROR ||
+            sessions[config.id]?.protocolEra != ProtocolEra.MODERN
+        ) {
+            throw error
+        }
+        // A modern server can change an x-mcp-header annotation after the
+        // client listed its tools. The protocol recovery is one fresh list
+        // followed by one retry with the updated mirrored headers.
+        modernHeaderBindings.remove(modernToolKey(config.id, toolName))
+        val refreshedTools = parseToolDescriptors(
+            config,
+            callModernJsonRpc(config, "tools/list", emptyMap()),
+        )
+        require(refreshedTools.any { it.toolName == toolName }) {
+            "MCP tool is no longer available after refreshing its schema: $toolName"
+        }
         callToolOnce(config, toolName, arguments, meta)
     }
 
@@ -125,19 +246,40 @@ object RemoteMcpClient {
             // those keys to remain retry-safe.
             if (meta.isNotEmpty()) put("_meta", meta)
         }
-        val result = if (looksLikeSseEndpoint(config.endpointUrl)) {
+        val result = if (usesSseTransport(config)) {
             callSseMethodWithInitialize(
                 config = config,
                 method = "tools/call",
                 params = params,
             )
-        } else {
-            initialize(config)
-            callJsonRpc(
+        } else if (useModernProtocol(config)) {
+            if (!modernHeaderBindings.containsKey(modernToolKey(config.id, toolName))) {
+                parseToolDescriptors(
+                    config,
+                    callModernJsonRpc(config, "tools/list", emptyMap()),
+                )
+            }
+            callModernJsonRpc(
                 config = config,
                 method = "tools/call",
-                params = params
+                params = params,
+                name = toolName,
             )
+        } else {
+            initialize(config)
+            if (usesSseTransport(config)) {
+                callSseMethodWithInitialize(
+                    config = config,
+                    method = "tools/call",
+                    params = params,
+                )
+            } else {
+                callJsonRpc(
+                    config = config,
+                    method = "tools/call",
+                    params = params
+                )
+            }
         }
         val rawJson = gson.toJson(result)
         return RemoteMcpCallResult(
@@ -151,9 +293,15 @@ object RemoteMcpClient {
     fun invalidateSession(serverId: String? = null) {
         if (serverId == null) {
             sessions.clear()
+            initializationLocks.clear()
+            protocolProbeLocks.clear()
+            modernHeaderBindings.clear()
             return
         }
         sessions.remove(serverId)
+        initializationLocks.remove(serverId)
+        protocolProbeLocks.remove(serverId)
+        modernHeaderBindings.keys.removeAll { it.startsWith("$serverId\u0000") }
     }
 
     private suspend fun callJsonRpc(
@@ -185,6 +333,7 @@ object RemoteMcpClient {
                 "Invalid MCP response: ${it.message}; preview=${responseBody.take(200)}"
             )
         }
+        requireMatchingResponseId(responseMap, requestId)
         val errorMap = deepStringMap(responseMap["error"])
         if (errorMap != null) {
             val errorMessage = errorMap["message"]?.toString()?.takeIf { it.isNotBlank() }
@@ -208,14 +357,19 @@ object RemoteMcpClient {
         requestId: String,
         expectResponse: Boolean,
     ): String {
-        if (looksLikeSseEndpoint(config.endpointUrl)) {
+        if (usesSseTransport(config)) {
             return executeSseRpc(config, payload, requestId, expectResponse)
         }
         return runCatching {
             executeHttpRpc(config, config.endpointUrl, payload, requestId, expectResponse)
         }.getOrElse { throwable ->
-            if (shouldTryLegacySseFallback(throwable)) {
-                return executeSseRpc(config, payload, requestId, expectResponse)
+            if (shouldTryLegacySseFallback(config, throwable)) {
+                val response = executeSseRpc(config, payload, requestId, expectResponse)
+                updateSession(
+                    serverId = config.id,
+                    effectiveTransport = RemoteMcpTransport.SSE,
+                )
+                return response
             }
             throw throwable
         }
@@ -233,10 +387,7 @@ object RemoteMcpClient {
             .header("Accept", "application/json, text/event-stream")
 
         applyMcpSessionHeaders(config, requestBuilder)
-
-        if (config.bearerToken.isNotBlank()) {
-            requestBuilder.header("Authorization", "Bearer ${config.bearerToken}")
-        }
+        applyConfiguredHeaders(config, requestBuilder)
 
         client.newCall(requestBuilder.build()).execute().use { response ->
             val responseBody = response.body?.string().orEmpty().trim()
@@ -246,6 +397,7 @@ object RemoteMcpClient {
             if (!response.isSuccessful) {
                 throw HttpStatusException(
                     code = response.code,
+                    responseBody = responseBody,
                     message = "HTTP ${response.code}: ${response.message}",
                 )
             }
@@ -255,6 +407,27 @@ object RemoteMcpClient {
                 contentType = contentType,
                 sessionId = sessionId,
             )
+        }
+    }
+
+    private suspend fun closeLegacyHttpSession(
+        config: RemoteMcpServerConfig,
+    ) = withContext(Dispatchers.IO) {
+        val requestBuilder = Request.Builder()
+            .url(config.endpointUrl)
+            .delete()
+            .header("Accept", "application/json, text/event-stream")
+        applyMcpSessionHeaders(config, requestBuilder)
+        applyConfiguredHeaders(config, requestBuilder)
+        client.newCall(requestBuilder.build()).execute().use { response ->
+            if (!response.isSuccessful && response.code !in setOf(404, 405)) {
+                val body = response.body?.string().orEmpty()
+                throw HttpStatusException(
+                    code = response.code,
+                    responseBody = body,
+                    message = "HTTP ${response.code}: ${response.message}",
+                )
+            }
         }
     }
 
@@ -272,10 +445,7 @@ object RemoteMcpClient {
             .header("Accept", "application/json, text/event-stream")
 
         applyMcpSessionHeaders(config, requestBuilder)
-
-        if (config.bearerToken.isNotBlank()) {
-            requestBuilder.header("Authorization", "Bearer ${config.bearerToken}")
-        }
+        applyConfiguredHeaders(config, requestBuilder)
 
         client.newCall(requestBuilder.build()).execute().use { response ->
             val contentType = response.header("Content-Type")
@@ -283,8 +453,10 @@ object RemoteMcpClient {
             updateSession(config.id, sessionId = sessionId)
 
             if (!response.isSuccessful) {
+                val errorBody = response.body?.string().orEmpty()
                 throw HttpStatusException(
                     code = response.code,
+                    responseBody = errorBody,
                     message = "HTTP ${response.code}: ${response.message}",
                 )
             }
@@ -320,14 +492,14 @@ object RemoteMcpClient {
             .header("Accept", "text/event-stream")
             .header("Cache-Control", "no-cache")
 
-        if (config.bearerToken.isNotBlank()) {
-            sseRequestBuilder.header("Authorization", "Bearer ${config.bearerToken}")
-        }
+        applyConfiguredHeaders(config, sseRequestBuilder)
 
         client.newCall(sseRequestBuilder.build()).execute().use { sseResponse ->
             if (!sseResponse.isSuccessful) {
+                val errorBody = sseResponse.body?.string().orEmpty()
                 throw HttpStatusException(
                     code = sseResponse.code,
+                    responseBody = errorBody,
                     message = "HTTP ${sseResponse.code}: ${sseResponse.message}",
                 )
             }
@@ -360,14 +532,14 @@ object RemoteMcpClient {
             .header("Accept", "text/event-stream")
             .header("Cache-Control", "no-cache")
 
-        if (config.bearerToken.isNotBlank()) {
-            sseRequestBuilder.header("Authorization", "Bearer ${config.bearerToken}")
-        }
+        applyConfiguredHeaders(config, sseRequestBuilder)
 
         client.newCall(sseRequestBuilder.build()).execute().use { sseResponse ->
             if (!sseResponse.isSuccessful) {
+                val errorBody = sseResponse.body?.string().orEmpty()
                 throw HttpStatusException(
                     code = sseResponse.code,
+                    responseBody = errorBody,
                     message = "HTTP ${sseResponse.code}: ${sseResponse.message}",
                 )
             }
@@ -450,20 +622,398 @@ object RemoteMcpClient {
         serverId: String,
         sessionId: String? = null,
         protocolVersion: String? = null,
+        initialized: Boolean? = null,
+        initializeResult: Map<String, Any?>? = null,
+        effectiveTransport: RemoteMcpTransport? = null,
+        protocolEra: ProtocolEra? = null,
     ) {
-        if (sessionId == null && protocolVersion == null) return
+        if (
+            sessionId == null &&
+            protocolVersion == null &&
+            initialized == null &&
+            initializeResult == null &&
+            effectiveTransport == null
+            && protocolEra == null
+        ) return
         sessions.compute(serverId) { _, current ->
             RemoteMcpSession(
                 sessionId = sessionId ?: current?.sessionId,
                 protocolVersion = protocolVersion ?: current?.protocolVersion ?: DEFAULT_PROTOCOL_VERSION,
+                initialized = initialized ?: current?.initialized ?: false,
+                initializeResult = initializeResult ?: current?.initializeResult.orEmpty(),
+                effectiveTransport = effectiveTransport ?: current?.effectiveTransport,
+                protocolEra = protocolEra ?: current?.protocolEra ?: ProtocolEra.UNKNOWN,
             )
         }
     }
 
-    private fun shouldTryLegacySseFallback(throwable: Throwable): Boolean {
+    private fun shouldTryLegacySseFallback(
+        config: RemoteMcpServerConfig,
+        throwable: Throwable,
+    ): Boolean {
+        if (config.transport != RemoteMcpTransport.AUTO) return false
         if (throwable !is HttpStatusException) return false
-        return throwable.code == 404 || throwable.code == 405
+        if (sessions[config.id]?.initialized == true) return false
+        if (throwable.code !in setOf(404, 405)) return false
+        return !isRecognizedModernError(throwable.responseBody)
     }
+
+    private fun usesSseTransport(config: RemoteMcpServerConfig): Boolean {
+        return config.transport == RemoteMcpTransport.SSE ||
+            sessions[config.id]?.effectiveTransport == RemoteMcpTransport.SSE ||
+            (
+                config.transport == RemoteMcpTransport.AUTO &&
+                    looksLikeSseEndpoint(config.endpointUrl)
+                )
+    }
+
+    private fun applyConfiguredHeaders(
+        config: RemoteMcpServerConfig,
+        requestBuilder: Request.Builder,
+    ) {
+        config.headers.forEach { (name, value) ->
+            val normalizedName = name.lowercase()
+            if (name.isNotBlank() &&
+                normalizedName !in RESERVED_TRANSPORT_HEADERS &&
+                !normalizedName.startsWith("mcp-param-")
+            ) {
+                requestBuilder.header(name, value)
+            }
+        }
+        val hasAuthorization = config.headers.keys.any {
+            it.equals("Authorization", ignoreCase = true)
+        }
+        if (!hasAuthorization && config.bearerToken.isNotBlank()) {
+            requestBuilder.header("Authorization", "Bearer ${config.bearerToken.trim()}")
+        }
+    }
+
+    private suspend fun useModernProtocol(config: RemoteMcpServerConfig): Boolean {
+        if (usesSseTransport(config)) return false
+        when (sessions[config.id]?.protocolEra) {
+            ProtocolEra.MODERN -> return true
+            ProtocolEra.LEGACY -> return false
+            else -> Unit
+        }
+        val lock = protocolProbeLocks.getOrPut(config.id) { Mutex() }
+        return lock.withLock {
+            when (sessions[config.id]?.protocolEra) {
+                ProtocolEra.MODERN -> return@withLock true
+                ProtocolEra.LEGACY -> return@withLock false
+                else -> Unit
+            }
+            try {
+                val result = callModernJsonRpc(config, "server/discover", emptyMap())
+                val supported = (deepStringMap(result)?.get("supportedVersions") as? List<*>)
+                    .orEmpty()
+                    .map(Any?::toString)
+                if (MODERN_PROTOCOL_VERSION !in supported) {
+                    updateSession(config.id, protocolEra = ProtocolEra.LEGACY)
+                    false
+                } else {
+                    updateSession(
+                        serverId = config.id,
+                        protocolVersion = MODERN_PROTOCOL_VERSION,
+                        protocolEra = ProtocolEra.MODERN,
+                    )
+                    true
+                }
+            } catch (error: Throwable) {
+                if (!isLegacyModernProbeResponse(error)) throw error
+                OmniLog.i(
+                    TAG,
+                    "Modern MCP discovery unavailable for ${config.name}; " +
+                        "falling back to legacy initialize (${probeFailureKind(error)})",
+                )
+                updateSession(config.id, protocolEra = ProtocolEra.LEGACY)
+                false
+            }
+        }
+    }
+
+    private suspend fun callModernJsonRpc(
+        config: RemoteMcpServerConfig,
+        method: String,
+        params: Map<String, Any?>,
+        name: String? = null,
+    ): Any? {
+        val requestId = UUID.randomUUID().toString()
+        val requestParams = LinkedHashMap(params)
+        val callerMeta = deepStringMap(requestParams["_meta"]).orEmpty()
+        requestParams["_meta"] = callerMeta + mapOf(
+            "io.modelcontextprotocol/protocolVersion" to MODERN_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientInfo" to mapOf(
+                "name" to "omnibot-android",
+                "version" to "1.0",
+            ),
+            "io.modelcontextprotocol/clientCapabilities" to emptyMap<String, Any?>(),
+        )
+        val payload = gson.toJson(
+            mapOf(
+                "jsonrpc" to "2.0",
+                "id" to requestId,
+                "method" to method,
+                "params" to requestParams,
+            )
+        )
+        val responseBody = executeModernHttpRpc(
+            config = config,
+            payload = payload,
+            requestId = requestId,
+            method = method,
+            name = name,
+            mirroredHeaders = if (method == "tools/call" && name != null) {
+                buildModernParameterHeaders(
+                    configId = config.id,
+                    toolName = name,
+                    arguments = deepStringMap(requestParams["arguments"]).orEmpty(),
+                )
+            } else {
+                emptyMap()
+            },
+        )
+        val responseMap = parseJsonMap(responseBody)
+        requireMatchingResponseId(responseMap, requestId)
+        val error = deepStringMap(responseMap["error"])
+        if (error != null) {
+            throw RpcErrorException(
+                code = (error["code"] as? Number)?.toInt()
+                    ?: error["code"]?.toString()?.toIntOrNull()
+                    ?: -32603,
+                data = deepStringMap(error["data"]),
+                message = error["message"]?.toString() ?: "Unknown MCP error",
+            )
+        }
+        val result = responseMap["result"]
+        val resultType = deepStringMap(result)?.get("resultType")?.toString()
+        when (resultType) {
+            "complete" -> Unit
+            "input_required" -> throw IllegalStateException(
+                "MCP server requires a multi-round-trip input that this Agent cannot provide yet"
+            )
+            else -> throw IllegalStateException(
+                "Modern MCP response has an unsupported resultType: ${resultType ?: "missing"}"
+            )
+        }
+        return result
+    }
+
+    private suspend fun executeModernHttpRpc(
+        config: RemoteMcpServerConfig,
+        payload: String,
+        requestId: String,
+        method: String,
+        name: String?,
+        mirroredHeaders: Map<String, String>,
+    ): String = withContext(Dispatchers.IO) {
+        val requestBuilder = Request.Builder()
+            .url(config.endpointUrl)
+            .post(payload.toRequestBody(jsonMediaType))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header(PROTOCOL_VERSION_HEADER, MODERN_PROTOCOL_VERSION)
+            .header("Mcp-Method", method)
+        if (name != null) requestBuilder.header("Mcp-Name", encodeMcpHeaderValue(name))
+        mirroredHeaders.forEach { (headerName, value) ->
+            requestBuilder.header(headerName, value)
+        }
+        applyConfiguredHeaders(config, requestBuilder)
+
+        client.newCall(requestBuilder.build()).execute().use { response ->
+            val contentType = response.header("Content-Type")
+            val responseBody = response.body?.string().orEmpty().trim()
+            if (!response.isSuccessful) {
+                if (response.code == 400 && isJsonRpcErrorForRequest(responseBody, requestId)) {
+                    return@withContext responseBody
+                }
+                throw HttpStatusException(
+                    code = response.code,
+                    responseBody = responseBody,
+                    message = "HTTP ${response.code}: ${response.message}",
+                )
+            }
+            if (responseBody.isBlank()) return@withContext "{}"
+            if (isEventStream(contentType) || looksLikeSseBody(responseBody)) {
+                return@withContext parseSseJsonResponseBody(responseBody, requestId)
+            }
+            responseBody
+        }
+    }
+
+    private fun isLegacyModernProbeResponse(error: Throwable): Boolean {
+        return when (error) {
+            // Discovery is the protocol-era probe. A JSON-RPC error proves
+            // that an MCP endpoint answered, but not that it implements the
+            // modern discovery contract. Only modern request/header errors
+            // should stop instead of trying the legacy initialize handshake.
+            is RpcErrorException -> error.code !in MODERN_REQUEST_ERROR_CODES
+            is HttpStatusException -> {
+                if (error.code !in setOf(400, 404, 405)) return false
+                val modernCode = modernErrorCode(error.responseBody)
+                modernCode == null || modernCode !in MODERN_REQUEST_ERROR_CODES
+            }
+            else -> false
+        }
+    }
+
+    private fun probeFailureKind(error: Throwable): String {
+        return when (error) {
+            is RpcErrorException -> "rpc=${error.code}"
+            is HttpStatusException -> "http=${error.code}"
+            else -> error::class.java.simpleName
+        }
+    }
+
+    private fun isRecognizedModernError(body: String): Boolean {
+        val code = modernErrorCode(body) ?: return false
+        return code in setOf(-32020, -32021, -32022, -32601)
+    }
+
+    private fun modernErrorCode(body: String): Int? {
+        val error = runCatching {
+            deepStringMap(parseJsonMap(body)["error"])
+        }.getOrNull() ?: return null
+        return (error["code"] as? Number)?.toInt()
+            ?: error["code"]?.toString()?.toIntOrNull()
+    }
+
+    private fun isJsonRpcErrorForRequest(body: String, requestId: String): Boolean {
+        val response = runCatching { parseJsonMap(body) }.getOrNull() ?: return false
+        if (deepStringMap(response["error"]) == null) return false
+        return response["id"]?.toString() == requestId
+    }
+
+    private fun requireMatchingResponseId(
+        response: Map<String, Any?>,
+        requestId: String,
+    ) {
+        require(response["id"]?.toString() == requestId) {
+            "MCP response id does not match request id"
+        }
+    }
+
+    internal fun encodeMcpHeaderValue(value: String): String {
+        val safe = value == value.trim() &&
+            value.all { character -> character.code in 0x20..0x7e } &&
+            !(value.startsWith("=?base64?") && value.endsWith("?="))
+        if (safe) return value
+        val encoded = java.util.Base64.getEncoder()
+            .encodeToString(value.toByteArray(Charsets.UTF_8))
+        return "=?base64?$encoded?="
+    }
+
+    private fun collectModernHeaderBindings(
+        schema: Map<String, Any?>,
+    ): List<ModernHeaderBinding> {
+        val bindings = mutableListOf<ModernHeaderBinding>()
+        val usedNames = linkedSetOf<String>()
+
+        fun rejectNestedAnnotation(value: Any?) {
+            when (value) {
+                is Map<*, *> -> {
+                    require("x-mcp-header" !in value.keys.map(Any?::toString)) {
+                        "x-mcp-header is only valid on schemas reached through properties"
+                    }
+                    value.values.forEach(::rejectNestedAnnotation)
+                }
+                is Iterable<*> -> value.forEach(::rejectNestedAnnotation)
+            }
+        }
+
+        fun visit(node: Map<String, Any?>, path: List<String>) {
+            val annotation = node["x-mcp-header"]?.toString()
+            if (annotation != null) {
+                require(path.isNotEmpty()) { "x-mcp-header cannot annotate the schema root" }
+                require(annotation.isNotEmpty() && HTTP_TOKEN.matches(annotation)) {
+                    "invalid x-mcp-header name: $annotation"
+                }
+                require(usedNames.add(annotation.lowercase())) {
+                    "duplicate x-mcp-header name: $annotation"
+                }
+                val type = node["type"]?.toString().orEmpty()
+                require(type == "string" || type == "integer" || type == "boolean") {
+                    "x-mcp-header parameter must be string, integer, or boolean"
+                }
+                bindings += ModernHeaderBinding(annotation, path, type)
+            }
+
+            val properties = deepStringMap(node["properties"]).orEmpty()
+            properties.forEach { (name, child) ->
+                val childSchema = deepStringMap(child) ?: return@forEach
+                visit(childSchema, path + name)
+            }
+            node.forEach { (key, value) ->
+                if (key != "properties" && key != "x-mcp-header") {
+                    rejectNestedAnnotation(value)
+                }
+            }
+        }
+
+        visit(schema, emptyList())
+        return bindings
+    }
+
+    private fun buildModernParameterHeaders(
+        configId: String,
+        toolName: String,
+        arguments: Map<String, Any?>,
+    ): Map<String, String> {
+        val bindings = modernHeaderBindings[modernToolKey(configId, toolName)].orEmpty()
+        return buildMap {
+            bindings.forEach { binding ->
+                var current: Any? = arguments
+                binding.path.forEach { segment ->
+                    current = deepStringMap(current)?.get(segment)
+                }
+                if (current == null) return@forEach
+                val raw = when (binding.type) {
+                    "string" -> current as? String
+                        ?: throw IllegalArgumentException(
+                            "MCP header parameter ${binding.path.joinToString(".")} must be string"
+                        )
+                    "boolean" -> (current as? Boolean)?.toString()
+                        ?: throw IllegalArgumentException(
+                            "MCP header parameter ${binding.path.joinToString(".")} must be boolean"
+                        )
+                    "integer" -> modernIntegerHeaderValue(current, binding.path)
+                    else -> error("Unsupported MCP header parameter type: ${binding.type}")
+                }
+                put("Mcp-Param-${binding.name}", encodeMcpHeaderValue(raw))
+            }
+        }
+    }
+
+    private fun modernIntegerHeaderValue(value: Any, path: List<String>): String {
+        val number = value as? Number ?: throw IllegalArgumentException(
+            "MCP header parameter ${path.joinToString(".")} must be integer"
+        )
+        val asDouble = number.toDouble()
+        require(asDouble.isFinite() && asDouble % 1.0 == 0.0) {
+            "MCP header parameter ${path.joinToString(".")} must be integer"
+        }
+        require(kotlin.math.abs(asDouble) <= MAX_SAFE_INTEGER.toDouble()) {
+            "MCP header parameter ${path.joinToString(".")} exceeds the safe integer range"
+        }
+        return asDouble.toLong().toString()
+    }
+
+    private fun modernToolKey(configId: String, toolName: String): String =
+        "$configId\u0000$toolName"
+
+    private val RESERVED_TRANSPORT_HEADERS = setOf(
+        "host",
+        "content-length",
+        "content-type",
+        "accept",
+        "mcp-protocol-version",
+        "mcp-session-id",
+        "mcp-method",
+        "mcp-name",
+    )
+    private val HTTP_TOKEN = Regex("[!#$%&'*+.^_`|~0-9A-Za-z-]+")
+    private val MODERN_REQUEST_ERROR_CODES = setOf(-32020, -32021)
+    private const val MAX_SAFE_INTEGER = 9_007_199_254_740_991L
+    private const val HEADER_MISMATCH_ERROR = -32020
 
     private fun isEventStream(contentType: String?): Boolean {
         return contentType

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/RemoteMcpConfigStore.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/RemoteMcpConfigStore.kt
@@ -12,14 +12,12 @@ object RemoteMcpConfigStore {
     private val gson = Gson()
     private val mmkv: MMKV?
         get() = MMKV.defaultMMKV()
-    private val listType = object : TypeToken<List<RemoteMcpServerConfig>>() {}.type
+    private val persistedListType = object : TypeToken<List<Map<String, Any?>>>() {}.type
 
     fun listServers(): List<RemoteMcpServerConfig> {
         ensureMigrated()
         val saved = mmkv?.decodeString(GLOBAL_KEY) ?: return emptyList()
-        return runCatching {
-            gson.fromJson<List<RemoteMcpServerConfig>>(saved, listType) ?: emptyList()
-        }.getOrDefault(emptyList())
+        return decodeServersJson(saved)
     }
 
     fun getServer(serverId: String): RemoteMcpServerConfig? {
@@ -103,6 +101,20 @@ object RemoteMcpConfigStore {
 
     private fun saveServers(servers: List<RemoteMcpServerConfig>) {
         mmkv?.encode(GLOBAL_KEY, gson.toJson(servers))
+    }
+
+    /**
+     * Persisted entries predate some fields on [RemoteMcpServerConfig]. Gson
+     * allocates Kotlin classes without invoking their default constructor, so
+     * decoding directly into the data class can leave non-null fields null at
+     * runtime. Rebuild every entry through the compatibility boundary instead.
+     */
+    internal fun decodeServersJson(saved: String): List<RemoteMcpServerConfig> {
+        return runCatching {
+            val persisted = gson.fromJson<List<Map<String, Any?>>>(saved, persistedListType)
+                ?: emptyList()
+            persisted.map(RemoteMcpServerConfig::fromMap)
+        }.getOrDefault(emptyList())
     }
 
     private fun ensureMigrated() {

--- a/app/src/main/java/cn/com/omnimind/bot/mcp/RemoteMcpModels.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/mcp/RemoteMcpModels.kt
@@ -9,7 +9,25 @@ enum class RemoteMcpHealth(val value: String) {
 
     companion object {
         fun fromValue(value: String?): RemoteMcpHealth {
-            return entries.firstOrNull { it.value == value } ?: UNKNOWN
+            return entries.firstOrNull {
+                it.value.equals(value, ignoreCase = true) ||
+                    it.name.equals(value, ignoreCase = true)
+            } ?: UNKNOWN
+        }
+    }
+}
+
+enum class RemoteMcpTransport(val value: String) {
+    AUTO("auto"),
+    HTTP("http"),
+    SSE("sse");
+
+    companion object {
+        fun fromValue(value: String?): RemoteMcpTransport {
+            return entries.firstOrNull {
+                it.value.equals(value, ignoreCase = true) ||
+                    it.name.equals(value, ignoreCase = true)
+            } ?: AUTO
         }
     }
 }
@@ -19,6 +37,10 @@ data class RemoteMcpServerConfig(
     val name: String,
     val endpointUrl: String,
     val bearerToken: String = "",
+    /** ACP session declarations may carry arbitrary HTTP headers. */
+    val headers: Map<String, String> = emptyMap(),
+    /** Explicit for ACP `sse`; AUTO preserves URL-based legacy discovery. */
+    val transport: RemoteMcpTransport = RemoteMcpTransport.AUTO,
     val enabled: Boolean = true,
     val lastHealth: RemoteMcpHealth = RemoteMcpHealth.UNKNOWN,
     val lastError: String? = null,
@@ -31,6 +53,8 @@ data class RemoteMcpServerConfig(
             "name" to name,
             "endpointUrl" to endpointUrl,
             "bearerToken" to bearerToken,
+            "headers" to headers,
+            "transport" to transport.value,
             "enabled" to enabled,
             "lastHealth" to lastHealth.value,
             "lastError" to lastError,
@@ -56,6 +80,16 @@ data class RemoteMcpServerConfig(
                 name = raw["name"]?.toString()?.trim().orEmpty(),
                 endpointUrl = raw["endpointUrl"]?.toString()?.trim().orEmpty(),
                 bearerToken = raw["bearerToken"]?.toString() ?: "",
+                headers = (raw["headers"] as? Map<*, *>)
+                    ?.entries
+                    ?.mapNotNull { (key, value) ->
+                        val name = key?.toString()?.trim().orEmpty()
+                        val headerValue = value?.toString() ?: return@mapNotNull null
+                        name.takeIf(String::isNotEmpty)?.let { it to headerValue }
+                    }
+                    ?.toMap()
+                    .orEmpty(),
+                transport = RemoteMcpTransport.fromValue(raw["transport"]?.toString()),
                 enabled = raw["enabled"] != false,
                 lastHealth = RemoteMcpHealth.fromValue(raw["lastHealth"]?.toString()),
                 lastError = raw["lastError"]?.toString()?.takeIf { it.isNotBlank() },

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/ChannelManager.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/ChannelManager.kt
@@ -83,7 +83,7 @@ class ChannelManager {
         hideFromRecentsChannel.onCreate(context)
         appUpdateChannel.onCreate(context)
         mcpServerChannel.onCreate(context)
-        remoteMcpConfigChannel.onCreate()
+        remoteMcpConfigChannel.onCreate(context)
         overlayChannel.onCreate(context)
         storageUsageChannel.onCreate(context)
         agentRuntimeChannel.onCreate(context)

--- a/app/src/main/java/cn/com/omnimind/bot/ui/channel/RemoteMcpConfigChannel.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/ui/channel/RemoteMcpConfigChannel.kt
@@ -1,6 +1,9 @@
 package cn.com.omnimind.bot.ui.channel
 
+import android.content.Context
 import cn.com.omnimind.baselib.util.OmniLog
+import cn.com.omnimind.bot.App
+import cn.com.omnimind.bot.agent.runtime.AgentRuntimeManager
 import cn.com.omnimind.bot.mcp.RemoteMcpConfigStore
 import cn.com.omnimind.bot.mcp.RemoteMcpDiscoveryRegistry
 import cn.com.omnimind.bot.mcp.RemoteMcpServerConfig
@@ -15,8 +18,11 @@ class RemoteMcpConfigChannel {
     private val channelName = "cn.com.omnimind.bot/RemoteMcpConfig"
     private val scope = CoroutineScope(Dispatchers.IO)
     private var channel: MethodChannel? = null
+    private var appContext: Context? = null
 
-    fun onCreate() = Unit
+    fun onCreate(context: Context) {
+        appContext = context.applicationContext
+    }
 
     fun setChannel(flutterEngine: FlutterEngine) {
         channel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
@@ -31,21 +37,22 @@ class RemoteMcpConfigChannel {
                             val raw = call.arguments<Map<String, Any?>>() ?: emptyMap()
                             val saved = RemoteMcpConfigStore.upsertServer(RemoteMcpServerConfig.fromMap(raw))
                             RemoteMcpDiscoveryRegistry.invalidate(saved.id)
+                            invalidateAcpMcpSessions()
                             respondSuccess(result, saved.toMap())
                         }
                         "deleteServer" -> {
                             val serverId = call.argument<String>("id").orEmpty()
                             RemoteMcpConfigStore.deleteServer(serverId)
                             RemoteMcpDiscoveryRegistry.invalidate(serverId)
+                            invalidateAcpMcpSessions()
                             respondSuccess(result, true)
                         }
                         "setServerEnabled" -> {
                             val serverId = call.argument<String>("id").orEmpty()
                             val enabled = call.argument<Boolean>("enabled") == true
                             val updated = RemoteMcpConfigStore.setServerEnabled(serverId, enabled)
-                            if (!enabled) {
-                                RemoteMcpDiscoveryRegistry.invalidate(serverId)
-                            }
+                            RemoteMcpDiscoveryRegistry.invalidate(serverId)
+                            invalidateAcpMcpSessions()
                             respondSuccess(result, updated?.toMap())
                         }
                         "refreshServerTools" -> {
@@ -64,7 +71,7 @@ class RemoteMcpConfigChannel {
                         else -> withContext(Dispatchers.Main) { result.notImplemented() }
                     }
                 } catch (t: Throwable) {
-                    OmniLog.e("[RemoteMcpConfigChannel]", "channel error: ${t.message}")
+                    OmniLog.e("[RemoteMcpConfigChannel]", "channel error: ${t.message}", t)
                     withContext(Dispatchers.Main) {
                         result.error("REMOTE_MCP_ERROR", t.message, null)
                     }
@@ -76,11 +83,17 @@ class RemoteMcpConfigChannel {
     fun clear() {
         channel?.setMethodCallHandler(null)
         channel = null
+        appContext = null
     }
 
     private suspend fun respondSuccess(result: MethodChannel.Result, value: Any?) {
         withContext(Dispatchers.Main) {
             result.success(value)
         }
+    }
+
+    private suspend fun invalidateAcpMcpSessions() {
+        val context = appContext ?: App.instance.applicationContext
+        AgentRuntimeManager.getInstance(context).invalidateMcpConfiguration()
     }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeMcpTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentRuntimeMcpTest.kt
@@ -68,13 +68,50 @@ class AgentRuntimeMcpTest {
                     endpointUrl = "https://mcp.example.test/sse",
                 ),
             ),
+            supportsHttp = true,
+            supportsSse = true,
         )
 
-        assertEquals(1, servers.size)
+        assertEquals(2, servers.size)
         val first = servers.first() as McpServer.Http
         assertEquals("Filesystem", first.name)
         assertEquals("https://mcp.example.test/mcp", first.url)
         assertEquals("Bearer remote-token", first.headers.single().value)
+        val second = servers[1] as McpServer.Sse
+        assertEquals("Legacy SSE", second.name)
+        assertEquals("https://mcp.example.test/sse", second.url)
+    }
+
+    @Test
+    fun configuredRemoteMcpServersRespectNegotiatedTransportCapabilities() {
+        val configured = listOf(
+            RemoteMcpServerConfig(
+                id = "http",
+                name = "HTTP",
+                endpointUrl = "https://mcp.example.test/mcp",
+            ),
+            RemoteMcpServerConfig(
+                id = "sse",
+                name = "SSE",
+                endpointUrl = "https://mcp.example.test/events",
+                transport = cn.com.omnimind.bot.mcp.RemoteMcpTransport.SSE,
+            ),
+        )
+
+        assertTrue(
+            buildConfiguredRemoteAcpMcpServers(
+                configured,
+                supportsHttp = true,
+                supportsSse = false,
+            ).single() is McpServer.Http
+        )
+        assertTrue(
+            buildConfiguredRemoteAcpMcpServers(
+                configured,
+                supportsHttp = false,
+                supportsSse = true,
+            ).single() is McpServer.Sse
+        )
     }
 
     @Test

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/XiaowanAcpConnectionTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/XiaowanAcpConnectionTest.kt
@@ -1,14 +1,61 @@
 package cn.com.omnimind.bot.agent.runtime
 
+import cn.com.omnimind.bot.mcp.RemoteMcpCallResult
+import cn.com.omnimind.bot.mcp.RemoteMcpToolDescriptor
 import com.agentclientprotocol.model.ContentBlock
 import com.agentclientprotocol.model.SessionUpdate
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class XiaowanAcpConnectionTest {
+
+    @Test
+    fun `xiaowan advertises only the ACP lifecycle and MCP transports it implements`() {
+        val capabilities = xiaowanAgentCapabilities()
+
+        assertFalse(capabilities.loadSession)
+        assertTrue(capabilities.mcpCapabilities.http)
+        assertTrue(capabilities.mcpCapabilities.sse)
+        assertNotNull(capabilities.sessionCapabilities.list)
+        assertNotNull(capabilities.sessionCapabilities.resume)
+        assertNotNull(capabilities.sessionCapabilities.delete)
+        assertNotNull(capabilities.sessionCapabilities.close)
+        assertNull(capabilities.sessionCapabilities.fork)
+    }
+
+    @Test
+    fun `session MCP tools receive safe unique model names and MCP metadata`() {
+        val connection = fakeMcpConnection("session-server", "团队 MCP")
+        val descriptor = RemoteMcpToolDescriptor(
+            serverId = connection.connectionId,
+            serverName = connection.serverName,
+            toolName = "查询/天气",
+            description = "查询天气",
+            inputSchema = mapOf("type" to "object"),
+        )
+        val bindings = buildXiaowanMcpToolBindings(
+            listOf(
+                XiaowanMcpDiscoveredTool(connection, descriptor),
+                XiaowanMcpDiscoveredTool(connection, descriptor),
+            )
+        )
+
+        assertEquals(2, bindings.map { it.modelToolName }.distinct().size)
+        bindings.forEach { binding ->
+            assertTrue(binding.modelToolName.length <= 64)
+            assertTrue(binding.modelToolName.matches(Regex("[A-Za-z0-9_-]+")))
+        }
+        val module = XiaowanMcpCapabilityModule(bindings)
+        assertEquals(setOf("mcp"), module.toolDefinitions.map { it.toolType }.toSet())
+        assertEquals(setOf("团队 MCP"), module.toolDefinitions.map { it.serverName }.toSet())
+        assertEquals(bindings.map { it.modelToolName }.toSet(), module.handlers.single().toolNames)
+    }
 
     @Test
     fun `xiaowan adapter uses canonical reasoning aliases and provider levels`() {
@@ -38,5 +85,24 @@ class XiaowanAcpConnectionTest {
         }
         assertEquals(2, contentUpdates.size)
         assertNotEquals(contentUpdates[0].content, contentUpdates[1].content)
+    }
+
+    private fun fakeMcpConnection(
+        id: String,
+        name: String,
+    ): XiaowanMcpServerConnection = object : XiaowanMcpServerConnection {
+        override val connectionId: String = id
+        override val serverName: String = name
+
+        override suspend fun start() = Unit
+
+        override suspend fun listTools(): List<RemoteMcpToolDescriptor> = emptyList()
+
+        override suspend fun callTool(
+            toolName: String,
+            arguments: Map<String, Any?>,
+        ): RemoteMcpCallResult = error("not used")
+
+        override suspend fun close() = Unit
     }
 }

--- a/app/src/test/java/cn/com/omnimind/bot/mcp/McpServerPortAvailabilityTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/mcp/McpServerPortAvailabilityTest.kt
@@ -9,6 +9,55 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class McpServerPortAvailabilityTest {
+
+    @Test
+    fun `MCP authority validation permits loopback and LAN but rejects rebinding origins`() {
+        val allowed = listOf("127.0.0.1", "192.168.1.20", "localhost", "[::1]")
+
+        assertTrue(
+            McpServerManager.isAllowedMcpRequestAuthority(
+                host = "192.168.1.20:8899",
+                origin = "http://192.168.1.20:8899",
+                allowedHosts = allowed,
+            )
+        )
+        assertTrue(
+            McpServerManager.isAllowedMcpRequestAuthority(
+                host = "127.0.0.1",
+                origin = null,
+                allowedHosts = allowed,
+            )
+        )
+        assertTrue(
+            McpServerManager.isAllowedMcpRequestAuthority(
+                host = "[::1]:8899",
+                origin = "http://[::1]:8899",
+                allowedHosts = allowed,
+            )
+        )
+        assertFalse(
+            McpServerManager.isAllowedMcpRequestAuthority(
+                host = "127.0.0.1",
+                origin = "https://attacker.example",
+                allowedHosts = allowed,
+            )
+        )
+        assertFalse(
+            McpServerManager.isAllowedMcpRequestAuthority(
+                host = "attacker.example",
+                origin = null,
+                allowedHosts = allowed,
+            )
+        )
+        assertFalse(
+            McpServerManager.isAllowedMcpRequestAuthority(
+                host = "attacker.example@127.0.0.1",
+                origin = null,
+                allowedHosts = allowed,
+            )
+        )
+    }
+
     @Test
     fun occupiedPortIsRejectedBeforeStartingKtor() {
         ServerSocket().use { socket ->

--- a/app/src/test/java/cn/com/omnimind/bot/mcp/RemoteMcpClientInteropTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/mcp/RemoteMcpClientInteropTest.kt
@@ -1,0 +1,446 @@
+package cn.com.omnimind.bot.mcp
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class RemoteMcpClientInteropTest {
+    private lateinit var server: MockWebServer
+    private lateinit var config: RemoteMcpServerConfig
+    private val responsePlans = ConcurrentLinkedQueue<ResponsePlan>()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val plan = responsePlans.poll()
+                    ?: return MockResponse().setResponseCode(500).setBody("No response planned")
+                val body = if (plan.echoRequestId && plan.body.isNotBlank()) {
+                    val requestId = runCatching {
+                        Json.parseToJsonElement(request.body.clone().readUtf8()).jsonObject["id"]
+                    }.getOrNull() ?: JsonNull
+                    val response = Json.parseToJsonElement(plan.body).jsonObject
+                    JsonObject(response + ("id" to requestId)).toString()
+                } else {
+                    plan.body
+                }
+                val response = MockResponse()
+                    .setResponseCode(plan.code)
+                    .setBody(body)
+                plan.headers.forEach { (name, value) -> response.setHeader(name, value) }
+                return response
+            }
+        }
+        server.start()
+        config = RemoteMcpServerConfig(
+            id = "interop-${System.nanoTime()}",
+            name = "interop",
+            endpointUrl = server.url("/mcp").toString(),
+            headers = mapOf("X-Test-Header" to "forwarded"),
+            transport = RemoteMcpTransport.HTTP,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        RemoteMcpClient.invalidateSession(config.id)
+        server.shutdown()
+    }
+
+    @Test
+    fun `modern server is discovered and receives per-request metadata`() = runBlocking {
+        enqueueJson(
+            """{
+                "jsonrpc":"2.0","id":"discover","result":{
+                  "resultType":"complete","ttlMs":0,"cacheScope":"private",
+                  "supportedVersions":["2026-07-28"],"capabilities":{"tools":{}}
+                }
+            }""".trimIndent()
+        )
+        enqueueJson(
+            """{
+                "jsonrpc":"2.0","id":"list","result":{
+                  "resultType":"complete","ttlMs":0,"cacheScope":"private",
+                  "tools":[{"name":"天气 查询","description":"weather","inputSchema":{
+                    "type":"object","properties":{
+                      "region":{"type":"string","x-mcp-header":"Region"}
+                    }
+                  }}]
+                }
+            }""".trimIndent()
+        )
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"call","result":{
+                "resultType":"complete","content":[{"type":"text","text":"晴"}]
+              }
+            }""".trimIndent()
+        )
+
+        val tools = RemoteMcpClient.listTools(config)
+        val callResult = RemoteMcpClient.callTool(
+            config,
+            "天气 查询",
+            mapOf("region" to "华东"),
+        )
+
+        assertEquals(listOf("天气 查询"), tools.map { it.toolName })
+        assertEquals("晴", callResult.summaryText)
+        val discover = server.takeRequest()
+        assertEquals("server/discover", discover.getHeader("Mcp-Method"))
+        assertEquals("2026-07-28", discover.getHeader("MCP-Protocol-Version"))
+        assertEquals("forwarded", discover.getHeader("X-Test-Header"))
+        val body = Json.parseToJsonElement(discover.body.readUtf8()).jsonObject
+        assertNull(body["_meta"])
+        val meta = body["params"]!!.jsonObject["_meta"]!!.jsonObject
+        assertEquals(
+            "2026-07-28",
+            meta["io.modelcontextprotocol/protocolVersion"]!!.jsonPrimitive.content,
+        )
+        assertTrue(meta["io.modelcontextprotocol/clientCapabilities"] != null)
+
+        val list = server.takeRequest()
+        assertEquals("tools/list", list.getHeader("Mcp-Method"))
+        assertFalse(list.headers.names().contains("Mcp-Session-Id"))
+        val call = server.takeRequest()
+        assertEquals("tools/call", call.getHeader("Mcp-Method"))
+        assertEquals(
+            "天气 查询",
+            ModernMcpProtocol.decodeMcpHeaderValue(call.getHeader("Mcp-Name")!!),
+        )
+        assertEquals(
+            "华东",
+            ModernMcpProtocol.decodeMcpHeaderValue(call.getHeader("Mcp-Param-Region")!!),
+        )
+    }
+
+    @Test
+    fun `modern header mismatch refreshes the tool schema and retries once`() = runBlocking {
+        enqueueModernDiscover()
+        enqueueModernToolList(headerName = "Region")
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"call",
+              "error":{"code":-32020,"message":"Header mismatch"}
+            }""".trimIndent(),
+            code = 400,
+        )
+        enqueueModernToolList(headerName = "Zone")
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"call","result":{
+                "resultType":"complete","content":[{"type":"text","text":"updated"}]
+              }
+            }""".trimIndent()
+        )
+
+        RemoteMcpClient.listTools(config)
+        val result = RemoteMcpClient.callTool(
+            config,
+            "weather",
+            mapOf("region" to "east"),
+        )
+
+        assertEquals("updated", result.summaryText)
+        val requests = (0 until 5).map { server.takeRequest() }
+        assertEquals("east", requests[2].getHeader("Mcp-Param-Region"))
+        assertNull(requests[2].getHeader("Mcp-Param-Zone"))
+        assertNull(requests[4].getHeader("Mcp-Param-Region"))
+        assertEquals("east", requests[4].getHeader("Mcp-Param-Zone"))
+    }
+
+    @Test
+    fun `legacy streamable HTTP initializes once and reuses its session`() = runBlocking {
+        enqueueJson(
+            """{"jsonrpc":"2.0","id":"probe","error":{"code":-32601,"message":"Method not found"}}"""
+        )
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"init","result":{
+                "protocolVersion":"2025-11-25","capabilities":{"tools":{}},
+                "serverInfo":{"name":"legacy","version":"1"}
+              }
+            }""".trimIndent(),
+            headers = mapOf("Mcp-Session-Id" to "legacy-session-1"),
+        )
+        enqueueStatus(202)
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"list","result":{
+                "tools":[{"name":"echo","description":"echo","inputSchema":{"type":"object"}}]
+              }
+            }""".trimIndent()
+        )
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"call","result":{
+                "content":[{"type":"text","text":"ok"}],"isError":false
+              }
+            }""".trimIndent()
+        )
+
+        assertEquals("echo", RemoteMcpClient.listTools(config).single().toolName)
+        assertEquals(
+            "ok",
+            RemoteMcpClient.callTool(config, "echo", mapOf("value" to "hello")).summaryText,
+        )
+
+        val methods = (0 until 5).map {
+            val request = server.takeRequest()
+            val body = request.body.readUtf8()
+            Json.parseToJsonElement(body).jsonObject["method"]!!.jsonPrimitive.content to request
+        }
+        assertEquals(
+            listOf(
+                "server/discover",
+                "initialize",
+                "notifications/initialized",
+                "tools/list",
+                "tools/call",
+            ),
+            methods.map { it.first },
+        )
+        assertNull(methods[1].second.getHeader("Mcp-Session-Id"))
+        methods.drop(2).forEach { (_, request) ->
+            assertEquals("legacy-session-1", request.getHeader("Mcp-Session-Id"))
+        }
+    }
+
+    @Test
+    fun `legacy server version rejection falls back from modern discovery`() = runBlocking {
+        listOf(-32600, -32602).forEach { rejectionCode ->
+            val attemptConfig = config.copy(id = "${config.id}-$rejectionCode")
+            enqueueJson(
+                """{
+                  "jsonrpc":"2.0","id":"probe",
+                  "error":{"code":$rejectionCode,"message":"Invalid MCP-Protocol-Version"}
+                }""".trimIndent(),
+                code = 400,
+            )
+            enqueueJson(
+                """{
+                  "jsonrpc":"2.0","id":"init","result":{
+                    "protocolVersion":"2025-06-18","capabilities":{"tools":{}},
+                    "serverInfo":{"name":"legacy","version":"1"}
+                  }
+                }""".trimIndent(),
+                headers = mapOf("Mcp-Session-Id" to "legacy-$rejectionCode"),
+            )
+            enqueueStatus(202)
+            enqueueJson(
+                """{
+                  "jsonrpc":"2.0","id":"list","result":{
+                    "tools":[{"name":"echo","inputSchema":{"type":"object"}}]
+                  }
+                }""".trimIndent(),
+            )
+
+            assertEquals("echo", RemoteMcpClient.listTools(attemptConfig).single().toolName)
+
+            val requests = (0 until 4).map { server.takeRequest() }
+            val methods = requests.map { request ->
+                Json.parseToJsonElement(request.body.readUtf8())
+                    .jsonObject["method"]!!.jsonPrimitive.content
+            }
+            assertEquals(
+                listOf("server/discover", "initialize", "notifications/initialized", "tools/list"),
+                methods,
+            )
+            assertEquals("2026-07-28", requests[0].getHeader("MCP-Protocol-Version"))
+            assertNull(requests[1].getHeader("MCP-Protocol-Version"))
+            assertEquals("2025-06-18", requests[3].getHeader("MCP-Protocol-Version"))
+            RemoteMcpClient.invalidateSession(attemptConfig.id)
+        }
+    }
+
+    @Test
+    fun `stale legacy HTTP session is reinitialized once without forwarding old id`() = runBlocking {
+        enqueueLegacyProbeFailure()
+        enqueueLegacyInitialize("legacy-session-old")
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"list","result":{
+                "tools":[{"name":"echo","inputSchema":{"type":"object"}}]
+              }
+            }""".trimIndent()
+        )
+        enqueueStatus(404)
+        enqueueLegacyProbeFailure()
+        enqueueLegacyInitialize("legacy-session-new")
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"call","result":{
+                "content":[{"type":"text","text":"recovered"}],"isError":false
+              }
+            }""".trimIndent()
+        )
+
+        RemoteMcpClient.listTools(config)
+        val result = RemoteMcpClient.callTool(config, "echo", emptyMap())
+
+        assertEquals("recovered", result.summaryText)
+        val requests = (0 until 9).map { server.takeRequest() }
+        val methods = requests.map { request ->
+            Json.parseToJsonElement(request.body.clone().readUtf8())
+                .jsonObject["method"]!!
+                .jsonPrimitive
+                .content
+        }
+        assertEquals(
+            listOf(
+                "server/discover",
+                "initialize",
+                "notifications/initialized",
+                "tools/list",
+                "tools/call",
+                "server/discover",
+                "initialize",
+                "notifications/initialized",
+                "tools/call",
+            ),
+            methods,
+        )
+        assertEquals("legacy-session-old", requests[4].getHeader("Mcp-Session-Id"))
+        assertNull(requests[5].getHeader("Mcp-Session-Id"))
+        assertNull(requests[6].getHeader("Mcp-Session-Id"))
+        assertEquals("legacy-session-new", requests[8].getHeader("Mcp-Session-Id"))
+    }
+
+    @Test
+    fun `closing a stateful legacy HTTP connection terminates its MCP session`() = runBlocking {
+        enqueueLegacyProbeFailure()
+        enqueueLegacyInitialize("legacy-session-close")
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"list","result":{"tools":[]}
+            }""".trimIndent()
+        )
+        enqueueStatus(200)
+
+        RemoteMcpClient.listTools(config)
+        RemoteMcpClient.close(config)
+
+        val requests = (0 until 5).map { server.takeRequest() }
+        assertEquals("DELETE", requests.last().method)
+        assertEquals(
+            "legacy-session-close",
+            requests.last().getHeader("Mcp-Session-Id"),
+        )
+        assertEquals(
+            "2025-11-25",
+            requests.last().getHeader("MCP-Protocol-Version"),
+        )
+    }
+
+    @Test
+    fun `explicit HTTP transport never falls through to deprecated SSE`() = runBlocking {
+        enqueueLegacyProbeFailure(code = 404)
+        enqueueStatus(404)
+
+        val failure = runCatching { RemoteMcpClient.listTools(config) }.exceptionOrNull()
+
+        assertNotNull(failure)
+        assertEquals(2, server.requestCount)
+        assertEquals("POST", server.takeRequest().method)
+        assertEquals("POST", server.takeRequest().method)
+    }
+
+    @Test
+    fun `modern MCP name header uses the required base64 sentinel`() {
+        val encoded = RemoteMcpClient.encodeMcpHeaderValue("天气 查询")
+
+        assertTrue(encoded.startsWith("=?base64?"))
+        assertTrue(encoded.endsWith("?="))
+        assertEquals("plain_tool", RemoteMcpClient.encodeMcpHeaderValue("plain_tool"))
+    }
+
+    private fun enqueueJson(
+        body: String,
+        headers: Map<String, String> = emptyMap(),
+        code: Int = 200,
+    ) {
+        responsePlans += ResponsePlan(
+            code = code,
+            body = body,
+            headers = mapOf("Content-Type" to "application/json") + headers,
+            echoRequestId = true,
+        )
+    }
+
+    private fun enqueueStatus(code: Int) {
+        responsePlans += ResponsePlan(code = code)
+    }
+
+    private fun enqueueLegacyProbeFailure(code: Int = 200) {
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"probe",
+              "error":{"code":-32601,"message":"Method not found"}
+            }""".trimIndent(),
+            code = code,
+        )
+    }
+
+    private fun enqueueLegacyInitialize(sessionId: String) {
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"init","result":{
+                "protocolVersion":"2025-11-25","capabilities":{"tools":{}},
+                "serverInfo":{"name":"legacy","version":"1"}
+              }
+            }""".trimIndent(),
+            headers = mapOf("Mcp-Session-Id" to sessionId),
+        )
+        enqueueStatus(202)
+    }
+
+    private fun enqueueModernDiscover() {
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"discover","result":{
+                "resultType":"complete","ttlMs":0,"cacheScope":"private",
+                "supportedVersions":["2026-07-28"],"capabilities":{"tools":{}}
+              }
+            }""".trimIndent()
+        )
+    }
+
+    private fun enqueueModernToolList(headerName: String) {
+        enqueueJson(
+            """{
+              "jsonrpc":"2.0","id":"list","result":{
+                "resultType":"complete","ttlMs":0,"cacheScope":"private",
+                "tools":[{"name":"weather","inputSchema":{
+                  "type":"object","properties":{
+                    "region":{"type":"string","x-mcp-header":"$headerName"}
+                  }
+                }}]
+              }
+            }""".trimIndent()
+        )
+    }
+
+    private data class ResponsePlan(
+        val code: Int,
+        val body: String = "",
+        val headers: Map<String, String> = emptyMap(),
+        val echoRequestId: Boolean = false,
+    )
+}

--- a/app/src/test/java/cn/com/omnimind/bot/mcp/RemoteMcpConfigCompatibilityTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/mcp/RemoteMcpConfigCompatibilityTest.kt
@@ -1,0 +1,62 @@
+package cn.com.omnimind.bot.mcp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteMcpConfigCompatibilityTest {
+
+    @Test
+    fun `legacy persisted entries receive defaults and remain usable`() {
+        val configs = RemoteMcpConfigStore.decodeServersJson(
+            """[
+              {
+                "id":"legacy-mt",
+                "name":"MT",
+                "endpointUrl":"http://127.0.0.1:8787/mcp",
+                "bearerToken":"",
+                "enabled":true,
+                "lastHealth":"HEALTHY",
+                "toolCount":26,
+                "lastSyncedAt":1788369271690
+              }
+            ]""".trimIndent(),
+        )
+
+        val config = configs.single()
+        assertEquals(RemoteMcpTransport.AUTO, config.transport)
+        assertTrue(config.headers.isEmpty())
+        assertEquals(RemoteMcpHealth.HEALTHY, config.lastHealth)
+        assertEquals(26, config.toolCount)
+        assertEquals("auto", config.toMap()["transport"])
+    }
+
+    @Test
+    fun `mixed legacy and current persisted entries decode independently`() {
+        val configs = RemoteMcpConfigStore.decodeServersJson(
+            """[
+              {
+                "id":"legacy",
+                "name":"legacy",
+                "endpointUrl":"http://127.0.0.1:8787/mcp",
+                "enabled":true,
+                "lastHealth":"ERROR"
+              },
+              {
+                "id":"current",
+                "name":"current",
+                "endpointUrl":"https://example.com/sse",
+                "headers":{"X-Tenant":"demo"},
+                "transport":"SSE",
+                "enabled":true,
+                "lastHealth":"healthy"
+              }
+            ]""".trimIndent(),
+        )
+
+        assertEquals(listOf("legacy", "current"), configs.map { it.id })
+        assertEquals(RemoteMcpHealth.ERROR, configs[0].lastHealth)
+        assertEquals(RemoteMcpTransport.SSE, configs[1].transport)
+        assertEquals(mapOf("X-Tenant" to "demo"), configs[1].headers)
+    }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/mcp/RemoteMcpProtocolVersionTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/mcp/RemoteMcpProtocolVersionTest.kt
@@ -3,6 +3,7 @@ package cn.com.omnimind.bot.mcp
 import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
 import io.modelcontextprotocol.kotlin.sdk.types.SUPPORTED_PROTOCOL_VERSIONS
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -17,5 +18,19 @@ class RemoteMcpProtocolVersionTest {
     @Test
     fun `server SDK keeps the previous acceptance protocol compatible`() {
         assertTrue(SUPPORTED_PROTOCOL_VERSIONS.contains("2025-03-26"))
+    }
+
+    @Test
+    fun `manual modern boundary uses the current protocol and decodes name headers`() {
+        assertEquals("2026-07-28", ModernMcpProtocol.PROTOCOL_VERSION)
+        assertEquals("2026-07-28", RemoteMcpClient.MODERN_PROTOCOL_VERSION)
+        assertEquals(
+            "天气 查询",
+            ModernMcpProtocol.decodeMcpHeaderValue(
+                RemoteMcpClient.encodeMcpHeaderValue("天气 查询")
+            ),
+        )
+        assertEquals("plain_tool", ModernMcpProtocol.decodeMcpHeaderValue("plain_tool"))
+        assertNull(ModernMcpProtocol.decodeMcpHeaderValue("=?base64?/w==?="))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,6 +146,7 @@ ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negoti
 ktor-serialization-gson = { module = "io.ktor:ktor-serialization-gson", version.ref = "ktor" }
 ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
 mcp-kotlin-sdk-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcpKotlinSdk" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttpVersion" }
 kotlin-metadata-jvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlinMetadataJvm" }
 nanohttpd = { group = "org.nanohttpd", name = "nanohttpd", version.ref = "nanohttpd" }
 bouncycastle = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }

--- a/ui/lib/features/home/pages/mcp/remote_mcp_servers_page.dart
+++ b/ui/lib/features/home/pages/mcp/remote_mcp_servers_page.dart
@@ -36,6 +36,16 @@ class _RemoteMcpServersPageState extends State<RemoteMcpServersPage> {
         _servers = servers;
         _loading = false;
       });
+    } on PlatformException catch (e) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      showToast(
+        e.message ??
+            (Localizations.localeOf(context).languageCode == 'en'
+                ? 'Failed to load MCP tools'
+                : '加载 MCP 工具失败'),
+        type: ToastType.error,
+      );
     } catch (e) {
       if (!mounted) return;
       setState(() => _loading = false);
@@ -93,6 +103,7 @@ class _RemoteMcpServersPageState extends State<RemoteMcpServersPage> {
             : '工具列表已刷新',
       );
     } on PlatformException catch (e) {
+      await _reloadServersSilently();
       showToast(
         e.message ??
             (Localizations.localeOf(context).languageCode == 'en'
@@ -109,6 +120,16 @@ class _RemoteMcpServersPageState extends State<RemoteMcpServersPage> {
       );
     } finally {
       _setBusy(server.id, false);
+    }
+  }
+
+  Future<void> _reloadServersSilently() async {
+    try {
+      final servers = await RemoteMcpConfigService.listServers();
+      if (!mounted) return;
+      setState(() => _servers = servers);
+    } catch (_) {
+      // Preserve the operation error already shown to the user.
     }
   }
 

--- a/ui/lib/models/remote_mcp_server.dart
+++ b/ui/lib/models/remote_mcp_server.dart
@@ -3,6 +3,8 @@ class RemoteMcpServer {
   final String name;
   final String endpointUrl;
   final String bearerToken;
+  final Map<String, String> headers;
+  final String transport;
   final bool enabled;
   final String lastHealth;
   final String? lastError;
@@ -14,6 +16,8 @@ class RemoteMcpServer {
     required this.name,
     required this.endpointUrl,
     required this.bearerToken,
+    this.headers = const {},
+    this.transport = 'auto',
     required this.enabled,
     required this.lastHealth,
     this.lastError,
@@ -27,6 +31,8 @@ class RemoteMcpServer {
       name: (raw['name'] ?? '').toString(),
       endpointUrl: (raw['endpointUrl'] ?? '').toString(),
       bearerToken: (raw['bearerToken'] ?? '').toString(),
+      headers: _stringMap(raw['headers']),
+      transport: (raw['transport'] ?? 'auto').toString(),
       enabled: raw['enabled'] == true,
       lastHealth: (raw['lastHealth'] ?? 'unknown').toString(),
       lastError: raw['lastError']?.toString(),
@@ -45,6 +51,8 @@ class RemoteMcpServer {
       'name': name,
       'endpointUrl': endpointUrl,
       'bearerToken': bearerToken,
+      'headers': headers,
+      'transport': transport,
       'enabled': enabled,
       'lastHealth': lastHealth,
       'lastError': lastError,
@@ -58,6 +66,8 @@ class RemoteMcpServer {
     String? name,
     String? endpointUrl,
     String? bearerToken,
+    Map<String, String>? headers,
+    String? transport,
     bool? enabled,
     String? lastHealth,
     String? lastError,
@@ -69,11 +79,21 @@ class RemoteMcpServer {
       name: name ?? this.name,
       endpointUrl: endpointUrl ?? this.endpointUrl,
       bearerToken: bearerToken ?? this.bearerToken,
+      headers: headers ?? this.headers,
+      transport: transport ?? this.transport,
       enabled: enabled ?? this.enabled,
       lastHealth: lastHealth ?? this.lastHealth,
       lastError: lastError ?? this.lastError,
       toolCount: toolCount ?? this.toolCount,
       lastSyncedAt: lastSyncedAt ?? this.lastSyncedAt,
     );
+  }
+
+  static Map<String, String> _stringMap(dynamic value) {
+    if (value is! Map) return const {};
+    return <String, String>{
+      for (final entry in value.entries)
+        entry.key.toString(): entry.value?.toString() ?? '',
+    };
   }
 }

--- a/ui/test/models/remote_mcp_server_test.dart
+++ b/ui/test/models/remote_mcp_server_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui/models/remote_mcp_server.dart';
+
+void main() {
+  test('preserves transport and headers through an edit round trip', () {
+    final server = RemoteMcpServer.fromMap({
+      'id': 'server-1',
+      'name': 'MCP',
+      'endpointUrl': 'https://example.com/mcp',
+      'bearerToken': '',
+      'headers': {'X-Tenant': 'demo'},
+      'transport': 'http',
+      'enabled': true,
+      'lastHealth': 'healthy',
+      'toolCount': 2,
+    });
+
+    final edited = server.copyWith(name: 'Edited').toMap();
+
+    expect(edited['headers'], {'X-Tenant': 'demo'});
+    expect(edited['transport'], 'http');
+  });
+}


### PR DESCRIPTION
## 背景

小万 ACP 之前没有正确声明和消费 MCP 能力，导致远端 MCP 工具无法加载。

真机验证发现两个问题：

- 旧版 MCP 配置缺少新增字段，Gson 反序列化后触发空指针。
- MT 管理器使用历史 MCP 协议，现代协议探测失败后没有回退到 legacy initialize。

## 变更内容

- 将 ACP Session 中的 MCP 服务接入统一工具注册和生命周期管理。
- 支持 HTTP、SSE、stdio MCP 服务。
- 兼容现代 MCP Streamable HTTP 和历史 MCP 握手流程。
- 现代协议探测失败时自动回退 legacy initialize。
- 修复旧配置字段兼容和 `transport`/`headers` 数据丢失问题。
- 增强 MCP Session 关闭、配置刷新和错误日志。
- 增加 MCP Host、Origin、Bearer 等安全校验。
- 增加 Android、Flutter 配置兼容和协议互操作测试。

## 验证

- Android MCP 配置兼容测试通过
- MCP HTTP/legacy 协议互操作测试通过
- Flutter MCP 模型测试通过
- Develop Debug APK 构建通过
- 真机 MT MCP 工具加载和调用验证通过

## 参考

- [MCP Streamable HTTP 官方规范](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
- [MCP 2026-07-28 Streamable HTTP 规范](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2026-07-28/basic/transports/streamable-http.mdx)
- [ACP Session 生命周期官方文档](https://agentclientprotocol.com/rfds/session-close)